### PR TITLE
feat: workspace content persistence, descriptions, deploy simplification

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -67,10 +67,5 @@ jobs:
           aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile hasaniqbal-dev
           aws configure set region us-east-1 --profile hasaniqbal-dev
 
-      - name: Deploy infrastructure
-        run: |
-          task deploy TARGET=integration DEP=repositories AUTO_APPROVE=true
-          task deploy TARGET=integration AUTO_APPROVE=true
-
-      - name: Build and deploy API
-        run: task deploy:api TARGET=integration
+      - name: Build and deploy
+        run: task deploy TARGET=integration AUTO_APPROVE=true

--- a/.github/workflows/ci-production.yml
+++ b/.github/workflows/ci-production.yml
@@ -103,10 +103,5 @@ jobs:
           aws configure set aws_session_token "$AWS_SESSION_TOKEN" --profile hasaniqbal-dev
           aws configure set region us-east-1 --profile hasaniqbal-dev
 
-      - name: Deploy infrastructure
-        run: |
-          task deploy TARGET=production DEP=repositories AUTO_APPROVE=true
-          task deploy TARGET=production AUTO_APPROVE=true
-
-      - name: Build and deploy API
-        run: task deploy:api TARGET=production
+      - name: Build and deploy
+        run: task deploy TARGET=production AUTO_APPROVE=true

--- a/src/openfactcheck/api/models/project.py
+++ b/src/openfactcheck/api/models/project.py
@@ -13,6 +13,7 @@ class Project(BaseModel):
     id: str
     user_id: str
     name: str
+    description: str
     created_at: datetime
     updated_at: datetime
 
@@ -21,9 +22,11 @@ class ProjectCreate(BaseModel):
     """Fields required to create a new project."""
 
     name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="", max_length=10000)
 
 
 class ProjectUpdate(BaseModel):
     """Fields that can be updated on a project. All optional."""
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=10000)

--- a/src/openfactcheck/api/models/workspace.py
+++ b/src/openfactcheck/api/models/workspace.py
@@ -24,6 +24,7 @@ class Workspace(BaseModel):
     locked: bool = False
     sort_order: int
     settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
+    content: dict[str, object] | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -32,6 +33,7 @@ class WorkspaceCreate(BaseModel):
     """Fields required to create a new workspace."""
 
     name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="", max_length=10000)
 
 
 class WorkspaceUpdate(BaseModel):
@@ -41,3 +43,4 @@ class WorkspaceUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=10000)
     locked: bool | None = None
     settings: WorkspaceSettings | None = None
+    content: dict[str, object] | None = None

--- a/src/openfactcheck/api/repositories/constants.py
+++ b/src/openfactcheck/api/repositories/constants.py
@@ -6,6 +6,7 @@ from secrets import token_urlsafe
 
 MAX_PROJECTS_PER_USER = 50
 MAX_WORKSPACES_PER_PROJECT = 5
+MAX_CONTENT_BYTES = 350_000
 
 
 def generate_id() -> str:

--- a/src/openfactcheck/api/repositories/dynamodb/projects.py
+++ b/src/openfactcheck/api/repositories/dynamodb/projects.py
@@ -18,6 +18,7 @@ def _item_to_model(item: dict[str, Any]) -> Project:
         id=item["id"],
         user_id=item["userId"],
         name=item["name"],
+        description=item.get("description", ""),
         created_at=datetime.fromisoformat(item["createdAt"]),
         updated_at=datetime.fromisoformat(item["updatedAt"]),
     )
@@ -69,6 +70,7 @@ class DynamoProjectRepository:
             "id": project_id,
             "userId": user_id,
             "name": data.name,
+            "description": data.description,
             "createdAt": now.isoformat(),
             "updatedAt": now.isoformat(),
         }

--- a/src/openfactcheck/api/repositories/dynamodb/workspaces.py
+++ b/src/openfactcheck/api/repositories/dynamodb/workspaces.py
@@ -27,6 +27,7 @@ def _item_to_model(item: dict[str, Any]) -> Workspace:
         locked=item.get("locked", False),
         sort_order=int(item.get("sortOrder", 0)),
         settings=WorkspaceSettings.model_validate_json(settings_str),
+        content=item.get("content"),
         created_at=datetime.fromisoformat(item["createdAt"]),
         updated_at=datetime.fromisoformat(item["updatedAt"]),
     )
@@ -82,7 +83,7 @@ class DynamoWorkspaceRepository:
                 "userId": user_id,
                 "projectId": project_id,
                 "name": data.name,
-                "description": "",
+                "description": data.description,
                 "locked": False,
                 "sortOrder": max_order + 1,
                 "settings": "{}",
@@ -115,6 +116,10 @@ class DynamoWorkspaceRepository:
             update_parts.append("#settings = :settings")
             attr_names["#settings"] = "settings"
             attr_values[":settings"] = data.settings.model_dump_json()
+        if data.content is not None:
+            update_parts.append("#content = :content")
+            attr_names["#content"] = "content"
+            attr_values[":content"] = data.content
 
         if not update_parts:
             return await self.get(user_id, project_id, workspace_id)
@@ -186,6 +191,8 @@ class DynamoWorkspaceRepository:
                 "createdAt": now.isoformat(),
                 "updatedAt": now.isoformat(),
             }
+            if source.content:
+                item["content"] = source.content
             self._table.put_item(Item=item)
             return _item_to_model(item)
 

--- a/src/openfactcheck/api/repositories/sqlite/projects.py
+++ b/src/openfactcheck/api/repositories/sqlite/projects.py
@@ -17,6 +17,7 @@ def _row_to_model(row: ProjectRow) -> Project:
         id=row.id,
         user_id=row.user_id,
         name=row.name,
+        description=row.description,
         created_at=row.created_at.replace(tzinfo=UTC),
         updated_at=row.updated_at.replace(tzinfo=UTC),
     )
@@ -60,6 +61,7 @@ class SqliteProjectRepository:
                 id=generate_id(),
                 user_id=user_id,
                 name=data.name,
+                description=data.description,
                 created_at=now,
                 updated_at=now,
             )

--- a/src/openfactcheck/api/repositories/sqlite/tables.py
+++ b/src/openfactcheck/api/repositories/sqlite/tables.py
@@ -18,6 +18,7 @@ class ProjectRow(Base):
     id: Mapped[str] = mapped_column(String(12), primary_key=True)
     user_id: Mapped[str] = mapped_column(String(255), index=True)
     name: Mapped[str] = mapped_column(String(255))
+    description: Mapped[str] = mapped_column(Text, default="")
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 
@@ -42,5 +43,6 @@ class WorkspaceRow(Base):
     locked: Mapped[bool] = mapped_column(Boolean, default=False)
     sort_order: Mapped[int] = mapped_column(Integer)
     settings_json: Mapped[str] = mapped_column(Text, default="{}")
+    content_json: Mapped[str] = mapped_column(Text, default="{}")
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)

--- a/src/openfactcheck/api/repositories/sqlite/workspaces.py
+++ b/src/openfactcheck/api/repositories/sqlite/workspaces.py
@@ -23,6 +23,7 @@ def _row_to_model(row: WorkspaceRow) -> Workspace:
         locked=row.locked,
         sort_order=row.sort_order,
         settings=WorkspaceSettings.model_validate_json(row.settings_json),
+        content=json.loads(row.content_json) if row.content_json and row.content_json != "{}" else None,
         created_at=row.created_at.replace(tzinfo=UTC),
         updated_at=row.updated_at.replace(tzinfo=UTC),
     )
@@ -82,7 +83,7 @@ class SqliteWorkspaceRepository:
                 user_id=user_id,
                 project_id=project_id,
                 name=data.name,
-                description="",
+                description=data.description,
                 locked=False,
                 sort_order=await self._next_sort_order(session, user_id, project_id),
                 settings_json="{}",
@@ -103,6 +104,8 @@ class SqliteWorkspaceRepository:
             values["locked"] = data.locked
         if data.settings is not None:
             values["settings_json"] = data.settings.model_dump_json()
+        if data.content is not None:
+            values["content_json"] = json.dumps(data.content)
 
         if not values:
             return await self.get(user_id, project_id, workspace_id)
@@ -156,6 +159,7 @@ class SqliteWorkspaceRepository:
                 locked=False,
                 sort_order=await self._next_sort_order(session, user_id, project_id),
                 settings_json=json.dumps(source.settings.model_dump()),
+                content_json=json.dumps(source.content) if source.content else "{}",
                 created_at=now,
                 updated_at=now,
             )

--- a/src/openfactcheck/api/routers/projects.py
+++ b/src/openfactcheck/api/routers/projects.py
@@ -36,7 +36,7 @@ async def create_project(
     repo: Annotated[ProjectRepository, Depends(get_project_repo)],
 ) -> ProjectResponse:
     """Create a new project."""
-    project = await repo.create(user.sub, ProjectCreate(name=body.name))
+    project = await repo.create(user.sub, ProjectCreate(name=body.name, description=body.description))
     if project is None:
         raise ProjectLimitError()
     return ProjectResponse.from_model(project)
@@ -63,7 +63,7 @@ async def update_project(
     repo: Annotated[ProjectRepository, Depends(get_project_repo)],
 ) -> ProjectResponse:
     """Update a project."""
-    project = await repo.update(user.sub, project_id, ProjectUpdate(name=body.name))
+    project = await repo.update(user.sub, project_id, ProjectUpdate(name=body.name, description=body.description))
     if project is None:
         raise NotFoundError(f"Project {project_id} not found")
     return ProjectResponse.from_model(project)

--- a/src/openfactcheck/api/routers/workspaces.py
+++ b/src/openfactcheck/api/routers/workspaces.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, Path, status
 from openfactcheck.api.dependencies import get_current_user, get_workspace_repo
 from openfactcheck.api.errors import AppError, ErrorCode, NotFoundError, WorkspaceLimitError
 from openfactcheck.api.models import AuthUser, WorkspaceCreate, WorkspaceUpdate
+from openfactcheck.api.repositories.constants import MAX_CONTENT_BYTES
 from openfactcheck.api.repositories.protocols import WorkspaceRepository
 from openfactcheck.api.schemas.workspaces import (
     CreateWorkspaceRequest,
@@ -41,7 +42,7 @@ async def create_workspace(
     repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
 ) -> WorkspaceResponse:
     """Create a new workspace in a project."""
-    ws = await repo.create(user.sub, project_id, WorkspaceCreate(name=body.name))
+    ws = await repo.create(user.sub, project_id, WorkspaceCreate(name=body.name, description=body.description))
     if ws is None:
         raise WorkspaceLimitError()
     return WorkspaceResponse.from_model(ws)
@@ -70,11 +71,19 @@ async def update_workspace(
     repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
 ) -> WorkspaceResponse:
     """Update a workspace."""
+    if body.content is not None and len(str(body.content)) > MAX_CONTENT_BYTES:
+        raise AppError("Workspace content exceeds size limit", ErrorCode.VALIDATION_ERROR, status=422)
     ws = await repo.update(
         user.sub,
         project_id,
         workspace_id,
-        WorkspaceUpdate(name=body.name, description=body.description, locked=body.locked, settings=body.settings),
+        WorkspaceUpdate(
+            name=body.name,
+            description=body.description,
+            locked=body.locked,
+            settings=body.settings,
+            content=body.content,
+        ),
     )
     if ws is None:
         raise NotFoundError(f"Workspace {workspace_id} not found")

--- a/src/openfactcheck/api/schemas/projects.py
+++ b/src/openfactcheck/api/schemas/projects.py
@@ -13,12 +13,14 @@ class CreateProjectRequest(BaseModel):
     """Body for POST /api/v1/projects."""
 
     name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="", max_length=10000)
 
 
 class UpdateProjectRequest(BaseModel):
     """Body for PATCH /api/v1/projects/{id}."""
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=10000)
 
 
 class ProjectResponse(BaseModel):
@@ -26,6 +28,7 @@ class ProjectResponse(BaseModel):
 
     id: str
     name: str
+    description: str
     created_at: datetime
     updated_at: datetime
 
@@ -35,6 +38,7 @@ class ProjectResponse(BaseModel):
         return ProjectResponse(
             id=project.id,
             name=project.name,
+            description=project.description,
             created_at=project.created_at,
             updated_at=project.updated_at,
         )

--- a/src/openfactcheck/api/schemas/workspaces.py
+++ b/src/openfactcheck/api/schemas/workspaces.py
@@ -12,6 +12,7 @@ class CreateWorkspaceRequest(BaseModel):
     """Body for POST /api/v1/projects/{pid}/workspaces."""
 
     name: str = Field(min_length=1, max_length=255)
+    description: str = Field(default="", max_length=10000)
 
 
 class UpdateWorkspaceRequest(BaseModel):
@@ -21,6 +22,7 @@ class UpdateWorkspaceRequest(BaseModel):
     description: str | None = Field(default=None, max_length=10000)
     locked: bool | None = None
     settings: WorkspaceSettings | None = None
+    content: dict[str, object] | None = None
 
 
 class ReorderWorkspacesRequest(BaseModel):
@@ -39,6 +41,7 @@ class WorkspaceResponse(BaseModel):
     locked: bool
     sort_order: int
     settings: WorkspaceSettings
+    content: dict[str, object] | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -53,6 +56,7 @@ class WorkspaceResponse(BaseModel):
             locked=ws.locked,
             sort_order=ws.sort_order,
             settings=ws.settings,
+            content=ws.content,
             created_at=ws.created_at,
             updated_at=ws.updated_at,
         )

--- a/taskfiles/build.taskfile.yml
+++ b/taskfiles/build.taskfile.yml
@@ -4,65 +4,65 @@ version: "3"
 
 tasks:
   lambda:
-    desc: Build + push container image (TARGET=<name>, WS=<workspace> for ECR push)
+    desc: Build + push container image (APP=<name>, TARGET=<environment> for ECR push)
     requires:
-      vars: [TARGET]
+      vars: [APP]
     cmds:
       - |
         source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
-        set_target "{{.TARGET}}"
-        {{if .WS}}set_workspace "{{.WS}}"{{end}}
+        set_target "{{.APP}}"
+        {{if .TARGET}}set_workspace "{{.TARGET}}"{{end}}
 
         if build_needed; then
             assemble
             build_image
             write_hash
-            {{if .WS}}
+            {{if .TARGET}}
             ecr_login
             push_all
             write_tfvars
             {{end}}
         else
-            c_echo "$COLOR_YELLOW" "[{{.TARGET}}] Skipping build — source unchanged"
+            c_echo "$COLOR_YELLOW" "[{{.APP}}] Skipping build — source unchanged"
         fi
 
   lambda:force:
-    desc: Build + push container image (TARGET=<name>, always rebuilds, WS=<workspace> for ECR push)
+    desc: Build + push container image (APP=<name>, always rebuilds, TARGET=<environment> for ECR push)
     requires:
-      vars: [TARGET]
+      vars: [APP]
     cmds:
       - |
         source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
-        set_target "{{.TARGET}}"
-        {{if .WS}}set_workspace "{{.WS}}"{{end}}
+        set_target "{{.APP}}"
+        {{if .TARGET}}set_workspace "{{.TARGET}}"{{end}}
 
         assemble
         build_image
         write_hash
-        {{if .WS}}
+        {{if .TARGET}}
         ecr_login
         push_all
         write_tfvars
         {{end}}
 
   lambda:assemble:
-    desc: Assemble build/ directory only (TARGET=<name>)
+    desc: Assemble build/ directory only (APP=<name>)
     requires:
-      vars: [TARGET]
+      vars: [APP]
     cmds:
       - |
         source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
-        set_target "{{.TARGET}}"
+        set_target "{{.APP}}"
         assemble
 
   clean:
-    desc: Remove build artifacts (TARGET=<name>)
+    desc: Remove build artifacts (APP=<name>)
     requires:
-      vars: [TARGET]
+      vars: [APP]
     cmds:
       - |
         source taskfiles/build.helpers.sh 2>/dev/null || source ./taskfiles/build.helpers.sh
-        set_target "{{.TARGET}}"
+        set_target "{{.APP}}"
         clean
 
   default:
@@ -70,4 +70,4 @@ tasks:
     cmds:
       - task: :print:info
         vars:
-          MSG: "Usage: task build:lambda TARGET=api [WS=devhasan]"
+          MSG: "Usage: task build:lambda APP=api [TARGET=devhasan]"

--- a/taskfiles/deploy.taskfile.yml
+++ b/taskfiles/deploy.taskfile.yml
@@ -194,64 +194,11 @@ tasks:
         done
         printf '{{.COLOR_GREEN}}✓ Files formatted{{.COLOR_RESET}}\n'
 
-  api:
-    desc: Build, push, and deploy API to Lambda (TARGET=<environment>)
-    requires:
-      vars: [TARGET]
-    cmds:
-      - |
-        export TF_BIN="{{.TF_BIN}}"
-        source taskfiles/build.helpers.sh
-        source taskfiles/common.helpers.sh && source taskfiles/deploy.helpers.sh
-
-        set_target "api"
-
-        if ! build_needed; then
-            c_echo "$COLOR_YELLOW" "[api] Skipping deploy — source unchanged"
-            exit 0
-        fi
-
-        # Build
-        assemble
-        build_image
-        write_hash
-
-        # Resolve deploy config
-        prepare "{{.TARGET}}" "base" || exit 1
-        AWS_PROFILE=$(jq -r .aws_profile "$VAR_FILE")
-        AWS_REGION=$(jq -r .aws_region "$VAR_FILE")
-
-        cd deployments/base
-        $TF_BIN workspace select $WORKSPACE 2>/dev/null
-        ECR_URL=$($TF_BIN output -raw ecr_repository_url)
-        FUNCTION_NAME=$($TF_BIN output -raw lambda_function_name 2>/dev/null || echo "openfactcheck-api-${WORKSPACE}-${AWS_REGION}")
-        API_URL=$($TF_BIN output -raw api_url)
-        cd -
-
-        IMAGE_REF="${ECR_URL}:latest"
-
-        # ECR login + push
-        c_echo "$COLOR_CYAN" "Logging into ECR..."
-        aws ecr get-login-password --region "$AWS_REGION" --profile "$AWS_PROFILE" \
-          | docker login --username AWS --password-stdin "${ECR_URL%%/*}"
-
-        c_echo "$COLOR_CYAN" "Pushing image to ECR..."
-        docker tag openfactcheck-api:latest "$IMAGE_REF"
-        docker push "$IMAGE_REF"
-
-        # Update Lambda
-        c_echo "$COLOR_CYAN" "Updating Lambda function..."
-        aws lambda update-function-code \
-          --function-name "$FUNCTION_NAME" \
-          --image-uri "$IMAGE_REF" \
-          --region "$AWS_REGION" \
-          --profile "$AWS_PROFILE" > /dev/null
-
-        c_echo "$COLOR_GREEN" "✓ Deployed to: ${API_URL}"
-
   default:
-    desc: Run the full infrastructure workflow (TARGET=<target>, optional DEP=<deployment>)
+    desc: Build API + deploy infrastructure (TARGET=<target>, optional DEP=<deployment>)
     cmds:
+      - task: :build:lambda
+        vars: {APP: 'api', TARGET: '{{.TARGET}}'}
       - task: _prepare
         vars: {TARGET: '{{.TARGET}}', DEP: '{{.DEP}}'}
       - |


### PR DESCRIPTION
API:
- Add content field (JSON) to Workspace model for Blockly state + notes
- Add description field to Project and Workspace models
- Add 350KB content size check on workspace update
- Wire content/description through schemas, repositories (SQLite + DynamoDB), routers

Deploy:
- Simplify to single 'task deploy' command (builds Lambda image first)
- Rename TARGET→APP, WS→TARGET for clarity
- Remove separate deploy:api task
- CI: single 'task deploy TARGET=<env> AUTO_APPROVE=true'