### PR TITLE
fix: correct keyring env var for CI publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           HATCH_INDEX_USER: __token__
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_TOKEN }}
-          KEYRING_BACKEND: keyring.backends.null.Keyring
+          PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
         run: task release:publish
 
       - name: Create GitHub Release


### PR DESCRIPTION
Use PYTHON_KEYRING_BACKEND instead of KEYRING_BACKEND.