### PR TITLE
feat: Add API layer with deployment infrastructure and CI/CD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# OpenFactCheck API Configuration
+# Copy to .env and update values as needed.
+
+# Server
+OPENFACTCHECK_HOST=0.0.0.0
+OPENFACTCHECK_PORT=8000
+OPENFACTCHECK_DEBUG=true
+
+# CORS
+OPENFACTCHECK_CORS_ORIGINS=["http://localhost:3001"]
+
+# Auth (auth_bypass only works when debug=true — both must be set for local dev)
+OPENFACTCHECK_AUTH_BYPASS=true
+OPENFACTCHECK_COGNITO_REGION=us-east-1
+OPENFACTCHECK_COGNITO_USER_POOL_ID=
+OPENFACTCHECK_COGNITO_CLIENT_ID=
+
+# Database
+OPENFACTCHECK_DATABASE_BACKEND=sqlite
+OPENFACTCHECK_SQLITE_PATH=~/.openfactcheck/data.db
+OPENFACTCHECK_DYNAMODB_TABLE_NAME=openfactcheck
+OPENFACTCHECK_DYNAMODB_REGION=us-east-1
+
+# Execution
+OPENFACTCHECK_MAX_EXECUTION_TIMEOUT=600

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -67,5 +67,10 @@ jobs:
           aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile hasaniqbal-dev
           aws configure set region us-east-1 --profile hasaniqbal-dev
 
-      - name: Deploy to integration
-        run: task deploy TARGET=integration AUTO_APPROVE=true
+      - name: Deploy infrastructure
+        run: |
+          task deploy TARGET=integration DEP=repositories AUTO_APPROVE=true
+          task deploy TARGET=integration AUTO_APPROVE=true
+
+      - name: Build and deploy API
+        run: task deploy:api TARGET=integration

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -103,5 +103,10 @@ jobs:
           aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile hasaniqbal-dev
           aws configure set region us-east-1 --profile hasaniqbal-dev
 
-      - name: Deploy to production
-        run: task deploy TARGET=production AUTO_APPROVE=true
+      - name: Deploy infrastructure
+        run: |
+          task deploy TARGET=production DEP=repositories AUTO_APPROVE=true
+          task deploy TARGET=production AUTO_APPROVE=true
+
+      - name: Build and deploy API
+        run: task deploy:api TARGET=production

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,8 @@ environments/
 
 # Temp files
 tmp
+
+# Build artifacts
+deployments/containers/*/build/
+deployments/containers/*/.hash
+deployments/base/ignore.*.auto.tfvars

--- a/deployments/base/aws_apigateway.tf
+++ b/deployments/base/aws_apigateway.tf
@@ -1,0 +1,113 @@
+# ##############################################################################
+# API Gateway HTTP API (v2)
+# ##############################################################################
+
+resource "aws_apigatewayv2_api" "openfactcheck" {
+  name          = "openfactcheck-api-${terraform.workspace}-${var.aws_region}"
+  description   = "OpenFactCheck API Gateway for ${terraform.workspace}-${var.aws_region}"
+  protocol_type = "HTTP"
+
+  disable_execute_api_endpoint = true
+
+  cors_configuration {
+    allow_origins     = var.cors_origins
+    allow_methods     = ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"]
+    allow_headers     = ["Authorization", "Content-Type", "X-Request-ID"]
+    allow_credentials = true
+    max_age           = 3600
+  }
+
+  tags = {
+    Name = "OpenFactCheck - API Gateway - ${terraform.workspace} - ${var.aws_region}"
+  }
+}
+
+# ##############################################################################
+# Integration — Lambda proxy via LIVE alias
+# ##############################################################################
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.openfactcheck.id
+  description            = "OpenFactCheck API Lambda for ${terraform.workspace}-${var.aws_region}"
+  integration_type       = "AWS_PROXY"
+  connection_type        = "INTERNET"
+  integration_method     = "POST"
+  integration_uri        = aws_lambda_alias.api_live.invoke_arn
+  payload_format_version = "2.0"
+}
+
+# ##############################################################################
+# Routes
+# ##############################################################################
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.openfactcheck.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_route" "options" {
+  api_id             = aws_apigatewayv2_api.openfactcheck.id
+  route_key          = "OPTIONS /{proxy+}"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "NONE"
+}
+
+
+# ##############################################################################
+# Stage — auto-deploy with access logging
+# ##############################################################################
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.openfactcheck.id
+  name        = "$default"
+  auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api.arn
+    format          = <<JSON
+  { "requestTime": "$context.requestTime", "requestId": "$context.requestId", "httpMethod": "$context.httpMethod", "path": "$context.path", "routeKey": "$context.routeKey", "status": $context.status, "responseLatency": $context.responseLatency, "integrationRequestId": "$context.integration.requestId", "functionResponseStatus": "$context.integration.status", "integrationLatency": "$context.integration.latency", "integrationServiceStatus": "$context.integration.integrationStatus", "ip": "$context.identity.sourceIp", "userAgent": "$context.identity.userAgent", "error": { "message": "$context.error.message", "responseType": "$context.error.responseType" } }
+  JSON
+  }
+
+  tags = {
+    Name = "OpenFactCheck - API Gateway Stage - ${terraform.workspace} - ${var.aws_region}"
+  }
+}
+
+# ##############################################################################
+# Custom Domain
+# ##############################################################################
+
+resource "aws_apigatewayv2_domain_name" "api" {
+  domain_name = local.api_domain
+
+  domain_name_configuration {
+    certificate_arn = local.certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+
+  tags = {
+    Name = "OpenFactCheck - API Domain - ${terraform.workspace} - ${var.aws_region}"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "api" {
+  api_id      = aws_apigatewayv2_api.openfactcheck.id
+  domain_name = aws_apigatewayv2_domain_name.api.id
+  stage       = aws_apigatewayv2_stage.default.id
+}
+
+# ##############################################################################
+# API Gateway Logs
+# ##############################################################################
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/openfactcheck-${terraform.workspace}-${var.aws_region}/api/"
+  retention_in_days = 30
+
+  tags = {
+    Name = "OpenFactCheck - CloudWatch - API - ${terraform.workspace} - ${var.aws_region}"
+  }
+}

--- a/deployments/base/aws_dynamodb.tf
+++ b/deployments/base/aws_dynamodb.tf
@@ -1,0 +1,31 @@
+# ##############################################################################
+# DynamoDB Table — Single-table design
+# ##############################################################################
+
+resource "aws_dynamodb_table" "openfactcheck" {
+  name         = "openfactcheck-db-${terraform.workspace}-${var.aws_region}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "PK"
+
+  global_secondary_index {
+    name            = "gs1"
+    hash_key        = "GS1PK"
+    projection_type = "ALL"
+  }
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "GS1PK"
+    type = "S"
+  }
+
+  deletion_protection_enabled = terraform.workspace == "production" ? true : false
+
+  tags = {
+    Name = "OpenFactCheck - DynamoDB - ${terraform.workspace} - ${var.aws_region}"
+  }
+}

--- a/deployments/base/aws_iam_lambda.tf
+++ b/deployments/base/aws_iam_lambda.tf
@@ -1,0 +1,77 @@
+# ##############################################################################
+# IAM Role — Lambda Execution
+# ##############################################################################
+
+resource "aws_iam_role" "lambda_api" {
+  name = "openfactcheck-lambda-api-${terraform.workspace}-${var.aws_region}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name = "OpenFactCheck - Lambda API Role - ${terraform.workspace}"
+  }
+}
+
+# ##############################################################################
+# CloudWatch Logs
+# ##############################################################################
+
+resource "aws_iam_role_policy" "lambda_api_logs" {
+  name = "cloudwatch-logs"
+  role = aws_iam_role.lambda_api.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${var.aws_account}:*"
+      }
+    ]
+  })
+}
+
+# ##############################################################################
+# DynamoDB Access
+# ##############################################################################
+
+resource "aws_iam_role_policy" "lambda_api_dynamodb" {
+  name = "dynamodb-access"
+  role = aws_iam_role.lambda_api.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Resource = [
+          aws_dynamodb_table.openfactcheck.arn,
+          "${aws_dynamodb_table.openfactcheck.arn}/index/*"
+        ]
+      }
+    ]
+  })
+}

--- a/deployments/base/aws_lambda.tf
+++ b/deployments/base/aws_lambda.tf
@@ -1,0 +1,75 @@
+# ##############################################################################
+# ECR Data Source — repository lives in deployments/repositories
+# ##############################################################################
+
+data "aws_ecr_repository" "api" {
+  name = "openfactcheck-api-${terraform.workspace}"
+}
+
+# ##############################################################################
+# Lambda Function — API
+# ##############################################################################
+
+resource "aws_lambda_function" "api" {
+  function_name = "openfactcheck-api-${terraform.workspace}-${var.aws_region}"
+  description   = var.build_version
+  role          = aws_iam_role.lambda_api.arn
+  package_type  = "Image"
+  image_uri     = "${data.aws_ecr_repository.api.repository_url}:latest"
+  publish       = true
+  timeout       = 30
+  memory_size   = 256
+
+  environment {
+    variables = {
+      OPENFACTCHECK_DATABASE_BACKEND     = "dynamodb"
+      OPENFACTCHECK_DYNAMODB_TABLE_NAME  = aws_dynamodb_table.openfactcheck.name
+      OPENFACTCHECK_DYNAMODB_REGION      = var.aws_region
+      OPENFACTCHECK_COGNITO_REGION       = var.aws_region
+      OPENFACTCHECK_COGNITO_USER_POOL_ID = aws_cognito_user_pool.openfactcheck.id
+      OPENFACTCHECK_COGNITO_CLIENT_ID    = aws_cognito_user_pool_client.openfactcheck_client.id
+      OPENFACTCHECK_CORS_ORIGINS         = jsonencode(var.cors_origins)
+      OPENFACTCHECK_DEBUG                = "false"
+      OPENFACTCHECK_AUTH_BYPASS          = "false"
+    }
+  }
+
+  tags = {
+    Name = "OpenFactCheck - Lambda API - ${terraform.workspace} - ${var.aws_region}"
+  }
+
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
+}
+
+# ##############################################################################
+# Lambda Alias — LIVE
+# ##############################################################################
+
+resource "aws_lambda_alias" "api_live" {
+  name             = "LIVE"
+  description      = "OpenFactCheck API Current Release"
+  function_name    = aws_lambda_function.api.arn
+  function_version = aws_lambda_function.api.version
+}
+
+# ##############################################################################
+# Lambda Permissions — Allow API Gateway to invoke via LIVE alias
+# ##############################################################################
+
+resource "aws_lambda_permission" "api_gateway_default" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.openfactcheck.execution_arn}/*/$default"
+  qualifier     = "LIVE"
+}
+
+resource "aws_lambda_permission" "api_gateway_proxy" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.openfactcheck.execution_arn}/*/*/{proxy+}"
+  qualifier     = "LIVE"
+}

--- a/deployments/base/aws_route53.tf
+++ b/deployments/base/aws_route53.tf
@@ -1,0 +1,27 @@
+# ##############################################################################
+# Route 53 — DNS records for the API custom domain
+# ##############################################################################
+
+resource "aws_route53_record" "api" {
+  zone_id = local.route53_zone_id
+  name    = local.api_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "api_ipv6" {
+  zone_id = local.route53_zone_id
+  name    = local.api_domain
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].target_domain_name
+    zone_id                = aws_apigatewayv2_domain_name.api.domain_name_configuration[0].hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/deployments/base/backend.tf
+++ b/deployments/base/backend.tf
@@ -39,11 +39,11 @@ provider "aws" {
 
   default_tags {
     tags = {
-      Module      = "OpenFactCheck"
-      Owner       = "OpenFactCheck Research"
-      Creator     = "openfactcheck@gmail.com"
-      Environment = terraform.workspace
-      Criticality = terraform.workspace == "production" ? "High" : "Low"
+      Module        = "OpenFactCheck"
+      Owner         = "OpenFactCheck Research"
+      Creator       = "openfactcheck@gmail.com"
+      Environment   = terraform.workspace
+      Criticality   = terraform.workspace == "production" ? "High" : "Low"
       ManagedBy     = "terraform"
       TerraformPath = "deployments/base"
       Region        = var.aws_region

--- a/deployments/base/locals.tf
+++ b/deployments/base/locals.tf
@@ -2,4 +2,14 @@
 # Locals
 # ##############################################################################
 locals {
+  attributes = {
+    root_domain     = "openfactcheck.com"
+    certificate_arn = "arn:aws:acm:us-east-1:252286678527:certificate/bd2961d6-5a11-48d0-9ccc-c5e1f603ff09"
+    route53_zone_id = "Z08124453UJZ86BMG3TNR"
+  }
+
+  certificate_arn = local.attributes.certificate_arn
+  route53_zone_id = local.attributes.route53_zone_id
+  root_domain     = local.attributes.root_domain
+  api_domain      = terraform.workspace == "production" ? "api.${local.root_domain}" : "${terraform.workspace}-api.${local.root_domain}"
 }

--- a/deployments/base/outputs.tf
+++ b/deployments/base/outputs.tf
@@ -11,3 +11,28 @@ output "cognito_user_pool_client_id" {
   description = "Cognito User Pool Client ID"
   value       = aws_cognito_user_pool_client.openfactcheck_client.id
 }
+
+output "api_gateway_url" {
+  description = "API Gateway invoke URL"
+  value       = aws_apigatewayv2_stage.default.invoke_url
+}
+
+output "dynamodb_table_name" {
+  description = "DynamoDB table name"
+  value       = aws_dynamodb_table.openfactcheck.name
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL for the API container image"
+  value       = data.aws_ecr_repository.api.repository_url
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name"
+  value       = aws_lambda_function.api.function_name
+}
+
+output "api_url" {
+  description = "API custom domain URL"
+  value       = "https://${local.api_domain}"
+}

--- a/deployments/base/variables.tf
+++ b/deployments/base/variables.tf
@@ -22,3 +22,21 @@ variable "aws_account_name" {
   description = "AWS Account Name for deployment (optional, for reference)"
   type        = string
 }
+
+variable "cors_origins" {
+  description = "Allowed CORS origins for the API"
+  type        = list(string)
+  default     = ["http://localhost:3001"]
+}
+
+variable "build_version" {
+  description = "Application build version (auto-set by build script)"
+  type        = string
+  default     = "unknown"
+}
+
+variable "commit" {
+  description = "Git commit hash (auto-set by build script)"
+  type        = string
+  default     = "unknown"
+}

--- a/deployments/containers/api/Dockerfile
+++ b/deployments/containers/api/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.14
+
+COPY pyproject.toml VERSION LICENSE* README* ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir ".[api,cloud]" mangum
+
+CMD ["openfactcheck.api.lambda_handler.handler"]

--- a/deployments/containers/api/manifest.sh
+++ b/deployments/containers/api/manifest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# ============================================================================
+# API container manifest — defines what to assemble for the Lambda API build
+# ============================================================================
+
+# Source paths used for hash computation (change detection)
+SOURCE_PATHS=(
+    "${PROJECT_ROOT}/src/openfactcheck/__init__.py"
+    "${PROJECT_ROOT}/src/openfactcheck/api"
+    "${PROJECT_ROOT}/pyproject.toml"
+    "${PROJECT_ROOT}/VERSION"
+    "${CONTAINER_DIR}/Dockerfile"
+    "${CONTAINER_DIR}/manifest.sh"
+)
+
+# Assemble the build directory with only what this container needs
+assemble_target() {
+    mkdir -p "$BUILD_DIR/src/openfactcheck"
+
+    # Package source — only __init__.py (for __version__) and api/
+    cp "${PROJECT_ROOT}/src/openfactcheck/__init__.py" "$BUILD_DIR/src/openfactcheck/"
+    rsync -a --exclude='__pycache__' "${PROJECT_ROOT}/src/openfactcheck/api" "$BUILD_DIR/src/openfactcheck/"
+
+    # Build metadata referenced by pyproject.toml
+    cp "${PROJECT_ROOT}/pyproject.toml" "$BUILD_DIR/"
+    cp "${PROJECT_ROOT}/VERSION" "$BUILD_DIR/"
+    cp "${PROJECT_ROOT}/LICENSE" "$BUILD_DIR/" 2>/dev/null || true
+    cp "${PROJECT_ROOT}/README.md" "$BUILD_DIR/" 2>/dev/null || true
+}

--- a/deployments/repositories/.terraform.lock.hcl
+++ b/deployments/repositories/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.39.0"
+  constraints = ">= 6.32.0"
+  hashes = [
+    "h1:c9SG8ZdYgzqpxORpTqeLFeXW4qQQ8GMGCcUkU+FAfQM=",
+    "zh:00a6c0d8b5b86833087e367b632e9ab73fb8db9c43569020ebd0489dc2c919ce",
+    "zh:05f2b56211f4c8a0b66a093d025187cbc7be086dedef62306f5a28290598ebdc",
+    "zh:24d97a31d5ab814c33ed32a5b7674f1a15544b2367a95bddd00cfdd8d6b82740",
+    "zh:258194e24ac07ee194d580ca25a25fa7bc48fa40fed4fd58352b0a64da0da4c9",
+    "zh:315337e5f0ccafeadf490f117151b52c6d66244bf652f4fee975eddda662af3b",
+    "zh:38573dd56cca8c0ffe33396cf17cc8bd13de1d27d3c4da4177e485d174f1eaf0",
+    "zh:4baa806c5eb8faae95cea3f1dfafb153b5e3e96c5b30a2102072da4f032d2d9b",
+    "zh:4f258106baca7e00a6904b2353579d283e4400a75cd0353a25e057921e8a8d96",
+    "zh:62e5d4628d03883a6c2a6e3c297eb54df9b5935e9e3a655dbb1c6c5ddaf7ea33",
+    "zh:8af5fae01c1cef65d149fa6fe47e94cf46ffa97d29e8f2dfe41aeae01da590ea",
+    "zh:a8240b40f7be408ac24897597a85dc4fe56f390224b11ecad2c1327e686fca58",
+    "zh:c549eee2a0cf0e2c4a676614d990121b685beab0047b1073407ee26247c4be13",
+    "zh:cfed074ba8948c75445c74c69722cb17c960024b1917b4f26905aa9c9ac4e667",
+    "zh:d6f4f4fa01e33d0d546705e2776f38d0b4f2847827b3f07ecde87cc02ef3d23e",
+    "zh:e7239b349c3149e4670750481b687c5c828908fd09f2196d7af1ac1b4d83e80b",
+  ]
+}

--- a/deployments/repositories/aws_ecr.tf
+++ b/deployments/repositories/aws_ecr.tf
@@ -1,0 +1,38 @@
+# ##############################################################################
+# ECR Repository — Container images for Lambda
+# ##############################################################################
+
+resource "aws_ecr_repository" "openfactcheck_api" {
+  name                 = "openfactcheck-api-${terraform.workspace}"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = terraform.workspace != "production"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name = "OpenFactCheck - ECR - API - ${terraform.workspace}"
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "openfactcheck_api" {
+  repository = aws_ecr_repository.openfactcheck_api.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 5 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 5
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/deployments/repositories/backend.tf
+++ b/deployments/repositories/backend.tf
@@ -1,0 +1,59 @@
+# ##############################################################################
+# Workspace Validation
+# ##############################################################################
+resource "terraform_data" "workspace_validation" {
+  lifecycle {
+    precondition {
+      condition     = terraform.workspace != "default"
+      error_message = "Workspace must not be default"
+    }
+  }
+}
+
+# ##############################################################################
+# Backend
+# ##############################################################################
+terraform {
+  required_version = ">=1.11.5"
+
+  backend "s3" {
+    key                  = "openfactcheck-repositories/terraform.tfstate"
+    workspace_key_prefix = "openfactcheck-repositories"
+  }
+
+  required_providers {
+    aws = {
+      version = ">=6.32.0"
+      source  = "hashicorp/aws"
+    }
+  }
+}
+
+# ##############################################################################
+# Provider Configuration
+# ##############################################################################
+provider "aws" {
+  region              = var.aws_region
+  profile             = var.aws_profile
+  allowed_account_ids = [var.aws_account]
+
+  default_tags {
+    tags = {
+      Module        = "OpenFactCheck"
+      Owner         = "OpenFactCheck Research"
+      Creator       = "openfactcheck@gmail.com"
+      Environment   = terraform.workspace
+      Criticality   = terraform.workspace == "production" ? "High" : "Low"
+      ManagedBy     = "terraform"
+      TerraformPath = "deployments/repositories"
+      Region        = var.aws_region
+    }
+  }
+}
+
+# ##############################################################################
+# Data Sources
+# ##############################################################################
+data "aws_caller_identity" "self" {}
+
+data "aws_region" "current" {}

--- a/deployments/repositories/outputs.tf
+++ b/deployments/repositories/outputs.tf
@@ -1,0 +1,8 @@
+# ##############################################################################
+# Outputs
+# ##############################################################################
+
+output "ecr_repository_url_api" {
+  description = "ECR repository URL for the API container image"
+  value       = aws_ecr_repository.openfactcheck_api.repository_url
+}

--- a/deployments/repositories/variables.tf
+++ b/deployments/repositories/variables.tf
@@ -1,0 +1,24 @@
+variable "aws_profile" {
+  description = "AWS profile for deployment"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS Region for deployment"
+  type        = string
+}
+
+variable "aws_account" {
+  description = "AWS Account ID for deployment"
+  type        = string
+
+  validation {
+    condition     = length(var.aws_account) == 12 && can(regex("^[0-9]+$", var.aws_account))
+    error_message = "AWS Account ID must be a 12-digit number."
+  }
+}
+
+variable "aws_account_name" {
+  description = "AWS Account Name for deployment (optional, for reference)"
+  type        = string
+}

--- a/http/api.devhasan.http
+++ b/http/api.devhasan.http
@@ -1,0 +1,98 @@
+@base = https://devhasan-api.openfactcheck.com
+@api = {{base}}/api/v1
+@token = REPLACE_WITH_COGNITO_ID_TOKEN
+
+###############################################################################
+# Health
+###############################################################################
+
+### Root
+GET {{base}}/
+
+### Health check
+GET {{base}}/health
+
+###############################################################################
+# Projects
+###############################################################################
+
+### List projects
+GET {{api}}/projects/
+Authorization: Bearer {{token}}
+
+### Create project
+POST {{api}}/projects/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "My Project"
+}
+
+### Get project
+@projectId = REPLACE_ME
+GET {{api}}/projects/{{projectId}}
+Authorization: Bearer {{token}}
+
+### Update project
+PATCH {{api}}/projects/{{projectId}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "Renamed Project"
+}
+
+### Delete project
+DELETE {{api}}/projects/{{projectId}}
+Authorization: Bearer {{token}}
+
+###############################################################################
+# Workspaces
+###############################################################################
+
+### List workspaces
+GET {{api}}/projects/{{projectId}}/workspaces/
+Authorization: Bearer {{token}}
+
+### Create workspace
+POST {{api}}/projects/{{projectId}}/workspaces/
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "My Workspace"
+}
+
+### Get workspace
+@workspaceId = REPLACE_ME
+GET {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+Authorization: Bearer {{token}}
+
+### Update workspace
+PATCH {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "name": "Renamed Workspace",
+    "description": "Updated description",
+    "locked": false
+}
+
+### Delete workspace
+DELETE {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+Authorization: Bearer {{token}}
+
+### Duplicate workspace
+POST {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}/duplicate
+Authorization: Bearer {{token}}
+
+### Reorder workspaces
+PUT {{api}}/projects/{{projectId}}/workspaces/reorder
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "ordered_ids": ["id1", "id2", "id3"]
+}

--- a/http/api.http
+++ b/http/api.http
@@ -1,0 +1,86 @@
+@base = http://localhost:8000
+@api = {{base}}/api/v1
+
+###############################################################################
+# Health
+###############################################################################
+
+### Root
+GET {{base}}/
+
+### Health check
+GET {{base}}/health
+
+###############################################################################
+# Projects
+###############################################################################
+
+### List projects
+GET {{api}}/projects/
+
+### Create project
+POST {{api}}/projects/
+Content-Type: application/json
+
+{
+
+    "name": "My Project"
+}
+
+### Get project
+@projectId = REPLACE_ME
+GET {{api}}/projects/{{projectId}}
+
+### Update project
+PATCH {{api}}/projects/{{projectId}}
+Content-Type: application/json
+
+{
+    "name": "Renamed Project"
+}
+
+### Delete project
+DELETE {{api}}/projects/{{projectId}}
+
+###############################################################################
+# Workspaces
+###############################################################################
+
+### List workspaces
+GET {{api}}/projects/{{projectId}}/workspaces/
+
+### Create workspace
+POST {{api}}/projects/{{projectId}}/workspaces/
+Content-Type: application/json
+
+{
+    "name": "My Workspace 2"
+}
+
+### Get workspace
+@workspaceId = REPLACE_ME
+GET {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+
+### Update workspace
+PATCH {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+Content-Type: application/json
+
+{
+    "name": "Renamed Workspace",
+    "description": "Updated description",
+    "locked": false
+}
+
+### Delete workspace
+DELETE {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}
+
+### Duplicate workspace
+POST {{api}}/projects/{{projectId}}/workspaces/{{workspaceId}}/duplicate
+
+### Reorder workspaces
+PUT {{api}}/projects/{{projectId}}/workspaces/reorder
+Content-Type: application/json
+
+{
+    "ordered_ids": ["id1", "id2", "id3"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,23 @@ readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "Hasan Iqbal", email = "hasan.iqbal@mbzuai.ac.ae" }]
 license = { file = "LICENSE" }
-dependencies = []
+dependencies = [
+    "pydantic>=2.11",
+]
+
+[project.optional-dependencies]
+api = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "pydantic-settings>=2.9",
+    "PyJWT[crypto]>=2.10",
+    "sqlalchemy[asyncio]>=2.0",
+    "aiosqlite>=0.21",
+    "mangum>=0.19",
+]
+cloud = [
+    "boto3>=1.35",
+]
 
 ###############################################################################
 # Build System
@@ -50,7 +66,7 @@ indent-width = 4
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "UP", "I", "T20", "LOG", "ANN", "UP", "FA"]
+select = ["E4", "E7", "E9", "F", "UP", "I", "T20", "LOG", "ANN", "FA"]
 ignore = ["E712", "ANN401"]
 fixable = ["ALL"]
 unfixable = []
@@ -72,9 +88,14 @@ docstring-code-line-length = "dynamic"
 ###############################################################################
 [dependency-groups]
 dev = [
+    "openfactcheck[api,cloud]",
     "pyright>=1.1",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
+    "pytest-asyncio>=0.26",
+    "httpx>=0.28",
+    "boto3-stubs[dynamodb]>=1.35",
+    "moto[dynamodb]>=5.1",
     "ruff>=0.15.8",
 ]

--- a/src/openfactcheck/api/app.py
+++ b/src/openfactcheck/api/app.py
@@ -1,0 +1,41 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, FastAPI
+
+from openfactcheck.api.config import APIConfig
+from openfactcheck.api.dependencies import get_config
+from openfactcheck.api.middleware import register_middleware
+from openfactcheck.api.routers import health, projects, workspaces
+
+
+def create_app(config: APIConfig | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    if config is None:
+        config = APIConfig()
+
+    app = FastAPI(
+        title="OpenFactCheck API",
+        description="API for executing fact-checking pipelines",
+        debug=config.debug,
+    )
+
+    # Override get_config so all dependencies see the same config instance
+    app.dependency_overrides[get_config] = lambda: config
+
+    register_middleware(app, config.cors_origins)
+
+    # Health — no version prefix (infrastructure)
+    app.include_router(health.router)
+
+    # v1 — all versioned API routes
+    v1 = APIRouter(prefix="/api/v1")
+    v1.include_router(projects.router)
+    v1.include_router(workspaces.router)
+    app.include_router(v1)
+
+    return app
+
+
+app = create_app()

--- a/src/openfactcheck/api/auth/__init__.py
+++ b/src/openfactcheck/api/auth/__init__.py
@@ -1,0 +1,8 @@
+"""Authentication — Cognito JWT verification and dev bypass."""
+
+from openfactcheck.api.auth.cognito import CognitoVerifier, DevVerifier
+
+__all__ = [
+    "CognitoVerifier",
+    "DevVerifier",
+]

--- a/src/openfactcheck/api/auth/cognito.py
+++ b/src/openfactcheck/api/auth/cognito.py
@@ -1,0 +1,81 @@
+"""Cognito JWT verification and dev bypass."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import jwt
+from jwt import PyJWKClient
+
+from openfactcheck.api.errors import AuthError
+from openfactcheck.api.models import AuthUser
+
+
+class TokenVerifier(Protocol):
+    """Interface for verifying an Authorization bearer token."""
+
+    def verify(self, token: str) -> AuthUser: ...
+
+
+class CognitoVerifier:
+    """Verify Cognito ID tokens using JWKS.
+
+    Fetches the public keys from the Cognito user pool and validates:
+    RS256 signature, expiration, issuer, audience, and token_use=id.
+    """
+
+    def __init__(
+        self,
+        region: str,
+        user_pool_id: str,
+        client_id: str,
+        *,
+        jwk_client: PyJWKClient | None = None,
+    ) -> None:
+        self._issuer = f"https://cognito-idp.{region}.amazonaws.com/{user_pool_id}"
+        self._client_id = client_id
+        self._jwk_client = jwk_client or PyJWKClient(f"{self._issuer}/.well-known/jwks.json")
+
+    def verify(self, token: str) -> AuthUser:
+        """Decode and validate a Cognito ID token, returning the authenticated user."""
+        try:
+            signing_key = self._jwk_client.get_signing_key_from_jwt(token)
+            payload: dict[str, object] = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=["RS256"],
+                issuer=self._issuer,
+                audience=self._client_id,
+                options={"require": ["exp", "iss", "aud", "sub", "token_use"]},
+            )
+        except jwt.InvalidTokenError as e:
+            raise AuthError("Invalid or expired token") from e
+
+        if payload.get("token_use") != "id":
+            raise AuthError("Token is not an ID token")
+
+        sub = payload.get("sub")
+        email = payload.get("email")
+        if not isinstance(sub, str) or not isinstance(email, str):
+            raise AuthError("Token missing required claims")
+
+        name = payload.get("name", "")
+        if not isinstance(name, str):
+            name = ""
+
+        return AuthUser(sub=sub, email=email, name=name)
+
+
+DEV_USER = AuthUser(
+    sub="dev-user-00000000",
+    email="dev@localhost",
+    name="Dev User",
+)
+
+
+class DevVerifier:
+    """Bypass verifier for local development. Always returns a fixed dev user."""
+
+    def verify(self, token: str) -> AuthUser:  # noqa: ARG002
+        """Return the hardcoded dev user regardless of the token value."""
+        return DEV_USER

--- a/src/openfactcheck/api/config.py
+++ b/src/openfactcheck/api/config.py
@@ -1,0 +1,36 @@
+"""API server configuration loaded from OPENFACTCHECK_ prefixed environment variables."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class APIConfig(BaseSettings):
+    """Configuration for the FastAPI server and all API subsystems."""
+
+    model_config = SettingsConfigDict(env_prefix="OPENFACTCHECK_", env_file=".env")
+
+    # Server
+    host: str = "0.0.0.0"
+    port: int = 8000
+    debug: bool = False
+
+    # CORS
+    cors_origins: list[str] = ["http://localhost:3001"]
+
+    # Auth
+    auth_bypass: bool = False
+    cognito_region: str = "us-east-1"
+    cognito_user_pool_id: str = ""
+    cognito_client_id: str = ""
+
+    # Database
+    database_backend: Literal["sqlite", "dynamodb"] = "sqlite"
+    sqlite_path: str = "~/.openfactcheck/data.db"
+    dynamodb_table_name: str = "openfactcheck"
+    dynamodb_region: str = "us-east-1"
+
+    # Execution
+    max_execution_timeout: int = 600

--- a/src/openfactcheck/api/dependencies.py
+++ b/src/openfactcheck/api/dependencies.py
@@ -1,0 +1,112 @@
+"""FastAPI dependency injection — settings, auth, repositories."""
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+from typing import Annotated, Any
+
+from fastapi import Depends, Header
+
+from openfactcheck.api.auth.cognito import CognitoVerifier, DevVerifier, TokenVerifier
+from openfactcheck.api.config import APIConfig
+from openfactcheck.api.errors import AuthError
+from openfactcheck.api.models import AuthUser
+from openfactcheck.api.repositories.protocols import ProjectRepository, WorkspaceRepository
+
+
+@lru_cache(maxsize=1)
+def get_config() -> APIConfig:
+    """Return the singleton API configuration."""
+    return APIConfig()
+
+
+_verifier: TokenVerifier | None = None
+_project_repo: ProjectRepository | None = None
+_workspace_repo: WorkspaceRepository | None = None
+_sqlite_session_factory: Any = None
+_sqlite_lock = asyncio.Lock()
+
+
+async def _get_sqlite_session_factory(config: APIConfig) -> Any:  # noqa: ANN401
+    """Return a shared SQLite session factory, creating the engine once (thread-safe)."""
+    global _sqlite_session_factory  # noqa: PLW0603
+    if _sqlite_session_factory is not None:
+        return _sqlite_session_factory
+    async with _sqlite_lock:
+        if _sqlite_session_factory is None:
+            from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
+
+            engine = await create_engine_and_tables(config.sqlite_path)
+            _sqlite_session_factory = session_factory(engine)
+    return _sqlite_session_factory
+
+
+async def get_verifier(config: Annotated[APIConfig, Depends(get_config)]) -> TokenVerifier:
+    """Return the token verifier, creating it on first call."""
+    global _verifier  # noqa: PLW0603
+    if _verifier is None:
+        if config.auth_bypass and config.debug:
+            _verifier = DevVerifier()
+        else:
+            _verifier = CognitoVerifier(
+                region=config.cognito_region,
+                user_pool_id=config.cognito_user_pool_id,
+                client_id=config.cognito_client_id,
+            )
+    return _verifier
+
+
+async def get_current_user(
+    config: Annotated[APIConfig, Depends(get_config)],
+    verifier: Annotated[TokenVerifier, Depends(get_verifier)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> AuthUser:
+    """Extract and verify the bearer token, returning the current user."""
+    if config.auth_bypass and config.debug:
+        return verifier.verify("")
+
+    if authorization is None:
+        raise AuthError("Missing Authorization header")
+
+    parts = authorization.split(" ", maxsplit=1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise AuthError("Authorization header must be: Bearer <token>")
+
+    return verifier.verify(parts[1])
+
+
+async def get_project_repo(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> ProjectRepository:
+    """Return the project repository, creating it on first call."""
+    global _project_repo  # noqa: PLW0603
+    if _project_repo is None:
+        if config.database_backend == "dynamodb":
+            from openfactcheck.api.repositories.dynamodb.projects import DynamoProjectRepository
+
+            _project_repo = DynamoProjectRepository(config.dynamodb_table_name, config.dynamodb_region)
+        else:
+            from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+
+            sf = await _get_sqlite_session_factory(config)
+            _project_repo = SqliteProjectRepository(sf)
+    return _project_repo
+
+
+async def get_workspace_repo(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> WorkspaceRepository:
+    """Return the workspace repository, creating it on first call."""
+    global _workspace_repo  # noqa: PLW0603
+    if _workspace_repo is None:
+        if config.database_backend == "dynamodb":
+            from openfactcheck.api.repositories.dynamodb.workspaces import DynamoWorkspaceRepository
+
+            _workspace_repo = DynamoWorkspaceRepository(config.dynamodb_table_name, config.dynamodb_region)
+        else:
+            from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
+
+            sf = await _get_sqlite_session_factory(config)
+            _workspace_repo = SqliteWorkspaceRepository(sf)
+    return _workspace_repo

--- a/src/openfactcheck/api/errors.py
+++ b/src/openfactcheck/api/errors.py
@@ -1,0 +1,90 @@
+"""API error types and machine-readable error codes."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    """Machine-readable error codes returned in JSON error responses."""
+
+    NOT_FOUND = "NOT_FOUND"
+    ALREADY_EXISTS = "ALREADY_EXISTS"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    PROJECT_LIMIT_REACHED = "PROJECT_LIMIT_REACHED"
+    WORKSPACE_LIMIT_REACHED = "WORKSPACE_LIMIT_REACHED"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    FORBIDDEN = "FORBIDDEN"
+    EXECUTION_TIMEOUT = "EXECUTION_TIMEOUT"
+    EXECUTION_ERROR = "EXECUTION_ERROR"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class AppError(Exception):
+    """Base exception for all API errors.
+
+    Caught by middleware and converted to a JSON response:
+    ``{"detail": "...", "code": "MACHINE_CODE", "status": 500}``
+    """
+
+    def __init__(self, detail: str, code: ErrorCode, status: int = 500) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.code = code
+        self.status = status
+
+
+class NotFoundError(AppError):
+    """Raised when a requested resource does not exist."""
+
+    def __init__(self, detail: str = "Resource not found") -> None:
+        super().__init__(detail, ErrorCode.NOT_FOUND, status=404)
+
+
+class AlreadyExistsError(AppError):
+    """Raised when attempting to create a resource that already exists."""
+
+    def __init__(self, detail: str = "Resource already exists") -> None:
+        super().__init__(detail, ErrorCode.ALREADY_EXISTS, status=409)
+
+
+class ProjectLimitError(AppError):
+    """Raised when a user has reached their maximum project count."""
+
+    def __init__(self, detail: str = "Project limit reached") -> None:
+        super().__init__(detail, ErrorCode.PROJECT_LIMIT_REACHED, status=422)
+
+
+class WorkspaceLimitError(AppError):
+    """Raised when a project has reached its maximum workspace count."""
+
+    def __init__(self, detail: str = "Workspace limit reached") -> None:
+        super().__init__(detail, ErrorCode.WORKSPACE_LIMIT_REACHED, status=422)
+
+
+class AuthError(AppError):
+    """Raised when authentication fails or is missing."""
+
+    def __init__(self, detail: str = "Authentication required") -> None:
+        super().__init__(detail, ErrorCode.UNAUTHORIZED, status=401)
+
+
+class ForbiddenError(AppError):
+    """Raised when the user lacks permission for the requested action."""
+
+    def __init__(self, detail: str = "Forbidden") -> None:
+        super().__init__(detail, ErrorCode.FORBIDDEN, status=403)
+
+
+class ExecutionTimeoutError(AppError):
+    """Raised when pipeline execution exceeds the allowed timeout."""
+
+    def __init__(self, detail: str = "Execution timed out") -> None:
+        super().__init__(detail, ErrorCode.EXECUTION_TIMEOUT, status=408)
+
+
+class ExecutionError(AppError):
+    """Raised when pipeline execution fails."""
+
+    def __init__(self, detail: str = "Execution failed") -> None:
+        super().__init__(detail, ErrorCode.EXECUTION_ERROR, status=500)

--- a/src/openfactcheck/api/lambda_handler.py
+++ b/src/openfactcheck/api/lambda_handler.py
@@ -1,0 +1,9 @@
+"""AWS Lambda handler — wraps the FastAPI app with Mangum."""
+
+from __future__ import annotations
+
+from mangum import Mangum
+
+from openfactcheck.api.app import create_app
+
+handler = Mangum(create_app())

--- a/src/openfactcheck/api/middleware.py
+++ b/src/openfactcheck/api/middleware.py
@@ -1,0 +1,52 @@
+"""Middleware — error handling and CORS."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from openfactcheck.api.errors import AppError, ErrorCode
+
+logger = logging.getLogger(__name__)
+
+
+async def app_error_handler(_request: Request, exc: AppError) -> JSONResponse:
+    """Convert AppError exceptions into structured JSON responses."""
+    return JSONResponse(
+        status_code=exc.status,
+        content={
+            "detail": exc.detail,
+            "code": exc.code.value,
+            "status": exc.status,
+        },
+    )
+
+
+async def generic_error_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """Catch-all handler — prevents stack traces from leaking to clients."""
+    logger.exception("Unhandled exception: %s", exc)
+    return JSONResponse(
+        status_code=500,
+        content={
+            "detail": "Internal server error",
+            "code": ErrorCode.INTERNAL_ERROR.value,
+            "status": 500,
+        },
+    )
+
+
+def register_middleware(app: FastAPI, cors_origins: list[str]) -> None:
+    """Register all middleware and exception handlers on the app."""
+    app.add_exception_handler(AppError, app_error_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(Exception, generic_error_handler)  # type: ignore[arg-type]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-Request-ID"],
+    )

--- a/src/openfactcheck/api/models/__init__.py
+++ b/src/openfactcheck/api/models/__init__.py
@@ -1,0 +1,16 @@
+"""Domain models for the API layer."""
+
+from openfactcheck.api.models.project import Project, ProjectCreate, ProjectUpdate
+from openfactcheck.api.models.user import AuthUser
+from openfactcheck.api.models.workspace import Workspace, WorkspaceCreate, WorkspaceSettings, WorkspaceUpdate
+
+__all__ = [
+    "AuthUser",
+    "Project",
+    "ProjectCreate",
+    "ProjectUpdate",
+    "Workspace",
+    "WorkspaceCreate",
+    "WorkspaceSettings",
+    "WorkspaceUpdate",
+]

--- a/src/openfactcheck/api/models/project.py
+++ b/src/openfactcheck/api/models/project.py
@@ -1,0 +1,29 @@
+"""Project domain model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class Project(BaseModel):
+    """A user's fact-checking project."""
+
+    id: str
+    user_id: str
+    name: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectCreate(BaseModel):
+    """Fields required to create a new project."""
+
+    name: str = Field(min_length=1, max_length=255)
+
+
+class ProjectUpdate(BaseModel):
+    """Fields that can be updated on a project. All optional."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)

--- a/src/openfactcheck/api/models/user.py
+++ b/src/openfactcheck/api/models/user.py
@@ -1,0 +1,20 @@
+"""Authenticated user model derived from JWT claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AuthUser:
+    """Current authenticated user, extracted from a Cognito JWT.
+
+    Attributes:
+        sub: Cognito user pool subject identifier (used as user_id throughout the API).
+        email: User's verified email address.
+        name: User's display name (may be empty).
+    """
+
+    sub: str
+    email: str
+    name: str = ""

--- a/src/openfactcheck/api/models/workspace.py
+++ b/src/openfactcheck/api/models/workspace.py
@@ -1,0 +1,43 @@
+"""Workspace domain model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WorkspaceSettings(BaseModel):
+    """Optional per-workspace configuration."""
+
+    verbose_mode: bool = False
+
+
+class Workspace(BaseModel):
+    """A workspace within a project, containing a single pipeline configuration."""
+
+    id: str
+    user_id: str
+    project_id: str
+    name: str
+    description: str = ""
+    locked: bool = False
+    sort_order: int
+    settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkspaceCreate(BaseModel):
+    """Fields required to create a new workspace."""
+
+    name: str = Field(min_length=1, max_length=255)
+
+
+class WorkspaceUpdate(BaseModel):
+    """Fields that can be updated on a workspace. All optional."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=10000)
+    locked: bool | None = None
+    settings: WorkspaceSettings | None = None

--- a/src/openfactcheck/api/repositories/__init__.py
+++ b/src/openfactcheck/api/repositories/__init__.py
@@ -1,0 +1,8 @@
+"""Repository layer — data access protocols and implementations."""
+
+from openfactcheck.api.repositories.protocols import ProjectRepository, WorkspaceRepository
+
+__all__ = [
+    "ProjectRepository",
+    "WorkspaceRepository",
+]

--- a/src/openfactcheck/api/repositories/constants.py
+++ b/src/openfactcheck/api/repositories/constants.py
@@ -1,0 +1,13 @@
+"""Shared constants and utilities for all repository implementations."""
+
+from __future__ import annotations
+
+from secrets import token_urlsafe
+
+MAX_PROJECTS_PER_USER = 50
+MAX_WORKSPACES_PER_PROJECT = 5
+
+
+def generate_id() -> str:
+    """Generate a URL-safe 12-character ID."""
+    return token_urlsafe(9)  # 9 bytes → 12 base64 chars

--- a/src/openfactcheck/api/repositories/dynamodb/__init__.py
+++ b/src/openfactcheck/api/repositories/dynamodb/__init__.py
@@ -1,0 +1,9 @@
+"""DynamoDB repository implementations using boto3 with asyncio.to_thread."""
+
+from openfactcheck.api.repositories.dynamodb.projects import DynamoProjectRepository
+from openfactcheck.api.repositories.dynamodb.workspaces import DynamoWorkspaceRepository
+
+__all__ = [
+    "DynamoProjectRepository",
+    "DynamoWorkspaceRepository",
+]

--- a/src/openfactcheck/api/repositories/dynamodb/client.py
+++ b/src/openfactcheck/api/repositories/dynamodb/client.py
@@ -1,0 +1,14 @@
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
+"""boto3 DynamoDB table resource factory."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+
+
+def get_table(table_name: str, region_name: str = "us-east-1") -> Any:  # noqa: ANN401
+    """Return a boto3 DynamoDB Table resource."""
+    resource = boto3.resource("dynamodb", region_name=region_name)
+    return resource.Table(table_name)

--- a/src/openfactcheck/api/repositories/dynamodb/keys.py
+++ b/src/openfactcheck/api/repositories/dynamodb/keys.py
@@ -1,0 +1,36 @@
+"""DynamoDB single-table key composition — mirrors the frontend key scheme.
+
+Table design:
+    PK (hash key)  — unique item identifier
+    GS1PK (GSI)    — query key for listing items by parent
+
+Project keys:
+    PK:    USER#<userId>#PROJECT#<projectId>
+    GS1PK: USER#<userId>
+
+Workspace keys:
+    PK:    USER#<userId>#PROJECT#<projectId>#WORKSPACE#<workspaceId>
+    GS1PK: USER#<userId>#PROJECT#<projectId>
+"""
+
+from __future__ import annotations
+
+
+def project_pk(user_id: str, project_id: str) -> str:
+    """Primary key for a project item."""
+    return f"USER#{user_id}#PROJECT#{project_id}"
+
+
+def project_gs1pk(user_id: str) -> str:
+    """GSI key to list all projects for a user."""
+    return f"USER#{user_id}"
+
+
+def workspace_pk(user_id: str, project_id: str, workspace_id: str) -> str:
+    """Primary key for a workspace item."""
+    return f"USER#{user_id}#PROJECT#{project_id}#WORKSPACE#{workspace_id}"
+
+
+def workspace_gs1pk(user_id: str, project_id: str) -> str:
+    """GSI key to list all workspaces for a project."""
+    return f"USER#{user_id}#PROJECT#{project_id}"

--- a/src/openfactcheck/api/repositories/dynamodb/projects.py
+++ b/src/openfactcheck/api/repositories/dynamodb/projects.py
@@ -1,0 +1,151 @@
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+"""DynamoDB implementation of the project repository."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from openfactcheck.api.models import Project, ProjectCreate, ProjectUpdate
+from openfactcheck.api.repositories.constants import MAX_PROJECTS_PER_USER, generate_id
+from openfactcheck.api.repositories.dynamodb.client import get_table
+from openfactcheck.api.repositories.dynamodb.keys import project_gs1pk, project_pk
+
+
+def _item_to_model(item: dict[str, Any]) -> Project:
+    return Project(
+        id=item["id"],
+        user_id=item["userId"],
+        name=item["name"],
+        created_at=datetime.fromisoformat(item["createdAt"]),
+        updated_at=datetime.fromisoformat(item["updatedAt"]),
+    )
+
+
+class DynamoProjectRepository:
+    """Project CRUD backed by DynamoDB single-table design."""
+
+    def __init__(self, table_name: str, region_name: str = "us-east-1") -> None:
+        self._table = get_table(table_name, region_name)
+
+    async def list_by_user(self, user_id: str, limit: int = 50, offset: int = 0) -> list[Project]:
+        def _query() -> list[Project]:
+            response = self._table.query(
+                IndexName="gs1",
+                KeyConditionExpression="GS1PK = :gs1pk",
+                FilterExpression="begins_with(PK, :prefix)",
+                ExpressionAttributeValues={
+                    ":gs1pk": project_gs1pk(user_id),
+                    ":prefix": f"USER#{user_id}#PROJECT#",
+                },
+            )
+            items: list[dict[str, Any]] = response.get("Items", [])
+            projects = sorted((_item_to_model(item) for item in items), key=lambda p: p.created_at)
+            return projects[offset : offset + limit]
+
+        return await asyncio.to_thread(_query)
+
+    async def get(self, user_id: str, project_id: str) -> Project | None:
+        def _get() -> Project | None:
+            response = self._table.get_item(
+                Key={"PK": project_pk(user_id, project_id)},
+            )
+            item: dict[str, Any] | None = response.get("Item")
+            return _item_to_model(item) if item else None
+
+        return await asyncio.to_thread(_get)
+
+    async def create(self, user_id: str, data: ProjectCreate) -> Project | None:
+        existing = await self.list_by_user(user_id)
+        if len(existing) >= MAX_PROJECTS_PER_USER:
+            return None
+
+        now = datetime.now(UTC)
+        project_id = generate_id()
+        item: dict[str, Any] = {
+            "PK": project_pk(user_id, project_id),
+            "GS1PK": project_gs1pk(user_id),
+            "id": project_id,
+            "userId": user_id,
+            "name": data.name,
+            "createdAt": now.isoformat(),
+            "updatedAt": now.isoformat(),
+        }
+
+        def _put() -> None:
+            self._table.put_item(Item=item)
+
+        await asyncio.to_thread(_put)
+        return _item_to_model(item)
+
+    async def update(self, user_id: str, project_id: str, data: ProjectUpdate) -> Project | None:
+        values = data.model_dump(exclude_none=True)
+        if not values:
+            return await self.get(user_id, project_id)
+
+        now = datetime.now(UTC)
+        update_parts: list[str] = []
+        attr_names: dict[str, str] = {}
+        attr_values: dict[str, Any] = {}
+
+        for field, value in values.items():
+            alias = f"#{field}"
+            placeholder = f":{field}"
+            update_parts.append(f"{alias} = {placeholder}")
+            attr_names[alias] = field
+            attr_values[placeholder] = value
+
+        update_parts.append("#updatedAt = :updatedAt")
+        attr_names["#updatedAt"] = "updatedAt"
+        attr_values[":updatedAt"] = now.isoformat()
+
+        pk = project_pk(user_id, project_id)
+
+        def _update() -> dict[str, Any] | None:
+            try:
+                response: dict[str, Any] = self._table.update_item(
+                    Key={"PK": pk},
+                    UpdateExpression="SET " + ", ".join(update_parts),
+                    ExpressionAttributeNames=attr_names,
+                    ExpressionAttributeValues=attr_values,
+                    ConditionExpression="attribute_exists(PK)",
+                    ReturnValues="ALL_NEW",
+                )
+            except self._table.meta.client.exceptions.ConditionalCheckFailedException:
+                return None
+            return response["Attributes"]
+
+        attrs = await asyncio.to_thread(_update)
+        return _item_to_model(attrs) if attrs else None
+
+    async def delete(self, user_id: str, project_id: str) -> bool:
+        from openfactcheck.api.repositories.dynamodb.keys import workspace_gs1pk
+
+        pk = project_pk(user_id, project_id)
+
+        def _delete() -> bool:
+            try:
+                self._table.delete_item(
+                    Key={"PK": pk},
+                    ConditionExpression="attribute_exists(PK)",
+                )
+            except self._table.meta.client.exceptions.ConditionalCheckFailedException:
+                return False
+
+            # Cascade — delete all workspaces belonging to this project
+            gs1pk = workspace_gs1pk(user_id, project_id)
+            response = self._table.query(
+                IndexName="gs1",
+                KeyConditionExpression="GS1PK = :gs1pk",
+                ExpressionAttributeValues={":gs1pk": gs1pk},
+                ProjectionExpression="PK",
+            )
+            items: list[dict[str, Any]] = response.get("Items", [])
+            with self._table.batch_writer() as batch:
+                for item in items:
+                    batch.delete_item(Key={"PK": item["PK"]})
+
+            return True
+
+        return await asyncio.to_thread(_delete)

--- a/src/openfactcheck/api/repositories/dynamodb/workspaces.py
+++ b/src/openfactcheck/api/repositories/dynamodb/workspaces.py
@@ -1,0 +1,214 @@
+# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
+"""DynamoDB implementation of the workspace repository."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from openfactcheck.api.models import Workspace, WorkspaceCreate, WorkspaceSettings, WorkspaceUpdate
+from openfactcheck.api.repositories.constants import MAX_WORKSPACES_PER_PROJECT, generate_id
+from openfactcheck.api.repositories.dynamodb.client import get_table
+from openfactcheck.api.repositories.dynamodb.keys import workspace_gs1pk, workspace_pk
+
+
+def _item_to_model(item: dict[str, Any]) -> Workspace:
+    settings_raw = item.get("settings", "{}")
+    settings_str = settings_raw if isinstance(settings_raw, str) else json.dumps(settings_raw)
+
+    return Workspace(
+        id=item["id"],
+        user_id=item["userId"],
+        project_id=item["projectId"],
+        name=item["name"],
+        description=item.get("description", ""),
+        locked=item.get("locked", False),
+        sort_order=int(item.get("sortOrder", 0)),
+        settings=WorkspaceSettings.model_validate_json(settings_str),
+        created_at=datetime.fromisoformat(item["createdAt"]),
+        updated_at=datetime.fromisoformat(item["updatedAt"]),
+    )
+
+
+class DynamoWorkspaceRepository:
+    """Workspace CRUD backed by DynamoDB single-table design."""
+
+    def __init__(self, table_name: str, region_name: str = "us-east-1") -> None:
+        self._table = get_table(table_name, region_name)
+
+    def _list_items_sync(self, user_id: str, project_id: str) -> list[dict[str, Any]]:
+        response = self._table.query(
+            IndexName="gs1",
+            KeyConditionExpression="GS1PK = :gs1pk",
+            FilterExpression="begins_with(PK, :prefix)",
+            ExpressionAttributeValues={
+                ":gs1pk": workspace_gs1pk(user_id, project_id),
+                ":prefix": f"USER#{user_id}#PROJECT#{project_id}#WORKSPACE#",
+            },
+        )
+        return response.get("Items", [])
+
+    async def list_by_project(self, user_id: str, project_id: str) -> list[Workspace]:
+        items = await asyncio.to_thread(self._list_items_sync, user_id, project_id)
+        workspaces = [_item_to_model(item) for item in items]
+        return sorted(workspaces, key=lambda w: w.sort_order)
+
+    async def get(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
+        def _get() -> Workspace | None:
+            response = self._table.get_item(
+                Key={"PK": workspace_pk(user_id, project_id, workspace_id)},
+            )
+            item: dict[str, Any] | None = response.get("Item")
+            return _item_to_model(item) if item else None
+
+        return await asyncio.to_thread(_get)
+
+    async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None:
+        def _create() -> Workspace | None:
+            items = self._list_items_sync(user_id, project_id)
+            if len(items) >= MAX_WORKSPACES_PER_PROJECT:
+                return None
+
+            max_order = max((int(i.get("sortOrder", 0)) for i in items), default=0)
+
+            now = datetime.now(UTC)
+            workspace_id = generate_id()
+            item: dict[str, Any] = {
+                "PK": workspace_pk(user_id, project_id, workspace_id),
+                "GS1PK": workspace_gs1pk(user_id, project_id),
+                "id": workspace_id,
+                "userId": user_id,
+                "projectId": project_id,
+                "name": data.name,
+                "description": "",
+                "locked": False,
+                "sortOrder": max_order + 1,
+                "settings": "{}",
+                "createdAt": now.isoformat(),
+                "updatedAt": now.isoformat(),
+            }
+            self._table.put_item(Item=item)
+            return _item_to_model(item)
+
+        return await asyncio.to_thread(_create)
+
+    async def update(self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate) -> Workspace | None:
+        update_parts: list[str] = []
+        attr_names: dict[str, str] = {}
+        attr_values: dict[str, Any] = {}
+
+        if data.name is not None:
+            update_parts.append("#name = :name")
+            attr_names["#name"] = "name"
+            attr_values[":name"] = data.name
+        if data.description is not None:
+            update_parts.append("#description = :description")
+            attr_names["#description"] = "description"
+            attr_values[":description"] = data.description
+        if data.locked is not None:
+            update_parts.append("#locked = :locked")
+            attr_names["#locked"] = "locked"
+            attr_values[":locked"] = data.locked
+        if data.settings is not None:
+            update_parts.append("#settings = :settings")
+            attr_names["#settings"] = "settings"
+            attr_values[":settings"] = data.settings.model_dump_json()
+
+        if not update_parts:
+            return await self.get(user_id, project_id, workspace_id)
+
+        now = datetime.now(UTC)
+        update_parts.append("#updatedAt = :updatedAt")
+        attr_names["#updatedAt"] = "updatedAt"
+        attr_values[":updatedAt"] = now.isoformat()
+
+        pk = workspace_pk(user_id, project_id, workspace_id)
+
+        def _update() -> dict[str, Any] | None:
+            try:
+                response: dict[str, Any] = self._table.update_item(
+                    Key={"PK": pk},
+                    UpdateExpression="SET " + ", ".join(update_parts),
+                    ExpressionAttributeNames=attr_names,
+                    ExpressionAttributeValues=attr_values,
+                    ConditionExpression="attribute_exists(PK)",
+                    ReturnValues="ALL_NEW",
+                )
+            except self._table.meta.client.exceptions.ConditionalCheckFailedException:
+                return None
+            return response["Attributes"]
+
+        attrs = await asyncio.to_thread(_update)
+        return _item_to_model(attrs) if attrs else None
+
+    async def delete(self, user_id: str, project_id: str, workspace_id: str) -> bool:
+        pk = workspace_pk(user_id, project_id, workspace_id)
+
+        def _delete() -> bool:
+            try:
+                self._table.delete_item(
+                    Key={"PK": pk},
+                    ConditionExpression="attribute_exists(PK)",
+                )
+            except self._table.meta.client.exceptions.ConditionalCheckFailedException:
+                return False
+            return True
+
+        return await asyncio.to_thread(_delete)
+
+    async def duplicate(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
+        source = await self.get(user_id, project_id, workspace_id)
+        if source is None:
+            return None
+
+        def _duplicate() -> Workspace | None:
+            items = self._list_items_sync(user_id, project_id)
+            if len(items) >= MAX_WORKSPACES_PER_PROJECT:
+                return None
+
+            max_order = max((int(i.get("sortOrder", 0)) for i in items), default=0)
+
+            now = datetime.now(UTC)
+            new_id = generate_id()
+            item: dict[str, Any] = {
+                "PK": workspace_pk(user_id, project_id, new_id),
+                "GS1PK": workspace_gs1pk(user_id, project_id),
+                "id": new_id,
+                "userId": user_id,
+                "projectId": project_id,
+                "name": f"{source.name[:248]} (copy)",
+                "description": source.description,
+                "locked": False,
+                "sortOrder": max_order + 1,
+                "settings": json.dumps(source.settings.model_dump()),
+                "createdAt": now.isoformat(),
+                "updatedAt": now.isoformat(),
+            }
+            self._table.put_item(Item=item)
+            return _item_to_model(item)
+
+        return await asyncio.to_thread(_duplicate)
+
+    async def reorder(self, user_id: str, project_id: str, ordered_ids: list[str]) -> None:
+        now = datetime.now(UTC)
+
+        def _reorder() -> None:
+            for index, ws_id in enumerate(ordered_ids, start=1):
+                pk = workspace_pk(user_id, project_id, ws_id)
+                self._table.update_item(
+                    Key={"PK": pk},
+                    UpdateExpression="SET #sortOrder = :sortOrder, #updatedAt = :updatedAt",
+                    ExpressionAttributeNames={
+                        "#sortOrder": "sortOrder",
+                        "#updatedAt": "updatedAt",
+                    },
+                    ExpressionAttributeValues={
+                        ":sortOrder": index,
+                        ":updatedAt": now.isoformat(),
+                    },
+                    ConditionExpression="attribute_exists(PK)",
+                )
+
+        await asyncio.to_thread(_reorder)

--- a/src/openfactcheck/api/repositories/protocols.py
+++ b/src/openfactcheck/api/repositories/protocols.py
@@ -1,0 +1,41 @@
+"""Repository protocol definitions for structural typing (Pyright strict)."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from openfactcheck.api.models import Project, ProjectCreate, ProjectUpdate, Workspace, WorkspaceCreate, WorkspaceUpdate
+
+
+class ProjectRepository(Protocol):
+    """Data access interface for projects."""
+
+    async def list_by_user(self, user_id: str, limit: int = 50, offset: int = 0) -> list[Project]: ...
+
+    async def get(self, user_id: str, project_id: str) -> Project | None: ...
+
+    async def create(self, user_id: str, data: ProjectCreate) -> Project | None: ...
+
+    async def update(self, user_id: str, project_id: str, data: ProjectUpdate) -> Project | None: ...
+
+    async def delete(self, user_id: str, project_id: str) -> bool: ...
+
+
+class WorkspaceRepository(Protocol):
+    """Data access interface for workspaces."""
+
+    async def list_by_project(self, user_id: str, project_id: str) -> list[Workspace]: ...
+
+    async def get(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None: ...
+
+    async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None: ...
+
+    async def update(
+        self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate
+    ) -> Workspace | None: ...
+
+    async def delete(self, user_id: str, project_id: str, workspace_id: str) -> bool: ...
+
+    async def duplicate(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None: ...
+
+    async def reorder(self, user_id: str, project_id: str, ordered_ids: list[str]) -> None: ...

--- a/src/openfactcheck/api/repositories/sqlite/__init__.py
+++ b/src/openfactcheck/api/repositories/sqlite/__init__.py
@@ -1,0 +1,9 @@
+"""SQLite repository implementations using SQLAlchemy 2.0 async."""
+
+from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
+
+__all__ = [
+    "SqliteProjectRepository",
+    "SqliteWorkspaceRepository",
+]

--- a/src/openfactcheck/api/repositories/sqlite/engine.py
+++ b/src/openfactcheck/api/repositories/sqlite/engine.py
@@ -1,0 +1,46 @@
+"""SQLAlchemy async engine, session factory, and declarative base."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all ORM table models."""
+
+
+async def create_engine_and_tables(sqlite_path: str) -> AsyncEngine:
+    """Create an async SQLite engine and ensure all tables exist.
+
+    The parent directory for *sqlite_path* is created if it does not exist.
+    Pass ``":memory:"`` for an in-memory database (useful in tests).
+    """
+    if sqlite_path != ":memory:":
+        resolved = Path(sqlite_path).expanduser().resolve()
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        url = f"sqlite+aiosqlite:///{resolved}"
+    else:
+        url = "sqlite+aiosqlite:///:memory:"
+
+    engine = create_async_engine(url)
+
+    # Enable foreign key enforcement (required for CASCADE to work in SQLite)
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_foreign_keys(dbapi_conn: object, _connection_record: object) -> None:  # pyright: ignore[reportUnusedFunction]
+        cursor = dbapi_conn.cursor()  # type: ignore[union-attr]
+        cursor.execute("PRAGMA foreign_keys=ON")  # type: ignore[union-attr]
+        cursor.close()  # type: ignore[union-attr]
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    return engine
+
+
+def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Return a session factory bound to *engine*."""
+    return async_sessionmaker(engine, expire_on_commit=False)

--- a/src/openfactcheck/api/repositories/sqlite/projects.py
+++ b/src/openfactcheck/api/repositories/sqlite/projects.py
@@ -1,0 +1,93 @@
+"""SQLite implementation of the project repository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import Project, ProjectCreate, ProjectUpdate
+from openfactcheck.api.repositories.constants import MAX_PROJECTS_PER_USER, generate_id
+from openfactcheck.api.repositories.sqlite.tables import ProjectRow
+
+
+def _row_to_model(row: ProjectRow) -> Project:
+    return Project(
+        id=row.id,
+        user_id=row.user_id,
+        name=row.name,
+        created_at=row.created_at.replace(tzinfo=UTC),
+        updated_at=row.updated_at.replace(tzinfo=UTC),
+    )
+
+
+class SqliteProjectRepository:
+    """Project CRUD backed by SQLite via SQLAlchemy async."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def list_by_user(self, user_id: str, limit: int = 50, offset: int = 0) -> list[Project]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectRow)
+                .where(ProjectRow.user_id == user_id)
+                .order_by(ProjectRow.created_at)
+                .limit(limit)
+                .offset(offset)
+            )
+            return [_row_to_model(row) for row in result.scalars()]
+
+    async def get(self, user_id: str, project_id: str) -> Project | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id)
+            )
+            row = result.scalar_one_or_none()
+            return _row_to_model(row) if row else None
+
+    async def create(self, user_id: str, data: ProjectCreate) -> Project | None:
+        async with self._session_factory() as session:
+            count_result = await session.execute(
+                select(func.count()).select_from(ProjectRow).where(ProjectRow.user_id == user_id)
+            )
+            if count_result.scalar_one() >= MAX_PROJECTS_PER_USER:
+                return None
+
+            now = datetime.now(UTC)
+            row = ProjectRow(
+                id=generate_id(),
+                user_id=user_id,
+                name=data.name,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            return _row_to_model(row)
+
+    async def update(self, user_id: str, project_id: str, data: ProjectUpdate) -> Project | None:
+        values = data.model_dump(exclude_none=True)
+        if not values:
+            return await self.get(user_id, project_id)
+
+        values["updated_at"] = datetime.now(UTC)
+
+        async with self._session_factory() as session:
+            cursor = await session.execute(
+                update(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id).values(**values)
+            )
+            await session.commit()
+            if cursor.rowcount == 0:  # type: ignore[union-attr]
+                return None
+
+        return await self.get(user_id, project_id)
+
+    async def delete(self, user_id: str, project_id: str) -> bool:
+        async with self._session_factory() as session:
+            cursor = await session.execute(
+                delete(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id)
+            )
+            await session.commit()
+            return bool(cursor.rowcount)  # type: ignore[union-attr]

--- a/src/openfactcheck/api/repositories/sqlite/tables.py
+++ b/src/openfactcheck/api/repositories/sqlite/tables.py
@@ -1,0 +1,46 @@
+"""SQLAlchemy ORM table definitions for projects and workspaces."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKeyConstraint, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from openfactcheck.api.repositories.sqlite.engine import Base
+
+
+class ProjectRow(Base):
+    """ORM model for the ``projects`` table."""
+
+    __tablename__ = "projects"
+
+    id: Mapped[str] = mapped_column(String(12), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(255), index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class WorkspaceRow(Base):
+    """ORM model for the ``workspaces`` table."""
+
+    __tablename__ = "workspaces"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            ondelete="CASCADE",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(12), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(255), index=True)
+    project_id: Mapped[str] = mapped_column(String(12), index=True)
+    name: Mapped[str] = mapped_column(String(255))
+    description: Mapped[str] = mapped_column(Text, default="")
+    locked: Mapped[bool] = mapped_column(Boolean, default=False)
+    sort_order: Mapped[int] = mapped_column(Integer)
+    settings_json: Mapped[str] = mapped_column(Text, default="{}")
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)

--- a/src/openfactcheck/api/repositories/sqlite/workspaces.py
+++ b/src/openfactcheck/api/repositories/sqlite/workspaces.py
@@ -1,0 +1,178 @@
+"""SQLite implementation of the workspace repository."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import Workspace, WorkspaceCreate, WorkspaceSettings, WorkspaceUpdate
+from openfactcheck.api.repositories.constants import MAX_WORKSPACES_PER_PROJECT, generate_id
+from openfactcheck.api.repositories.sqlite.tables import WorkspaceRow
+
+
+def _row_to_model(row: WorkspaceRow) -> Workspace:
+    return Workspace(
+        id=row.id,
+        user_id=row.user_id,
+        project_id=row.project_id,
+        name=row.name,
+        description=row.description,
+        locked=row.locked,
+        sort_order=row.sort_order,
+        settings=WorkspaceSettings.model_validate_json(row.settings_json),
+        created_at=row.created_at.replace(tzinfo=UTC),
+        updated_at=row.updated_at.replace(tzinfo=UTC),
+    )
+
+
+class SqliteWorkspaceRepository:
+    """Workspace CRUD backed by SQLite via SQLAlchemy async."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def _count(self, session: AsyncSession, user_id: str, project_id: str) -> int:
+        result = await session.execute(
+            select(func.count())
+            .select_from(WorkspaceRow)
+            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
+        )
+        return result.scalar_one()
+
+    async def _next_sort_order(self, session: AsyncSession, user_id: str, project_id: str) -> int:
+        result = await session.execute(
+            select(func.coalesce(func.max(WorkspaceRow.sort_order), 0))
+            .select_from(WorkspaceRow)
+            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
+        )
+        return result.scalar_one() + 1
+
+    async def list_by_project(self, user_id: str, project_id: str) -> list[Workspace]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(WorkspaceRow)
+                .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
+                .order_by(WorkspaceRow.sort_order)
+            )
+            return [_row_to_model(row) for row in result.scalars()]
+
+    async def get(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(WorkspaceRow).where(
+                    WorkspaceRow.id == workspace_id,
+                    WorkspaceRow.user_id == user_id,
+                    WorkspaceRow.project_id == project_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+            return _row_to_model(row) if row else None
+
+    async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None:
+        async with self._session_factory() as session:
+            if await self._count(session, user_id, project_id) >= MAX_WORKSPACES_PER_PROJECT:
+                return None
+
+            now = datetime.now(UTC)
+            row = WorkspaceRow(
+                id=generate_id(),
+                user_id=user_id,
+                project_id=project_id,
+                name=data.name,
+                description="",
+                locked=False,
+                sort_order=await self._next_sort_order(session, user_id, project_id),
+                settings_json="{}",
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            return _row_to_model(row)
+
+    async def update(self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate) -> Workspace | None:
+        values: dict[str, object] = {}
+        if data.name is not None:
+            values["name"] = data.name
+        if data.description is not None:
+            values["description"] = data.description
+        if data.locked is not None:
+            values["locked"] = data.locked
+        if data.settings is not None:
+            values["settings_json"] = data.settings.model_dump_json()
+
+        if not values:
+            return await self.get(user_id, project_id, workspace_id)
+
+        values["updated_at"] = datetime.now(UTC)
+
+        async with self._session_factory() as session:
+            cursor = await session.execute(
+                update(WorkspaceRow)
+                .where(
+                    WorkspaceRow.id == workspace_id,
+                    WorkspaceRow.user_id == user_id,
+                    WorkspaceRow.project_id == project_id,
+                )
+                .values(**values)
+            )
+            await session.commit()
+            if cursor.rowcount == 0:  # type: ignore[union-attr]
+                return None
+
+        return await self.get(user_id, project_id, workspace_id)
+
+    async def delete(self, user_id: str, project_id: str, workspace_id: str) -> bool:
+        async with self._session_factory() as session:
+            cursor = await session.execute(
+                delete(WorkspaceRow).where(
+                    WorkspaceRow.id == workspace_id,
+                    WorkspaceRow.user_id == user_id,
+                    WorkspaceRow.project_id == project_id,
+                )
+            )
+            await session.commit()
+            return bool(cursor.rowcount)  # type: ignore[union-attr]
+
+    async def duplicate(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
+        source = await self.get(user_id, project_id, workspace_id)
+        if source is None:
+            return None
+
+        async with self._session_factory() as session:
+            if await self._count(session, user_id, project_id) >= MAX_WORKSPACES_PER_PROJECT:
+                return None
+
+            now = datetime.now(UTC)
+            row = WorkspaceRow(
+                id=generate_id(),
+                user_id=user_id,
+                project_id=project_id,
+                name=f"{source.name[:248]} (copy)",
+                description=source.description,
+                locked=False,
+                sort_order=await self._next_sort_order(session, user_id, project_id),
+                settings_json=json.dumps(source.settings.model_dump()),
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            return _row_to_model(row)
+
+    async def reorder(self, user_id: str, project_id: str, ordered_ids: list[str]) -> None:
+        async with self._session_factory() as session:
+            for index, ws_id in enumerate(ordered_ids, start=1):
+                await session.execute(
+                    update(WorkspaceRow)
+                    .where(
+                        WorkspaceRow.id == ws_id,
+                        WorkspaceRow.user_id == user_id,
+                        WorkspaceRow.project_id == project_id,
+                    )
+                    .values(sort_order=index, updated_at=datetime.now(UTC))
+                )
+            await session.commit()

--- a/src/openfactcheck/api/routers/health.py
+++ b/src/openfactcheck/api/routers/health.py
@@ -1,0 +1,25 @@
+"""Health and status endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from openfactcheck import __version__
+
+router = APIRouter()
+
+
+@router.get("/")
+async def root() -> dict[str, str]:
+    """Root endpoint returning service identity."""
+    return {
+        "name": "OpenFactCheck API",
+        "version": __version__,
+        "status": "running",
+    }
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    """Health check endpoint."""
+    return {"status": "healthy"}

--- a/src/openfactcheck/api/routers/projects.py
+++ b/src/openfactcheck/api/routers/projects.py
@@ -1,0 +1,81 @@
+"""Project CRUD endpoints — /api/v1/projects."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, status
+
+from openfactcheck.api.dependencies import get_current_user, get_project_repo
+from openfactcheck.api.errors import NotFoundError, ProjectLimitError
+from openfactcheck.api.models import AuthUser, ProjectCreate, ProjectUpdate
+from openfactcheck.api.repositories.protocols import ProjectRepository
+from openfactcheck.api.schemas.projects import CreateProjectRequest, ProjectResponse, UpdateProjectRequest
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+ResourceId = Annotated[str, Path(max_length=20)]
+
+
+@router.get("/")
+async def list_projects(
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[ProjectRepository, Depends(get_project_repo)],
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> list[ProjectResponse]:
+    """List all projects for the current user."""
+    projects = await repo.list_by_user(user.sub, limit=limit, offset=offset)
+    return [ProjectResponse.from_model(p) for p in projects]
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_project(
+    body: CreateProjectRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[ProjectRepository, Depends(get_project_repo)],
+) -> ProjectResponse:
+    """Create a new project."""
+    project = await repo.create(user.sub, ProjectCreate(name=body.name))
+    if project is None:
+        raise ProjectLimitError()
+    return ProjectResponse.from_model(project)
+
+
+@router.get("/{project_id}")
+async def get_project(
+    project_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[ProjectRepository, Depends(get_project_repo)],
+) -> ProjectResponse:
+    """Get a single project by ID."""
+    project = await repo.get(user.sub, project_id)
+    if project is None:
+        raise NotFoundError(f"Project {project_id} not found")
+    return ProjectResponse.from_model(project)
+
+
+@router.patch("/{project_id}")
+async def update_project(
+    project_id: ResourceId,
+    body: UpdateProjectRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[ProjectRepository, Depends(get_project_repo)],
+) -> ProjectResponse:
+    """Update a project."""
+    project = await repo.update(user.sub, project_id, ProjectUpdate(name=body.name))
+    if project is None:
+        raise NotFoundError(f"Project {project_id} not found")
+    return ProjectResponse.from_model(project)
+
+
+@router.delete("/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_project(
+    project_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[ProjectRepository, Depends(get_project_repo)],
+) -> None:
+    """Delete a project."""
+    deleted = await repo.delete(user.sub, project_id)
+    if not deleted:
+        raise NotFoundError(f"Project {project_id} not found")

--- a/src/openfactcheck/api/routers/workspaces.py
+++ b/src/openfactcheck/api/routers/workspaces.py
@@ -1,0 +1,133 @@
+"""Workspace CRUD endpoints — /api/v1/projects/{project_id}/workspaces."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, status
+
+from openfactcheck.api.dependencies import get_current_user, get_workspace_repo
+from openfactcheck.api.errors import AppError, ErrorCode, NotFoundError, WorkspaceLimitError
+from openfactcheck.api.models import AuthUser, WorkspaceCreate, WorkspaceUpdate
+from openfactcheck.api.repositories.protocols import WorkspaceRepository
+from openfactcheck.api.schemas.workspaces import (
+    CreateWorkspaceRequest,
+    ReorderWorkspacesRequest,
+    UpdateWorkspaceRequest,
+    WorkspaceResponse,
+)
+
+router = APIRouter(prefix="/projects/{project_id}/workspaces", tags=["workspaces"])
+
+ResourceId = Annotated[str, Path(max_length=20)]
+
+
+@router.get("/")
+async def list_workspaces(
+    project_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> list[WorkspaceResponse]:
+    """List all workspaces in a project."""
+    workspaces = await repo.list_by_project(user.sub, project_id)
+    return [WorkspaceResponse.from_model(ws) for ws in workspaces]
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_workspace(
+    project_id: ResourceId,
+    body: CreateWorkspaceRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> WorkspaceResponse:
+    """Create a new workspace in a project."""
+    ws = await repo.create(user.sub, project_id, WorkspaceCreate(name=body.name))
+    if ws is None:
+        raise WorkspaceLimitError()
+    return WorkspaceResponse.from_model(ws)
+
+
+@router.get("/{workspace_id}")
+async def get_workspace(
+    project_id: ResourceId,
+    workspace_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> WorkspaceResponse:
+    """Get a single workspace by ID."""
+    ws = await repo.get(user.sub, project_id, workspace_id)
+    if ws is None:
+        raise NotFoundError(f"Workspace {workspace_id} not found")
+    return WorkspaceResponse.from_model(ws)
+
+
+@router.patch("/{workspace_id}")
+async def update_workspace(
+    project_id: ResourceId,
+    workspace_id: ResourceId,
+    body: UpdateWorkspaceRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> WorkspaceResponse:
+    """Update a workspace."""
+    ws = await repo.update(
+        user.sub,
+        project_id,
+        workspace_id,
+        WorkspaceUpdate(name=body.name, description=body.description, locked=body.locked, settings=body.settings),
+    )
+    if ws is None:
+        raise NotFoundError(f"Workspace {workspace_id} not found")
+    return WorkspaceResponse.from_model(ws)
+
+
+@router.delete("/{workspace_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_workspace(
+    project_id: ResourceId,
+    workspace_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> None:
+    """Delete a workspace."""
+    deleted = await repo.delete(user.sub, project_id, workspace_id)
+    if not deleted:
+        raise NotFoundError(f"Workspace {workspace_id} not found")
+
+
+@router.post("/{workspace_id}/duplicate", status_code=status.HTTP_201_CREATED)
+async def duplicate_workspace(
+    project_id: ResourceId,
+    workspace_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> WorkspaceResponse:
+    """Duplicate a workspace."""
+    # Check if source exists before attempting duplicate
+    source = await repo.get(user.sub, project_id, workspace_id)
+    if source is None:
+        raise NotFoundError(f"Workspace {workspace_id} not found")
+
+    ws = await repo.duplicate(user.sub, project_id, workspace_id)
+    if ws is None:
+        raise WorkspaceLimitError()
+    return WorkspaceResponse.from_model(ws)
+
+
+@router.put("/reorder", status_code=status.HTTP_204_NO_CONTENT)
+async def reorder_workspaces(
+    project_id: ResourceId,
+    body: ReorderWorkspacesRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> None:
+    """Reorder workspaces in a project. ordered_ids must be a complete permutation."""
+    current = await repo.list_by_project(user.sub, project_id)
+    current_ids = {ws.id for ws in current}
+    submitted_ids = set(body.ordered_ids)
+
+    if len(body.ordered_ids) != len(submitted_ids):
+        raise AppError("ordered_ids contains duplicates", ErrorCode.VALIDATION_ERROR, status=422)
+    if submitted_ids != current_ids:
+        raise AppError("ordered_ids must contain exactly all workspace IDs", ErrorCode.VALIDATION_ERROR, status=422)
+
+    await repo.reorder(user.sub, project_id, body.ordered_ids)

--- a/src/openfactcheck/api/schemas/__init__.py
+++ b/src/openfactcheck/api/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP request/response schemas for the API layer."""

--- a/src/openfactcheck/api/schemas/errors.py
+++ b/src/openfactcheck/api/schemas/errors.py
@@ -1,0 +1,13 @@
+"""Error response schema."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """JSON body returned for all API errors."""
+
+    detail: str
+    code: str
+    status: int

--- a/src/openfactcheck/api/schemas/projects.py
+++ b/src/openfactcheck/api/schemas/projects.py
@@ -1,0 +1,40 @@
+"""Project request/response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from openfactcheck.api.models import Project
+
+
+class CreateProjectRequest(BaseModel):
+    """Body for POST /api/v1/projects."""
+
+    name: str = Field(min_length=1, max_length=255)
+
+
+class UpdateProjectRequest(BaseModel):
+    """Body for PATCH /api/v1/projects/{id}."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+
+
+class ProjectResponse(BaseModel):
+    """Single project in API responses."""
+
+    id: str
+    name: str
+    created_at: datetime
+    updated_at: datetime
+
+    @staticmethod
+    def from_model(project: Project) -> ProjectResponse:
+        """Convert a domain Project to a response schema."""
+        return ProjectResponse(
+            id=project.id,
+            name=project.name,
+            created_at=project.created_at,
+            updated_at=project.updated_at,
+        )

--- a/src/openfactcheck/api/schemas/workspaces.py
+++ b/src/openfactcheck/api/schemas/workspaces.py
@@ -1,0 +1,58 @@
+"""Workspace request/response schemas."""
+
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from openfactcheck.api.models import Workspace, WorkspaceSettings
+
+
+class CreateWorkspaceRequest(BaseModel):
+    """Body for POST /api/v1/projects/{pid}/workspaces."""
+
+    name: str = Field(min_length=1, max_length=255)
+
+
+class UpdateWorkspaceRequest(BaseModel):
+    """Body for PATCH /api/v1/projects/{pid}/workspaces/{wid}."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=10000)
+    locked: bool | None = None
+    settings: WorkspaceSettings | None = None
+
+
+class ReorderWorkspacesRequest(BaseModel):
+    """Body for PUT /api/v1/projects/{pid}/workspaces/reorder."""
+
+    ordered_ids: list[Annotated[str, Field(max_length=20)]] = Field(min_length=1, max_length=5)
+
+
+class WorkspaceResponse(BaseModel):
+    """Single workspace in API responses."""
+
+    id: str
+    project_id: str
+    name: str
+    description: str
+    locked: bool
+    sort_order: int
+    settings: WorkspaceSettings
+    created_at: datetime
+    updated_at: datetime
+
+    @staticmethod
+    def from_model(ws: Workspace) -> "WorkspaceResponse":
+        """Convert a domain Workspace to a response schema."""
+        return WorkspaceResponse(
+            id=ws.id,
+            project_id=ws.project_id,
+            name=ws.name,
+            description=ws.description,
+            locked=ws.locked,
+            sort_order=ws.sort_order,
+            settings=ws.settings,
+            created_at=ws.created_at,
+            updated_at=ws.updated_at,
+        )

--- a/src/openfactcheck/api/services/__init__.py
+++ b/src/openfactcheck/api/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business logic services."""

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -16,6 +16,8 @@ includes:
     taskfile: ./taskfiles/dev.taskfile.yml
   release:
     taskfile: ./taskfiles/release.taskfile.yml
+  build:
+    taskfile: ./taskfiles/build.taskfile.yml
   deploy:
     taskfile: ./taskfiles/deploy.taskfile.yml
 
@@ -33,6 +35,7 @@ tasks:
 
         printf '{{.COLOR_CYAN}}Namespaces{{.COLOR_RESET}}\n'
         printf '  dev      Development (sync, test, lint, format, clean)\n'
+        printf '  build    Build artifacts (Lambda container image)\n'
         printf '  check    Verify dependencies\n'
         printf '  release  Release workflow (bumps version, tags, CI publishes)\n'
         printf '  deploy   Infrastructure (init, plan, apply, destroy)\n\n'

--- a/taskfiles/build.helpers.sh
+++ b/taskfiles/build.helpers.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+
+# Source common helpers
+source "taskfiles/common.helpers.sh" 2>/dev/null || source "${BASH_SOURCE%/*}/common.helpers.sh"
+
+# ============================================================================
+# Build Helper Functions
+#
+# Generic container build system. Each target has:
+#   deployments/containers/<target>/Dockerfile
+#   deployments/containers/<target>/manifest.sh   — defines what to assemble
+#   deployments/containers/<target>/build/         — assembled output (gitignored)
+#   deployments/containers/<target>/.hash          — source hash for skip logic
+#
+# Usage:
+#   source taskfiles/build.helpers.sh
+#   set_target "api"
+#   set_workspace "devhasan"     # optional — enables ECR push
+#   assemble
+#   build_image
+#   push_image                   # only if workspace is set
+#   write_hash
+# ============================================================================
+
+PROJECT_ROOT=$(pwd)
+ENVIRONMENTS_DIR="${PROJECT_ROOT}/deployments/environments"
+
+# Collected image refs for parallel push
+declare -a IMAGE_REFS=()
+
+# ============================================================================
+# Target setup
+# ============================================================================
+
+set_target() {
+    local target="$1"
+
+    if [[ -z "$target" ]]; then
+        c_echo "$COLOR_RED" "Error: TARGET is required"
+        exit 1
+    fi
+
+    TARGET="$target"
+    CONTAINER_DIR="${PROJECT_ROOT}/deployments/containers/${TARGET}"
+    BUILD_DIR="${CONTAINER_DIR}/build"
+    HASH_FILE="${CONTAINER_DIR}/.hash"
+    MANIFEST="${CONTAINER_DIR}/manifest.sh"
+
+    if [[ ! -f "${CONTAINER_DIR}/Dockerfile" ]]; then
+        c_echo "$COLOR_RED" "Error: No Dockerfile found at ${CONTAINER_DIR}/Dockerfile"
+        exit 1
+    fi
+
+    if [[ ! -f "$MANIFEST" ]]; then
+        c_echo "$COLOR_RED" "Error: No manifest.sh found at ${MANIFEST}"
+        exit 1
+    fi
+
+    # Default image tag (overridden if workspace is set)
+    IMAGE_TAG="openfactcheck-${TARGET}:latest"
+
+    export TARGET CONTAINER_DIR BUILD_DIR HASH_FILE MANIFEST IMAGE_TAG
+}
+
+set_workspace() {
+    local workspace="$1"
+
+    if [[ -z "$workspace" ]]; then
+        c_echo "$COLOR_RED" "Error: WORKSPACE is required"
+        exit 1
+    fi
+
+    local env_tfvars="${ENVIRONMENTS_DIR}/${workspace}.tfvars.json"
+    if [[ ! -f "$env_tfvars" ]]; then
+        c_echo "$COLOR_RED" "Error: Missing workspace tfvars: $env_tfvars"
+        exit 1
+    fi
+
+    WORKSPACE="$workspace"
+    AWS_ACCOUNT="$(jq -r '.aws_account' "$env_tfvars")"
+    AWS_REGION="$(jq -r '.aws_region' "$env_tfvars")"
+    AWS_PROFILE="$(jq -r '.aws_profile' "$env_tfvars")"
+
+    ECR_REPO_NAME="openfactcheck-${TARGET}-${WORKSPACE}"
+    ECR_REPO_URL="${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO_NAME}"
+    IMAGE_TAG="${ECR_REPO_URL}:latest"
+
+    export WORKSPACE AWS_ACCOUNT AWS_REGION AWS_PROFILE ECR_REPO_NAME ECR_REPO_URL IMAGE_TAG
+}
+
+# ============================================================================
+# Hashing
+# ============================================================================
+
+hash_dir() {
+    local dir="$1"
+    (
+        cd "$dir"
+        find . -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            | sha256sum \
+            | awk '{print $1}'
+    )
+}
+
+compute_source_hash() {
+    # manifest.sh must define SOURCE_PATHS as an array
+    local source_paths
+    source_paths=$(source "$MANIFEST" && echo "${SOURCE_PATHS[@]}")
+
+    # shellcheck disable=SC2086
+    find $source_paths -type f 2>/dev/null \
+        | sort \
+        | xargs sha256sum \
+        | sha256sum \
+        | awk '{print $1}'
+}
+
+build_needed() {
+    local new_hash
+    new_hash=$(compute_source_hash)
+
+    if [[ -f "$HASH_FILE" ]]; then
+        local old_hash
+        old_hash=$(cat "$HASH_FILE")
+        if [[ "$new_hash" == "$old_hash" ]]; then
+            return 1  # not needed
+        fi
+    fi
+
+    return 0  # needed
+}
+
+write_hash() {
+    mkdir -p "$(dirname "$HASH_FILE")"
+    compute_source_hash > "$HASH_FILE"
+    c_echo "$COLOR_GREEN" "[$TARGET] Hash written"
+}
+
+# ============================================================================
+# Assemble
+# ============================================================================
+
+assemble() {
+    c_echo "$COLOR_GREEN" "[$TARGET] Assembling build/"
+
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+
+    # Clean caches before assembly
+    find "${PROJECT_ROOT}/src" -type d -name '__pycache__' -prune -exec rm -rf {} + 2>/dev/null || true
+    find "${PROJECT_ROOT}/src" -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete 2>/dev/null || true
+
+    # manifest.sh must define assemble_target()
+    source "$MANIFEST"
+    assemble_target
+
+    c_echo "$COLOR_GREEN" "[$TARGET] Assembled ($(du -sh "$BUILD_DIR" | awk '{print $1}'))"
+}
+
+# ============================================================================
+# Docker build
+# ============================================================================
+
+build_image() {
+    c_echo "$COLOR_GREEN" "[$TARGET] Building Docker image: $IMAGE_TAG"
+
+    docker build \
+        --platform linux/amd64 \
+        --provenance=false \
+        -f "${CONTAINER_DIR}/Dockerfile" \
+        -t "$IMAGE_TAG" \
+        "$BUILD_DIR"
+
+    if [[ $? -eq 0 ]]; then
+        c_echo "$COLOR_GREEN" "[$TARGET] Build success!"
+        IMAGE_REFS+=("$IMAGE_TAG")
+    else
+        c_echo "$COLOR_RED" "[$TARGET] Build failed!"
+        exit 1
+    fi
+}
+
+# ============================================================================
+# ECR login + push
+# ============================================================================
+
+ecr_login() {
+    local account="${1:-$AWS_ACCOUNT}"
+    local region="${2:-$AWS_REGION}"
+
+    c_echo "$COLOR_GREEN" "Logging into AWS ECR ($account / $region / $AWS_PROFILE)"
+    aws ecr get-login-password --region "$region" --profile "$AWS_PROFILE" \
+        | docker login --username AWS --password-stdin \
+          "${account}.dkr.ecr.${region}.amazonaws.com"
+}
+
+push_image() {
+    local image_ref="$1"
+    local retries="${2:-1}"
+    local attempt=0
+
+    while true; do
+        if docker push "$image_ref"; then
+            c_echo "$COLOR_GREEN" "[$TARGET] Pushed: $image_ref"
+            return 0
+        fi
+
+        attempt=$((attempt + 1))
+        if (( attempt > retries )); then
+            c_echo "$COLOR_RED" "[$TARGET] Push failed after $attempt attempt(s): $image_ref"
+            return 1
+        fi
+
+        c_echo "$COLOR_YELLOW" "[$TARGET] Push failed; re-login and retry ($attempt/$retries)"
+        ecr_login
+    done
+}
+
+push_all() {
+    if [[ ${#IMAGE_REFS[@]} -eq 0 ]]; then
+        c_echo "$COLOR_YELLOW" "No images to push"
+        return 0
+    fi
+
+    c_echo "$COLOR_GREEN" "Pushing ${#IMAGE_REFS[@]} image(s)"
+
+    for ref in "${IMAGE_REFS[@]}"; do
+        push_image "$ref" 3
+    done
+
+    c_echo "$COLOR_GREEN" "All images pushed!"
+}
+
+# ============================================================================
+# Clean
+# ============================================================================
+
+clean() {
+    rm -rf "$BUILD_DIR"
+    rm -f "$HASH_FILE"
+    c_echo "$COLOR_GREEN" "[$TARGET] Cleaned build/ and hash"
+}
+
+# ============================================================================
+# Auto tfvars — writes build metadata for Terraform
+# ============================================================================
+
+write_tfvars() {
+    local version
+    version=$(cat "${PROJECT_ROOT}/VERSION" 2>/dev/null || echo "unknown")
+    local commit
+    commit=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+    local tfvars_file="${PROJECT_ROOT}/deployments/base/ignore.build.auto.tfvars"
+
+    {
+        echo "#--------------------------------------------------------------"
+        echo "# Auto-generated by build.helpers.sh — do not edit."
+        echo "#--------------------------------------------------------------"
+        echo "build_version = \"${version}\""
+        echo "commit = \"${commit}\""
+    } > "$tfvars_file"
+
+    c_echo "$COLOR_GREEN" "Wrote $tfvars_file"
+}
+
+# Execute function if script is run directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    "$@"
+fi

--- a/taskfiles/build.taskfile.yml
+++ b/taskfiles/build.taskfile.yml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+
+version: "3"
+
+tasks:
+  lambda:
+    desc: Build + push container image (TARGET=<name>, WS=<workspace> for ECR push)
+    requires:
+      vars: [TARGET]
+    cmds:
+      - |
+        source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
+        set_target "{{.TARGET}}"
+        {{if .WS}}set_workspace "{{.WS}}"{{end}}
+
+        if build_needed; then
+            assemble
+            build_image
+            write_hash
+            {{if .WS}}
+            ecr_login
+            push_all
+            write_tfvars
+            {{end}}
+        else
+            c_echo "$COLOR_YELLOW" "[{{.TARGET}}] Skipping build — source unchanged"
+        fi
+
+  lambda:force:
+    desc: Build + push container image (TARGET=<name>, always rebuilds, WS=<workspace> for ECR push)
+    requires:
+      vars: [TARGET]
+    cmds:
+      - |
+        source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
+        set_target "{{.TARGET}}"
+        {{if .WS}}set_workspace "{{.WS}}"{{end}}
+
+        assemble
+        build_image
+        write_hash
+        {{if .WS}}
+        ecr_login
+        push_all
+        write_tfvars
+        {{end}}
+
+  lambda:assemble:
+    desc: Assemble build/ directory only (TARGET=<name>)
+    requires:
+      vars: [TARGET]
+    cmds:
+      - |
+        source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
+        set_target "{{.TARGET}}"
+        assemble
+
+  clean:
+    desc: Remove build artifacts (TARGET=<name>)
+    requires:
+      vars: [TARGET]
+    cmds:
+      - |
+        source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
+        set_target "{{.TARGET}}"
+        clean
+
+  default:
+    desc: Show available build tasks
+    cmds:
+      - task: :print:info
+        vars:
+          MSG: "Usage: task build:lambda TARGET=api [WS=devhasan]"

--- a/taskfiles/deploy.taskfile.yml
+++ b/taskfiles/deploy.taskfile.yml
@@ -9,7 +9,7 @@ vars:
   ACCOUNTS_DIR: deployments/accounts
 
   # Deployment Types
-  ENVIRONMENT_DEPLOYS: base
+  ENVIRONMENT_DEPLOYS: base repositories
   ACCOUNT_DEPLOYS: secrets
 
   # Binaries
@@ -360,6 +360,60 @@ tasks:
           printf '{{.COLOR_RED}}✗ Formatting failed{{.COLOR_RESET}}\n'
           exit 1
         fi
+
+  api:
+    desc: Build, push, and deploy API to Lambda (TARGET=<environment>)
+    requires:
+      vars: [TARGET]
+    cmds:
+      - |
+        source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
+        source taskfiles/deploy.helpers.sh 2>/dev/null || source ./taskfiles/deploy.helpers.sh
+
+        set_target "api"
+
+        if ! build_needed; then
+            c_echo "$COLOR_YELLOW" "[api] Skipping deploy — source unchanged"
+            exit 0
+        fi
+
+        # Build
+        assemble
+        build_image
+        write_hash
+
+        # Resolve deploy config
+        prepare "{{.TARGET}}" "base" || exit 1
+        AWS_PROFILE=$(jq -r .aws_profile "$VAR_FILE")
+        AWS_REGION=$(jq -r .aws_region "$VAR_FILE")
+
+        cd deployments/base
+        {{.TF_BIN}} workspace select $WORKSPACE 2>/dev/null
+        ECR_URL=$({{.TF_BIN}} output -raw ecr_repository_url)
+        FUNCTION_NAME=$({{.TF_BIN}} output -raw lambda_function_name 2>/dev/null || echo "openfactcheck-api-${WORKSPACE}-${AWS_REGION}")
+        API_URL=$({{.TF_BIN}} output -raw api_url)
+        cd -
+
+        IMAGE_REF="${ECR_URL}:latest"
+
+        # ECR login + push
+        printf '{{.COLOR_CYAN}}Logging into ECR...{{.COLOR_RESET}}\n'
+        aws ecr get-login-password --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+          | docker login --username AWS --password-stdin "${ECR_URL%%/*}"
+
+        printf '{{.COLOR_CYAN}}Pushing image to ECR...{{.COLOR_RESET}}\n'
+        docker tag openfactcheck-api:latest "$IMAGE_REF"
+        docker push "$IMAGE_REF"
+
+        # Update Lambda
+        printf '{{.COLOR_CYAN}}Updating Lambda function...{{.COLOR_RESET}}\n'
+        aws lambda update-function-code \
+          --function-name "$FUNCTION_NAME" \
+          --image-uri "$IMAGE_REF" \
+          --region "$AWS_REGION" \
+          --profile "$AWS_PROFILE" > /dev/null
+
+        printf '{{.COLOR_GREEN}}✓ Deployed to: %s{{.COLOR_RESET}}\n' "$API_URL"
 
   default:
     desc: Run the full infrastructure workflow (TARGET=<target>, optional DEP=<deployment>)

--- a/taskfiles/dev.taskfile.yml
+++ b/taskfiles/dev.taskfile.yml
@@ -52,6 +52,12 @@ tasks:
       - uv run ruff format src/
       - uv run ruff check --fix src/
 
+  serve:
+    desc: Start the API server
+    dotenv: ['.env']
+    cmds:
+      - uv run uvicorn openfactcheck.api.app:app --host ${OPENFACTCHECK_HOST:-0.0.0.0} --port ${OPENFACTCHECK_PORT:-8000} --reload
+
   version:
     desc: Show current version
     cmds:

--- a/tests/api/auth/test_cognito.py
+++ b/tests/api/auth/test_cognito.py
@@ -1,0 +1,167 @@
+"""Tests for Cognito JWT verification and dev bypass."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+from openfactcheck.api.auth.cognito import DEV_USER, CognitoVerifier, DevVerifier
+from openfactcheck.api.errors import AuthError
+
+REGION = "us-east-1"
+USER_POOL_ID = "us-east-1_TestPool"
+CLIENT_ID = "test-client-id"
+ISSUER = f"https://cognito-idp.{REGION}.amazonaws.com/{USER_POOL_ID}"
+
+
+@pytest.fixture
+def rsa_key() -> rsa.RSAPrivateKey:
+    """Generate an RSA private key for signing test tokens."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture
+def mock_jwk_client(rsa_key: rsa.RSAPrivateKey) -> MagicMock:
+    """Return a mock PyJWKClient that resolves to the test RSA public key."""
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = rsa_key.public_key()
+
+    client = MagicMock()
+    client.get_signing_key_from_jwt.return_value = mock_signing_key
+    return client
+
+
+@pytest.fixture
+def verifier(mock_jwk_client: MagicMock) -> CognitoVerifier:
+    return CognitoVerifier(REGION, USER_POOL_ID, CLIENT_ID, jwk_client=mock_jwk_client)
+
+
+def _make_token(key: rsa.RSAPrivateKey, claims: dict[str, Any] | None = None) -> str:
+    """Create a signed JWT with sensible defaults."""
+    now = int(time.time())
+    payload: dict[str, Any] = {
+        "sub": "user-123",
+        "email": "test@example.com",
+        "name": "Test User",
+        "token_use": "id",
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    if claims:
+        payload.update(claims)
+
+    private_pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    return jwt.encode(payload, private_pem, algorithm="RS256")
+
+
+# =============================================================================
+# DevVerifier
+# =============================================================================
+
+
+def test_DevVerifier_verify() -> None:
+    """DevVerifier returns the hardcoded dev user for any token."""
+    dev_verifier = DevVerifier()
+
+    user = dev_verifier.verify("anything")
+
+    assert user == DEV_USER
+    assert user.sub == "dev-user-00000000"
+    assert user.email == "dev@localhost"
+
+
+def test_DevVerifier_verify_empty_token() -> None:
+    """DevVerifier works even with an empty token string."""
+    dev_verifier = DevVerifier()
+
+    user = dev_verifier.verify("")
+
+    assert user == DEV_USER
+
+
+# =============================================================================
+# CognitoVerifier — valid token
+# =============================================================================
+
+
+def test_CognitoVerifier_verify_valid_token(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier returns AuthUser from a valid ID token."""
+    token = _make_token(rsa_key)
+
+    user = verifier.verify(token)
+
+    assert user.sub == "user-123"
+    assert user.email == "test@example.com"
+    assert user.name == "Test User"
+
+
+def test_CognitoVerifier_verify_missing_name(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier defaults name to empty string when absent."""
+    token = _make_token(rsa_key, {"name": None})
+
+    user = verifier.verify(token)
+
+    assert user.name == ""
+
+
+# =============================================================================
+# CognitoVerifier — error cases
+# =============================================================================
+
+
+def test_CognitoVerifier_verify_expired_token(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier raises AuthError for an expired token."""
+    token = _make_token(rsa_key, {"exp": int(time.time()) - 3600})
+
+    with pytest.raises(AuthError, match="Invalid or expired token"):
+        verifier.verify(token)
+
+
+def test_CognitoVerifier_verify_wrong_audience(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier raises AuthError when audience doesn't match."""
+    token = _make_token(rsa_key, {"aud": "wrong-client-id"})
+
+    with pytest.raises(AuthError, match="Invalid or expired token"):
+        verifier.verify(token)
+
+
+def test_CognitoVerifier_verify_wrong_issuer(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier raises AuthError when issuer doesn't match."""
+    token = _make_token(rsa_key, {"iss": "https://evil.example.com"})
+
+    with pytest.raises(AuthError, match="Invalid or expired token"):
+        verifier.verify(token)
+
+
+def test_CognitoVerifier_verify_access_token_rejected(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier raises AuthError when token_use is 'access' instead of 'id'."""
+    token = _make_token(rsa_key, {"token_use": "access"})
+
+    with pytest.raises(AuthError, match="not an ID token"):
+        verifier.verify(token)
+
+
+def test_CognitoVerifier_verify_missing_sub(verifier: CognitoVerifier, rsa_key: rsa.RSAPrivateKey) -> None:
+    """CognitoVerifier raises AuthError when sub claim is missing."""
+    token = _make_token(rsa_key, {"sub": None})
+
+    with pytest.raises(AuthError, match="Invalid or expired token"):
+        verifier.verify(token)
+
+
+def test_CognitoVerifier_verify_garbage_token() -> None:
+    """CognitoVerifier raises AuthError for a completely invalid token string."""
+    mock_client = MagicMock()
+    mock_client.get_signing_key_from_jwt.side_effect = jwt.InvalidTokenError("bad")
+    bad_verifier = CognitoVerifier(REGION, USER_POOL_ID, CLIENT_ID, jwk_client=mock_client)
+
+    with pytest.raises(AuthError, match="Invalid or expired token"):
+        bad_verifier.verify("not.a.jwt")

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,49 @@
+"""API integration test fixtures — test client, mock auth, in-memory SQLite."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from openfactcheck.api.app import create_app
+from openfactcheck.api.auth.cognito import DEV_USER
+from openfactcheck.api.config import APIConfig
+from openfactcheck.api.dependencies import get_current_user, get_project_repo, get_workspace_repo
+from openfactcheck.api.models import AuthUser
+from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
+from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
+
+TEST_USER = DEV_USER
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def client() -> AsyncIterator[AsyncClient]:
+    """Yield an httpx AsyncClient wired to a test app with in-memory SQLite and mock auth."""
+    engine = await create_engine_and_tables(":memory:")
+    sf = session_factory(engine)
+    project_repo = SqliteProjectRepository(sf)
+    workspace_repo = SqliteWorkspaceRepository(sf)
+
+    config = APIConfig(auth_bypass=True)
+    app = create_app(config)
+
+    async def override_current_user() -> AuthUser:
+        return TEST_USER
+
+    async def override_project_repo() -> SqliteProjectRepository:
+        return project_repo
+
+    async def override_workspace_repo() -> SqliteWorkspaceRepository:
+        return workspace_repo
+
+    app.dependency_overrides[get_current_user] = override_current_user
+    app.dependency_overrides[get_project_repo] = override_project_repo
+    app.dependency_overrides[get_workspace_repo] = override_workspace_repo
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    await engine.dispose()

--- a/tests/api/repositories/conftest.py
+++ b/tests/api/repositories/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures for repository tests — in-memory SQLite engine and sessions."""
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def db_session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Yield a session factory backed by a fresh in-memory SQLite database."""
+    engine = await create_engine_and_tables(":memory:")
+    factory = session_factory(engine)
+    yield factory
+    await engine.dispose()

--- a/tests/api/repositories/dynamodb/conftest.py
+++ b/tests/api/repositories/dynamodb/conftest.py
@@ -1,0 +1,45 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+"""Shared fixtures for DynamoDB repository tests — moto-mocked table."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import boto3
+import pytest_asyncio
+from moto import mock_aws
+
+TABLE_NAME = "openfactcheck-test"
+REGION = "us-east-1"
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def dynamo_table() -> AsyncIterator[str]:
+    """Create a moto-mocked DynamoDB table and yield its name."""
+    with mock_aws():
+        os.environ["AWS_DEFAULT_REGION"] = REGION
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_SECURITY_TOKEN"] = "testing"
+        os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+        client = boto3.client("dynamodb", region_name=REGION)
+        client.create_table(
+            TableName=TABLE_NAME,
+            KeySchema=[{"AttributeName": "PK", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "GS1PK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "gs1",
+                    "KeySchema": [{"AttributeName": "GS1PK", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        yield TABLE_NAME

--- a/tests/api/repositories/dynamodb/test_projects.py
+++ b/tests/api/repositories/dynamodb/test_projects.py
@@ -1,0 +1,118 @@
+"""Tests for DynamoProjectRepository."""
+
+import pytest
+
+from openfactcheck.api.models import ProjectCreate, ProjectUpdate
+from openfactcheck.api.repositories.dynamodb.projects import DynamoProjectRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+REGION = "us-east-1"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(dynamo_table: str) -> DynamoProjectRepository:
+    return DynamoProjectRepository(dynamo_table, region_name=REGION)
+
+
+async def test_DynamoProjectRepository_create(repo: DynamoProjectRepository) -> None:
+    """Create returns a project with the correct name and user."""
+    project = await repo.create(USER_ID, ProjectCreate(name="My Project"))
+
+    assert project.name == "My Project"
+    assert project.user_id == USER_ID
+    assert len(project.id) == 12
+
+
+async def test_DynamoProjectRepository_get(repo: DynamoProjectRepository) -> None:
+    """Get retrieves a previously created project."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Test"))
+
+    fetched = await repo.get(USER_ID, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.name == "Test"
+
+
+async def test_DynamoProjectRepository_get_wrong_user(repo: DynamoProjectRepository) -> None:
+    """Get returns None when queried by a different user."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Test"))
+
+    result = await repo.get(OTHER_USER, created.id)
+
+    assert result is None
+
+
+async def test_DynamoProjectRepository_get_nonexistent(repo: DynamoProjectRepository) -> None:
+    """Get returns None for a non-existent project ID."""
+    result = await repo.get(USER_ID, "does-not-exist")
+
+    assert result is None
+
+
+async def test_DynamoProjectRepository_list_by_user(repo: DynamoProjectRepository) -> None:
+    """List returns only projects belonging to the given user, ordered by created_at."""
+    await repo.create(USER_ID, ProjectCreate(name="First"))
+    await repo.create(USER_ID, ProjectCreate(name="Second"))
+    await repo.create(OTHER_USER, ProjectCreate(name="Other"))
+
+    projects = await repo.list_by_user(USER_ID)
+
+    assert len(projects) == 2
+    assert projects[0].name == "First"
+    assert projects[1].name == "Second"
+
+
+async def test_DynamoProjectRepository_list_by_user_empty(repo: DynamoProjectRepository) -> None:
+    """List returns an empty list when the user has no projects."""
+    projects = await repo.list_by_user(USER_ID)
+
+    assert projects == []
+
+
+async def test_DynamoProjectRepository_update(repo: DynamoProjectRepository) -> None:
+    """Update modifies the project name and bumps updated_at."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Old Name"))
+
+    updated = await repo.update(USER_ID, created.id, ProjectUpdate(name="New Name"))
+
+    assert updated is not None
+    assert updated.name == "New Name"
+    assert updated.updated_at > created.updated_at
+
+
+async def test_DynamoProjectRepository_update_no_fields(repo: DynamoProjectRepository) -> None:
+    """Update with no fields returns the project unchanged."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Keep"))
+
+    updated = await repo.update(USER_ID, created.id, ProjectUpdate())
+
+    assert updated is not None
+    assert updated.name == "Keep"
+
+
+async def test_DynamoProjectRepository_update_nonexistent(repo: DynamoProjectRepository) -> None:
+    """Update returns None for a non-existent project."""
+    result = await repo.update(USER_ID, "does-not-exist", ProjectUpdate(name="X"))
+
+    assert result is None
+
+
+async def test_DynamoProjectRepository_delete(repo: DynamoProjectRepository) -> None:
+    """Delete removes the project and returns True."""
+    created = await repo.create(USER_ID, ProjectCreate(name="To Delete"))
+
+    deleted = await repo.delete(USER_ID, created.id)
+
+    assert deleted is True
+    assert await repo.get(USER_ID, created.id) is None
+
+
+async def test_DynamoProjectRepository_delete_nonexistent(repo: DynamoProjectRepository) -> None:
+    """Delete returns False when the project does not exist."""
+    deleted = await repo.delete(USER_ID, "does-not-exist")
+
+    assert deleted is False

--- a/tests/api/repositories/dynamodb/test_workspaces.py
+++ b/tests/api/repositories/dynamodb/test_workspaces.py
@@ -1,0 +1,214 @@
+"""Tests for DynamoWorkspaceRepository."""
+
+import pytest
+import pytest_asyncio
+
+from openfactcheck.api.models import ProjectCreate, WorkspaceCreate, WorkspaceSettings, WorkspaceUpdate
+from openfactcheck.api.repositories.dynamodb.projects import DynamoProjectRepository
+from openfactcheck.api.repositories.dynamodb.workspaces import MAX_WORKSPACES_PER_PROJECT, DynamoWorkspaceRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+REGION = "us-east-1"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def project_id(dynamo_table: str) -> str:
+    """Create a project and return its ID for workspace tests."""
+    repo = DynamoProjectRepository(dynamo_table, region_name=REGION)
+    project = await repo.create(USER_ID, ProjectCreate(name="Test Project"))
+    return project.id
+
+
+@pytest.fixture
+def repo(dynamo_table: str) -> DynamoWorkspaceRepository:
+    return DynamoWorkspaceRepository(dynamo_table, region_name=REGION)
+
+
+async def test_DynamoWorkspaceRepository_create(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Create returns a workspace with correct fields and sort_order=1."""
+    ws = await repo.create(USER_ID, project_id, WorkspaceCreate(name="My Workspace"))
+
+    assert ws is not None
+    assert ws.name == "My Workspace"
+    assert ws.user_id == USER_ID
+    assert ws.project_id == project_id
+    assert ws.sort_order == 1
+    assert ws.locked is False
+    assert ws.description == ""
+
+
+async def test_DynamoWorkspaceRepository_create_increments_sort_order(
+    repo: DynamoWorkspaceRepository, project_id: str
+) -> None:
+    """Each new workspace gets an incrementing sort_order."""
+    ws1 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    ws2 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Second"))
+
+    assert ws1 is not None
+    assert ws2 is not None
+    assert ws1.sort_order == 1
+    assert ws2.sort_order == 2
+
+
+async def test_DynamoWorkspaceRepository_create_enforces_limit(
+    repo: DynamoWorkspaceRepository, project_id: str
+) -> None:
+    """Create returns None when the project already has MAX_WORKSPACES_PER_PROJECT workspaces."""
+    for i in range(MAX_WORKSPACES_PER_PROJECT):
+        result = await repo.create(USER_ID, project_id, WorkspaceCreate(name=f"WS {i}"))
+        assert result is not None
+
+    overflow = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Overflow"))
+
+    assert overflow is None
+
+
+async def test_DynamoWorkspaceRepository_get(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Get retrieves a previously created workspace."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Test"))
+    assert created is not None
+
+    fetched = await repo.get(USER_ID, project_id, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_DynamoWorkspaceRepository_get_wrong_user(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Get returns None when queried by a different user."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Test"))
+    assert created is not None
+
+    result = await repo.get(OTHER_USER, project_id, created.id)
+
+    assert result is None
+
+
+async def test_DynamoWorkspaceRepository_list_by_project(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """List returns workspaces ordered by sort_order."""
+    await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    await repo.create(USER_ID, project_id, WorkspaceCreate(name="Second"))
+
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+
+    assert len(workspaces) == 2
+    assert workspaces[0].name == "First"
+    assert workspaces[1].name == "Second"
+
+
+async def test_DynamoWorkspaceRepository_list_by_project_empty(
+    repo: DynamoWorkspaceRepository, project_id: str
+) -> None:
+    """List returns an empty list when the project has no workspaces."""
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+
+    assert workspaces == []
+
+
+async def test_DynamoWorkspaceRepository_update(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Update modifies fields and bumps updated_at."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Old"))
+    assert created is not None
+
+    updated = await repo.update(
+        USER_ID,
+        project_id,
+        created.id,
+        WorkspaceUpdate(name="New", description="Updated", locked=True, settings=WorkspaceSettings(verbose_mode=True)),
+    )
+
+    assert updated is not None
+    assert updated.name == "New"
+    assert updated.description == "Updated"
+    assert updated.locked is True
+    assert updated.settings.verbose_mode is True
+    assert updated.updated_at > created.updated_at
+
+
+async def test_DynamoWorkspaceRepository_update_no_fields(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Update with no fields returns the workspace unchanged."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Keep"))
+    assert created is not None
+
+    updated = await repo.update(USER_ID, project_id, created.id, WorkspaceUpdate())
+
+    assert updated is not None
+    assert updated.name == "Keep"
+
+
+async def test_DynamoWorkspaceRepository_update_nonexistent(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Update returns None for a non-existent workspace."""
+    result = await repo.update(USER_ID, project_id, "does-not-exist", WorkspaceUpdate(name="X"))
+
+    assert result is None
+
+
+async def test_DynamoWorkspaceRepository_delete(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Delete removes the workspace and returns True."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="To Delete"))
+    assert created is not None
+
+    deleted = await repo.delete(USER_ID, project_id, created.id)
+
+    assert deleted is True
+    assert await repo.get(USER_ID, project_id, created.id) is None
+
+
+async def test_DynamoWorkspaceRepository_delete_nonexistent(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Delete returns False when the workspace does not exist."""
+    deleted = await repo.delete(USER_ID, project_id, "does-not-exist")
+
+    assert deleted is False
+
+
+async def test_DynamoWorkspaceRepository_duplicate(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Duplicate creates a copy with '(copy)' suffix and a new ID."""
+    original = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Original"))
+    assert original is not None
+
+    copy = await repo.duplicate(USER_ID, project_id, original.id)
+
+    assert copy is not None
+    assert copy.id != original.id
+    assert copy.name == "Original (copy)"
+    assert copy.sort_order == 2
+    assert copy.locked is False
+
+
+async def test_DynamoWorkspaceRepository_duplicate_nonexistent(
+    repo: DynamoWorkspaceRepository, project_id: str
+) -> None:
+    """Duplicate returns None when the source workspace does not exist."""
+    result = await repo.duplicate(USER_ID, project_id, "does-not-exist")
+
+    assert result is None
+
+
+async def test_DynamoWorkspaceRepository_duplicate_enforces_limit(
+    repo: DynamoWorkspaceRepository, project_id: str
+) -> None:
+    """Duplicate returns None when the project is at the workspace limit."""
+    first = await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    assert first is not None
+    for i in range(1, MAX_WORKSPACES_PER_PROJECT):
+        await repo.create(USER_ID, project_id, WorkspaceCreate(name=f"WS {i}"))
+
+    result = await repo.duplicate(USER_ID, project_id, first.id)
+
+    assert result is None
+
+
+async def test_DynamoWorkspaceRepository_reorder(repo: DynamoWorkspaceRepository, project_id: str) -> None:
+    """Reorder updates sort_order to match the provided ID list."""
+    ws1 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="A"))
+    ws2 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="B"))
+    ws3 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="C"))
+    assert ws1 and ws2 and ws3
+
+    await repo.reorder(USER_ID, project_id, [ws3.id, ws1.id, ws2.id])
+
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+    assert [ws.name for ws in workspaces] == ["C", "A", "B"]

--- a/tests/api/repositories/sqlite/test_projects.py
+++ b/tests/api/repositories/sqlite/test_projects.py
@@ -1,0 +1,128 @@
+"""Tests for SqliteProjectRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import ProjectCreate, ProjectUpdate
+from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(db_session_factory: async_sessionmaker[AsyncSession]) -> SqliteProjectRepository:
+    return SqliteProjectRepository(db_session_factory)
+
+
+async def test_SqliteProjectRepository_create(repo: SqliteProjectRepository) -> None:
+    """Create returns a project with the correct name and user."""
+    project = await repo.create(USER_ID, ProjectCreate(name="My Project"))
+
+    assert project.name == "My Project"
+    assert project.user_id == USER_ID
+    assert len(project.id) == 12
+
+
+async def test_SqliteProjectRepository_get(repo: SqliteProjectRepository) -> None:
+    """Get retrieves a previously created project."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Test"))
+
+    fetched = await repo.get(USER_ID, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+    assert fetched.name == "Test"
+
+
+async def test_SqliteProjectRepository_get_wrong_user(repo: SqliteProjectRepository) -> None:
+    """Get returns None when queried by a different user."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Test"))
+
+    result = await repo.get(OTHER_USER, created.id)
+
+    assert result is None
+
+
+async def test_SqliteProjectRepository_get_nonexistent(repo: SqliteProjectRepository) -> None:
+    """Get returns None for a non-existent project ID."""
+    result = await repo.get(USER_ID, "does-not-exist")
+
+    assert result is None
+
+
+async def test_SqliteProjectRepository_list_by_user(repo: SqliteProjectRepository) -> None:
+    """List returns only projects belonging to the given user, ordered by created_at."""
+    await repo.create(USER_ID, ProjectCreate(name="First"))
+    await repo.create(USER_ID, ProjectCreate(name="Second"))
+    await repo.create(OTHER_USER, ProjectCreate(name="Other"))
+
+    projects = await repo.list_by_user(USER_ID)
+
+    assert len(projects) == 2
+    assert projects[0].name == "First"
+    assert projects[1].name == "Second"
+
+
+async def test_SqliteProjectRepository_list_by_user_empty(repo: SqliteProjectRepository) -> None:
+    """List returns an empty list when the user has no projects."""
+    projects = await repo.list_by_user(USER_ID)
+
+    assert projects == []
+
+
+async def test_SqliteProjectRepository_update(repo: SqliteProjectRepository) -> None:
+    """Update modifies the project name and bumps updated_at."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Old Name"))
+
+    updated = await repo.update(USER_ID, created.id, ProjectUpdate(name="New Name"))
+
+    assert updated is not None
+    assert updated.name == "New Name"
+    assert updated.updated_at > created.updated_at
+
+
+async def test_SqliteProjectRepository_update_no_fields(repo: SqliteProjectRepository) -> None:
+    """Update with no fields returns the project unchanged."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Keep"))
+
+    updated = await repo.update(USER_ID, created.id, ProjectUpdate())
+
+    assert updated is not None
+    assert updated.name == "Keep"
+
+
+async def test_SqliteProjectRepository_update_nonexistent(repo: SqliteProjectRepository) -> None:
+    """Update returns None for a non-existent project."""
+    result = await repo.update(USER_ID, "does-not-exist", ProjectUpdate(name="X"))
+
+    assert result is None
+
+
+async def test_SqliteProjectRepository_delete(repo: SqliteProjectRepository) -> None:
+    """Delete removes the project and returns True."""
+    created = await repo.create(USER_ID, ProjectCreate(name="To Delete"))
+
+    deleted = await repo.delete(USER_ID, created.id)
+
+    assert deleted is True
+    assert await repo.get(USER_ID, created.id) is None
+
+
+async def test_SqliteProjectRepository_delete_nonexistent(repo: SqliteProjectRepository) -> None:
+    """Delete returns False when the project does not exist."""
+    deleted = await repo.delete(USER_ID, "does-not-exist")
+
+    assert deleted is False
+
+
+async def test_SqliteProjectRepository_delete_wrong_user(repo: SqliteProjectRepository) -> None:
+    """Delete returns False when attempted by a different user."""
+    created = await repo.create(USER_ID, ProjectCreate(name="Mine"))
+
+    deleted = await repo.delete(OTHER_USER, created.id)
+
+    assert deleted is False
+    assert await repo.get(USER_ID, created.id) is not None

--- a/tests/api/repositories/sqlite/test_workspaces.py
+++ b/tests/api/repositories/sqlite/test_workspaces.py
@@ -1,0 +1,214 @@
+"""Tests for SqliteWorkspaceRepository."""
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import ProjectCreate, WorkspaceCreate, WorkspaceSettings, WorkspaceUpdate
+from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+from openfactcheck.api.repositories.sqlite.workspaces import MAX_WORKSPACES_PER_PROJECT, SqliteWorkspaceRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def project_id(db_session_factory: async_sessionmaker[AsyncSession]) -> str:
+    """Create a project and return its ID for workspace tests."""
+    repo = SqliteProjectRepository(db_session_factory)
+    project = await repo.create(USER_ID, ProjectCreate(name="Test Project"))
+    return project.id
+
+
+@pytest.fixture
+def repo(db_session_factory: async_sessionmaker[AsyncSession]) -> SqliteWorkspaceRepository:
+    return SqliteWorkspaceRepository(db_session_factory)
+
+
+async def test_SqliteWorkspaceRepository_create(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Create returns a workspace with correct fields and sort_order=1."""
+    ws = await repo.create(USER_ID, project_id, WorkspaceCreate(name="My Workspace"))
+
+    assert ws is not None
+    assert ws.name == "My Workspace"
+    assert ws.user_id == USER_ID
+    assert ws.project_id == project_id
+    assert ws.sort_order == 1
+    assert ws.locked is False
+    assert ws.description == ""
+
+
+async def test_SqliteWorkspaceRepository_create_increments_sort_order(
+    repo: SqliteWorkspaceRepository, project_id: str
+) -> None:
+    """Each new workspace gets an incrementing sort_order."""
+    ws1 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    ws2 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Second"))
+
+    assert ws1 is not None
+    assert ws2 is not None
+    assert ws1.sort_order == 1
+    assert ws2.sort_order == 2
+
+
+async def test_SqliteWorkspaceRepository_create_enforces_limit(
+    repo: SqliteWorkspaceRepository, project_id: str
+) -> None:
+    """Create returns None when the project already has MAX_WORKSPACES_PER_PROJECT workspaces."""
+    for i in range(MAX_WORKSPACES_PER_PROJECT):
+        result = await repo.create(USER_ID, project_id, WorkspaceCreate(name=f"WS {i}"))
+        assert result is not None
+
+    overflow = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Overflow"))
+
+    assert overflow is None
+
+
+async def test_SqliteWorkspaceRepository_get(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Get retrieves a previously created workspace."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Test"))
+    assert created is not None
+
+    fetched = await repo.get(USER_ID, project_id, created.id)
+
+    assert fetched is not None
+    assert fetched.id == created.id
+
+
+async def test_SqliteWorkspaceRepository_get_wrong_user(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Get returns None when queried by a different user."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Test"))
+    assert created is not None
+
+    result = await repo.get(OTHER_USER, project_id, created.id)
+
+    assert result is None
+
+
+async def test_SqliteWorkspaceRepository_list_by_project(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """List returns workspaces ordered by sort_order."""
+    await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    await repo.create(USER_ID, project_id, WorkspaceCreate(name="Second"))
+
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+
+    assert len(workspaces) == 2
+    assert workspaces[0].name == "First"
+    assert workspaces[1].name == "Second"
+
+
+async def test_SqliteWorkspaceRepository_list_by_project_empty(
+    repo: SqliteWorkspaceRepository, project_id: str
+) -> None:
+    """List returns an empty list when the project has no workspaces."""
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+
+    assert workspaces == []
+
+
+async def test_SqliteWorkspaceRepository_update(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Update modifies fields and bumps updated_at."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Old"))
+    assert created is not None
+
+    updated = await repo.update(
+        USER_ID,
+        project_id,
+        created.id,
+        WorkspaceUpdate(name="New", description="Updated", locked=True, settings=WorkspaceSettings(verbose_mode=True)),
+    )
+
+    assert updated is not None
+    assert updated.name == "New"
+    assert updated.description == "Updated"
+    assert updated.locked is True
+    assert updated.settings.verbose_mode is True
+    assert updated.updated_at > created.updated_at
+
+
+async def test_SqliteWorkspaceRepository_update_no_fields(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Update with no fields returns the workspace unchanged."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Keep"))
+    assert created is not None
+
+    updated = await repo.update(USER_ID, project_id, created.id, WorkspaceUpdate())
+
+    assert updated is not None
+    assert updated.name == "Keep"
+
+
+async def test_SqliteWorkspaceRepository_update_nonexistent(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Update returns None for a non-existent workspace."""
+    result = await repo.update(USER_ID, project_id, "does-not-exist", WorkspaceUpdate(name="X"))
+
+    assert result is None
+
+
+async def test_SqliteWorkspaceRepository_delete(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Delete removes the workspace and returns True."""
+    created = await repo.create(USER_ID, project_id, WorkspaceCreate(name="To Delete"))
+    assert created is not None
+
+    deleted = await repo.delete(USER_ID, project_id, created.id)
+
+    assert deleted is True
+    assert await repo.get(USER_ID, project_id, created.id) is None
+
+
+async def test_SqliteWorkspaceRepository_delete_nonexistent(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Delete returns False when the workspace does not exist."""
+    deleted = await repo.delete(USER_ID, project_id, "does-not-exist")
+
+    assert deleted is False
+
+
+async def test_SqliteWorkspaceRepository_duplicate(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Duplicate creates a copy with '(copy)' suffix and a new ID."""
+    original = await repo.create(USER_ID, project_id, WorkspaceCreate(name="Original"))
+    assert original is not None
+
+    copy = await repo.duplicate(USER_ID, project_id, original.id)
+
+    assert copy is not None
+    assert copy.id != original.id
+    assert copy.name == "Original (copy)"
+    assert copy.sort_order == 2
+    assert copy.locked is False
+
+
+async def test_SqliteWorkspaceRepository_duplicate_nonexistent(
+    repo: SqliteWorkspaceRepository, project_id: str
+) -> None:
+    """Duplicate returns None when the source workspace does not exist."""
+    result = await repo.duplicate(USER_ID, project_id, "does-not-exist")
+
+    assert result is None
+
+
+async def test_SqliteWorkspaceRepository_duplicate_enforces_limit(
+    repo: SqliteWorkspaceRepository, project_id: str
+) -> None:
+    """Duplicate returns None when the project is at the workspace limit."""
+    first = await repo.create(USER_ID, project_id, WorkspaceCreate(name="First"))
+    assert first is not None
+    for i in range(1, MAX_WORKSPACES_PER_PROJECT):
+        await repo.create(USER_ID, project_id, WorkspaceCreate(name=f"WS {i}"))
+
+    result = await repo.duplicate(USER_ID, project_id, first.id)
+
+    assert result is None
+
+
+async def test_SqliteWorkspaceRepository_reorder(repo: SqliteWorkspaceRepository, project_id: str) -> None:
+    """Reorder updates sort_order to match the provided ID list."""
+    ws1 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="A"))
+    ws2 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="B"))
+    ws3 = await repo.create(USER_ID, project_id, WorkspaceCreate(name="C"))
+    assert ws1 and ws2 and ws3
+
+    await repo.reorder(USER_ID, project_id, [ws3.id, ws1.id, ws2.id])
+
+    workspaces = await repo.list_by_project(USER_ID, project_id)
+    assert [ws.name for ws in workspaces] == ["C", "A", "B"]

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -1,0 +1,29 @@
+"""Tests for health endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from openfactcheck import __version__
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_root(client: AsyncClient) -> None:
+    """GET / returns service identity with name, version, and status."""
+    response = await client.get("/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "OpenFactCheck API"
+    assert body["version"] == __version__
+    assert body["status"] == "running"
+
+
+async def test_health(client: AsyncClient) -> None:
+    """GET /health returns healthy status."""
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}

--- a/tests/api/test_middleware.py
+++ b/tests/api/test_middleware.py
@@ -1,0 +1,26 @@
+"""Tests for error handling middleware."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_app_error_returns_json(client: AsyncClient) -> None:
+    """AppError (404) returns structured JSON with detail, code, and status."""
+    response = await client.get("/api/v1/projects/does-not-exist")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["code"] == "NOT_FOUND"
+    assert body["status"] == 404
+    assert "detail" in body
+
+
+async def test_validation_error_returns_422(client: AsyncClient) -> None:
+    """FastAPI validation errors return 422 for invalid request bodies."""
+    response = await client.post("/api/v1/projects/", json={})
+
+    assert response.status_code == 422

--- a/tests/api/test_projects.py
+++ b/tests/api/test_projects.py
@@ -1,0 +1,110 @@
+"""Tests for project CRUD endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+BASE = "/api/v1/projects"
+
+
+async def _create_project(client: AsyncClient, name: str = "Test Project") -> dict[str, object]:
+    response = await client.post(f"{BASE}/", json={"name": name})
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_create_project(client: AsyncClient) -> None:
+    """POST /projects creates a project and returns 201."""
+    body = await _create_project(client, "My Project")
+
+    assert body["name"] == "My Project"
+    assert "id" in body
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+async def test_list_projects(client: AsyncClient) -> None:
+    """GET /projects returns all projects for the user."""
+    await _create_project(client, "First")
+    await _create_project(client, "Second")
+
+    response = await client.get(f"{BASE}/")
+
+    assert response.status_code == 200
+    projects = response.json()
+    assert len(projects) == 2
+    assert projects[0]["name"] == "First"
+    assert projects[1]["name"] == "Second"
+
+
+async def test_list_projects_empty(client: AsyncClient) -> None:
+    """GET /projects returns an empty list when no projects exist."""
+    response = await client.get(f"{BASE}/")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_get_project(client: AsyncClient) -> None:
+    """GET /projects/{id} returns the project."""
+    created = await _create_project(client)
+
+    response = await client.get(f"{BASE}/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created["id"]
+
+
+async def test_get_project_not_found(client: AsyncClient) -> None:
+    """GET /projects/{id} returns 404 for a non-existent project."""
+    response = await client.get(f"{BASE}/does-not-exist")
+
+    assert response.status_code == 404
+    body = response.json()
+    assert body["code"] == "NOT_FOUND"
+
+
+async def test_update_project(client: AsyncClient) -> None:
+    """PATCH /projects/{id} updates the project name."""
+    created = await _create_project(client, "Old Name")
+
+    response = await client.patch(f"{BASE}/{created['id']}", json={"name": "New Name"})
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "New Name"
+
+
+async def test_update_project_not_found(client: AsyncClient) -> None:
+    """PATCH /projects/{id} returns 404 for a non-existent project."""
+    response = await client.patch(f"{BASE}/does-not-exist", json={"name": "X"})
+
+    assert response.status_code == 404
+
+
+async def test_delete_project(client: AsyncClient) -> None:
+    """DELETE /projects/{id} removes the project and returns 204."""
+    created = await _create_project(client)
+
+    response = await client.delete(f"{BASE}/{created['id']}")
+
+    assert response.status_code == 204
+
+    get_response = await client.get(f"{BASE}/{created['id']}")
+    assert get_response.status_code == 404
+
+
+async def test_delete_project_not_found(client: AsyncClient) -> None:
+    """DELETE /projects/{id} returns 404 for a non-existent project."""
+    response = await client.delete(f"{BASE}/does-not-exist")
+
+    assert response.status_code == 404
+
+
+async def test_create_project_empty_name(client: AsyncClient) -> None:
+    """POST /projects with an empty name returns 422."""
+    response = await client.post(f"{BASE}/", json={"name": ""})
+
+    assert response.status_code == 422

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -1,0 +1,177 @@
+"""Tests for workspace CRUD endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+PROJECTS_BASE = "/api/v1/projects"
+
+
+async def _create_project(client: AsyncClient, name: str = "Test Project") -> str:
+    response = await client.post(f"{PROJECTS_BASE}/", json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _ws_base(project_id: str) -> str:
+    return f"{PROJECTS_BASE}/{project_id}/workspaces"
+
+
+async def _create_workspace(client: AsyncClient, project_id: str, name: str = "Test WS") -> dict[str, object]:
+    response = await client.post(f"{_ws_base(project_id)}/", json={"name": name})
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_create_workspace(client: AsyncClient) -> None:
+    """POST creates a workspace and returns 201."""
+    pid = await _create_project(client)
+
+    body = await _create_workspace(client, pid, "My Workspace")
+
+    assert body["name"] == "My Workspace"
+    assert body["project_id"] == pid
+    assert body["sort_order"] == 1
+    assert body["locked"] is False
+
+
+async def test_list_workspaces(client: AsyncClient) -> None:
+    """GET returns all workspaces ordered by sort_order."""
+    pid = await _create_project(client)
+    await _create_workspace(client, pid, "First")
+    await _create_workspace(client, pid, "Second")
+
+    response = await client.get(f"{_ws_base(pid)}/")
+
+    assert response.status_code == 200
+    workspaces = response.json()
+    assert len(workspaces) == 2
+    assert workspaces[0]["name"] == "First"
+    assert workspaces[1]["name"] == "Second"
+
+
+async def test_list_workspaces_empty(client: AsyncClient) -> None:
+    """GET returns an empty list when no workspaces exist."""
+    pid = await _create_project(client)
+
+    response = await client.get(f"{_ws_base(pid)}/")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_get_workspace(client: AsyncClient) -> None:
+    """GET /{wid} returns the workspace."""
+    pid = await _create_project(client)
+    created = await _create_workspace(client, pid)
+
+    response = await client.get(f"{_ws_base(pid)}/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created["id"]
+
+
+async def test_get_workspace_not_found(client: AsyncClient) -> None:
+    """GET /{wid} returns 404 for a non-existent workspace."""
+    pid = await _create_project(client)
+
+    response = await client.get(f"{_ws_base(pid)}/does-not-exist")
+
+    assert response.status_code == 404
+    assert response.json()["code"] == "NOT_FOUND"
+
+
+async def test_update_workspace(client: AsyncClient) -> None:
+    """PATCH updates workspace fields."""
+    pid = await _create_project(client)
+    created = await _create_workspace(client, pid, "Old")
+
+    response = await client.patch(
+        f"{_ws_base(pid)}/{created['id']}",
+        json={"name": "New", "description": "Updated", "locked": True},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "New"
+    assert body["description"] == "Updated"
+    assert body["locked"] is True
+
+
+async def test_update_workspace_not_found(client: AsyncClient) -> None:
+    """PATCH returns 404 for a non-existent workspace."""
+    pid = await _create_project(client)
+
+    response = await client.patch(f"{_ws_base(pid)}/does-not-exist", json={"name": "X"})
+
+    assert response.status_code == 404
+
+
+async def test_delete_workspace(client: AsyncClient) -> None:
+    """DELETE removes the workspace and returns 204."""
+    pid = await _create_project(client)
+    created = await _create_workspace(client, pid)
+
+    response = await client.delete(f"{_ws_base(pid)}/{created['id']}")
+
+    assert response.status_code == 204
+
+    get_response = await client.get(f"{_ws_base(pid)}/{created['id']}")
+    assert get_response.status_code == 404
+
+
+async def test_delete_workspace_not_found(client: AsyncClient) -> None:
+    """DELETE returns 404 for a non-existent workspace."""
+    pid = await _create_project(client)
+
+    response = await client.delete(f"{_ws_base(pid)}/does-not-exist")
+
+    assert response.status_code == 404
+
+
+async def test_duplicate_workspace(client: AsyncClient) -> None:
+    """POST /{wid}/duplicate creates a copy."""
+    pid = await _create_project(client)
+    original = await _create_workspace(client, pid, "Original")
+
+    response = await client.post(f"{_ws_base(pid)}/{original['id']}/duplicate")
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Original (copy)"
+    assert body["id"] != original["id"]
+    assert body["sort_order"] == 2
+
+
+async def test_create_workspace_enforces_limit(client: AsyncClient) -> None:
+    """POST returns 422 when workspace limit is reached."""
+    pid = await _create_project(client)
+    for i in range(5):
+        await _create_workspace(client, pid, f"WS {i}")
+
+    response = await client.post(f"{_ws_base(pid)}/", json={"name": "Overflow"})
+
+    assert response.status_code == 422
+    assert response.json()["code"] == "WORKSPACE_LIMIT_REACHED"
+
+
+async def test_reorder_workspaces(client: AsyncClient) -> None:
+    """PUT /reorder updates sort order."""
+    pid = await _create_project(client)
+    ws1 = await _create_workspace(client, pid, "A")
+    ws2 = await _create_workspace(client, pid, "B")
+    ws3 = await _create_workspace(client, pid, "C")
+
+    response = await client.put(
+        f"{_ws_base(pid)}/reorder",
+        json={"ordered_ids": [ws3["id"], ws1["id"], ws2["id"]]},
+    )
+
+    assert response.status_code == 204
+
+    list_response = await client.get(f"{_ws_base(pid)}/")
+    names = [ws["name"] for ws in list_response.json()]
+    assert names == ["C", "A", "B"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,204 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/9d/a9a7b5a9351e3ff0baae01136f71ba6fc4652fe0dc2da3b0a8ebdfc1be44/boto3-1.42.85.tar.gz", hash = "sha256:1cd3dcbfaba85c6071ba9397c1804b6a94a1a97031b8f1993fdba27c0c5d6eba", size = 112769, upload-time = "2026-04-07T19:40:53.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/ab/3167b8ec3cf1d87ad08d2ad5f15823a22945cae7870798274c283c3a18f1/boto3-1.42.85-py3-none-any.whl", hash = "sha256:4f6ac066e41d18ec33f532253fac0f35e0fdca373724458f983ce3d531340b7a", size = 140556, upload-time = "2026-04-07T19:40:52.186Z" },
+]
+
+[[package]]
+name = "boto3-stubs"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/17/cb76053c9e3fef9b5f105894e564ae9415f88c4521bdc8312298aa1203f4/boto3_stubs-1.42.85.tar.gz", hash = "sha256:deaf52b51a660963170012cc6b7f1b220008e6c59fea84e35fbf5439f1360dd7", size = 102344, upload-time = "2026-04-07T19:51:33.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/30/1e511aaa6a0e102068c8f940d064110be8331e4f56c935ada4be1da4ef03/boto3_stubs-1.42.85-py3-none-any.whl", hash = "sha256:24425050b7a3a65b6e6e67281efbf941ce90bbb0043457a4771f9dc69944397f", size = 70522, upload-time = "2026-04-07T19:51:27.786Z" },
+]
+
+[package.optional-dependencies]
+dynamodb = [
+    { name = "mypy-boto3-dynamodb" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ac/7f14b05cf43e4baae99f4570b02e10b2aebf242dfd86245523340390c834/botocore-1.42.85.tar.gz", hash = "sha256:2ee61f80b7724a143e16d0a85408ef5fa20b99dce7a3c8ec5d25cc8dced164c1", size = 15159562, upload-time = "2026-04-07T19:40:43.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/f3/c1fbaff4c509c616fd01f44357283a8992f10b3a05d932b22e602aa3a221/botocore-1.42.85-py3-none-any.whl", hash = "sha256:828b67722caeb7e240eefedee74050e803d1fa102958ead9c4009101eefd5381", size = 14839741, upload-time = "2026-04-07T19:40:40.733Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.42.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/a8/a26608ff39e3a5866c6c79eda10133490205cbddd45074190becece3ff2a/botocore_stubs-1.42.41.tar.gz", hash = "sha256:dbeac2f744df6b814ce83ec3f3777b299a015cbea57a2efc41c33b8c38265825", size = 42411, upload-time = "2026-02-03T20:46:14.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/76/cab7af7f16c0b09347f2ebe7ffda7101132f786acb767666dce43055faab/botocore_stubs-1.42.41-py3-none-any.whl", hash = "sha256:9423110fb0e391834bd2ed44ae5f879d8cb370a444703d966d30842ce2bcb5f0", size = 66759, upload-time = "2026-02-03T20:46:13.02Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -60,12 +252,95 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
 ]
 
 [[package]]
@@ -78,6 +353,83 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -87,12 +439,119 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "mangum"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/cb/d9f4d685a0b8eceac10991e15ac471d9568e4e42c2489ae9bf072828c1c2/mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de", size = 89130, upload-time = "2026-02-01T17:17:42.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/50/e3c694b8e122551e4557450219283771334dee2ed5734a8398c8b8018c50/mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7", size = 17146, upload-time = "2026-02-01T17:17:41.553Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "moto"
+version = "5.1.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "jinja2" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3d/1765accbf753dc1ae52f26a2e2ed2881d78c2eb9322c178e45312472e4a0/moto-5.1.22.tar.gz", hash = "sha256:e5b2c378296e4da50ce5a3c355a1743c8d6d396ea41122f5bb2a40f9b9a8cc0e", size = 8547792, upload-time = "2026-03-08T21:06:43.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4f/8812a01e3e0bd6be3e13b90432fb5c696af9a720af3f00e6eba5ad748345/moto-5.1.22-py3-none-any.whl", hash = "sha256:d9f20ae3cf29c44f93c1f8f06c8f48d5560e5dc027816ef1d0d2059741ffcfbe", size = 6617400, upload-time = "2026-03-08T21:06:41.093Z" },
+]
+
+[package.optional-dependencies]
+dynamodb = [
+    { name = "docker" },
+    { name = "py-partiql-parser" },
+]
+
+[[package]]
+name = "mypy-boto3-dynamodb"
+version = "1.42.73"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/a2/fc93b44ed07322ede4cc45c6c66370ff53ad8a195b95f9f80d1edbb7735a/mypy_boto3_dynamodb-1.42.73.tar.gz", hash = "sha256:3fd9e093a8c982a53d55f6ac3d109d89957fe82b5c7ece65f27b772ed7a5ca9b", size = 48723, upload-time = "2026-03-20T19:59:32.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/41/f4ececbceb13d1c2fbc1cfee56d65231c98b19f4d0b41baf3ab5d88b6863/mypy_boto3_dynamodb-1.42.73-py3-none-any.whl", hash = "sha256:2df84f71ff41fba5f12e803be19c4483daa64ba030fc9d62ba5e5f9f09a4def8", size = 58828, upload-time = "2026-03-20T19:59:24.878Z" },
 ]
 
 [[package]]
@@ -107,23 +566,62 @@ wheels = [
 [[package]]
 name = "openfactcheck"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+api = [
+    { name = "aiosqlite" },
+    { name = "fastapi" },
+    { name = "mangum" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "uvicorn", extra = ["standard"] },
+]
+cloud = [
+    { name = "boto3" },
+]
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3-stubs", extra = ["dynamodb"] },
+    { name = "httpx" },
+    { name = "moto", extra = ["dynamodb"] },
+    { name = "openfactcheck", extra = ["api", "cloud"] },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "aiosqlite", marker = "extra == 'api'", specifier = ">=0.21" },
+    { name = "boto3", marker = "extra == 'cloud'", specifier = ">=1.35" },
+    { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115" },
+    { name = "mangum", marker = "extra == 'api'", specifier = ">=0.19" },
+    { name = "pydantic", specifier = ">=2.11" },
+    { name = "pydantic-settings", marker = "extra == 'api'", specifier = ">=2.9" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'api'", specifier = ">=2.10" },
+    { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'api'", specifier = ">=2.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.34" },
+]
+provides-extras = ["api", "cloud"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3-stubs", extras = ["dynamodb"], specifier = ">=1.35" },
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "moto", extras = ["dynamodb"], specifier = ">=5.1" },
+    { name = "openfactcheck", extras = ["api", "cloud"] },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=0.26" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.8" },
 ]
@@ -172,12 +670,112 @@ wheels = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.19.2"
+name = "py-partiql-parser"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -195,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -204,9 +802,21 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -224,16 +834,47 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/88/815e53084c5079a59df912825a279f41dd2e0df82281770eadc732f5352c/python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e", size = 58457, upload-time = "2026-03-26T22:30:44.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502", size = 31674, upload-time = "2026-03-26T22:30:43.396Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -263,28 +904,139 @@ wheels = [
 ]
 
 [[package]]
-name = "ruff"
-version = "0.15.8"
+name = "requests"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
-    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/b4/b7e040379838cc71bf5aabdb26998dfbe5ee73904c92c1c161faf5de8866/responses-0.26.0.tar.gz", hash = "sha256:c7f6923e6343ef3682816ba421c006626777893cb0d5e1434f674b649bac9eb4", size = 81303, upload-time = "2026-02-19T14:38:05.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/7f73d05b556da048923e31a0cc878f03be7c5425ed1f268082255c75d872/responses-0.26.0-py3-none-any.whl", hash = "sha256:03ec4409088cd5c66b71ecbbbd27fe2c58ddfad801c66203457b3e6a04868c37", size = 35099, upload-time = "2026-02-19T14:38:03.847Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "types-awscrt"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]
@@ -294,6 +1046,71 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
 ]
 
 [[package]]
@@ -309,4 +1126,86 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]


### PR DESCRIPTION
## Summary

- Full API layer: projects + workspaces CRUD, dual DB (SQLite + DynamoDB), Cognito JWT auth
- Deployed to Lambda + API Gateway at `{ws}-api.openfactcheck.com`
- Build tooling with hash-based skip, generic container build system
- CI/CD: auto-deploy on push to main (integration) and version tags (production)
- 94 tests, 3 security audits, Pyright strict, Ruff clean

## Test plan

- [x] `task dev:test` — 94 tests passing
- [x] `task dev:lint` — 0 pyright errors, 0 ruff issues
- [x] `task build:lambda TARGET=api` — container builds successfully
- [x] `task deploy:api TARGET=devhasan` — deployed and tested live
- [x] `curl https://devhasan-api.openfactcheck.com/health` → `{"status":"healthy"}`
- [x] CRUD via Swagger UI with Cognito token verified
- [ ] CI/CD workflows (will validate on merge to main)