### PR TITLE
fix: disable keyring in CI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         env:
           HATCH_INDEX_USER: __token__
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
+          KEYRING_BACKEND: keyring.backends.null.Keyring
         run: task release:publish
 
       - name: Create GitHub Release


### PR DESCRIPTION
Hatch was trying to use keyring for PyPI credentials instead of env vars. Set KEYRING_BACKEND to null in CI.