### PR TITLE
feat: run API endpoints with local execution dispatch

### DIFF
--- a/src/openfactcheck/api/app.py
+++ b/src/openfactcheck/api/app.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, FastAPI
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.dependencies import get_config
 from openfactcheck.api.middleware import register_middleware
-from openfactcheck.api.routers import health, projects, workspaces
+from openfactcheck.api.routers import health, projects, workspaces, runs
 
 
 def create_app(config: APIConfig | None = None) -> FastAPI:
@@ -33,6 +33,7 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
     v1 = APIRouter(prefix="/api/v1")
     v1.include_router(projects.router)
     v1.include_router(workspaces.router)
+    v1.include_router(runs.router)
     app.include_router(v1)
 
     return app

--- a/src/openfactcheck/api/dependencies.py
+++ b/src/openfactcheck/api/dependencies.py
@@ -12,7 +12,7 @@ from openfactcheck.api.auth.cognito import CognitoVerifier, DevVerifier, TokenVe
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.errors import AuthError
 from openfactcheck.api.models import AuthUser
-from openfactcheck.api.repositories.protocols import ProjectRepository, WorkspaceRepository
+from openfactcheck.api.repositories.protocols import ProjectRepository, RunRepository, WorkspaceRepository
 
 
 @lru_cache(maxsize=1)
@@ -24,6 +24,7 @@ def get_config() -> APIConfig:
 _verifier: TokenVerifier | None = None
 _project_repo: ProjectRepository | None = None
 _workspace_repo: WorkspaceRepository | None = None
+_run_repo: RunRepository | None = None
 _sqlite_session_factory: Any = None
 _sqlite_lock = asyncio.Lock()
 
@@ -110,3 +111,21 @@ async def get_workspace_repo(
             sf = await _get_sqlite_session_factory(config)
             _workspace_repo = SqliteWorkspaceRepository(sf)
     return _workspace_repo
+
+
+async def get_run_repo(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> RunRepository:
+    """Return the run repository, creating it on first call."""
+    global _run_repo  # noqa: PLW0603
+    if _run_repo is None:
+        if config.mode == "cloud":
+            from openfactcheck.api.repositories.dynamodb.runs import DynamoRunRepository
+
+            _run_repo = DynamoRunRepository(config.dynamodb_table_name, config.dynamodb_region)
+        else:
+            from openfactcheck.api.repositories.sqlite.runs import SqliteRunRepository
+
+            sf = await _get_sqlite_session_factory(config)
+            _run_repo = SqliteRunRepository(sf)
+    return _run_repo

--- a/src/openfactcheck/api/routers/runs.py
+++ b/src/openfactcheck/api/routers/runs.py
@@ -1,0 +1,89 @@
+"""Run endpoints — /api/v1/projects/{project_id}/runs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, status
+
+from openfactcheck.api.config import APIConfig
+from openfactcheck.api.dependencies import get_config, get_current_user, get_run_repo
+from openfactcheck.api.errors import AppError, ErrorCode, NotFoundError
+from openfactcheck.api.models import AuthUser, RunCreate, RunStatus
+from openfactcheck.api.repositories.constants import MAX_PIPELINE_BYTES
+from openfactcheck.api.repositories.protocols import RunRepository
+from openfactcheck.api.schemas.runs import CreateRunRequest, RunResponse
+
+router = APIRouter(prefix="/projects/{project_id}/runs", tags=["runs"])
+
+ResourceId = Annotated[str, Path(max_length=20)]
+
+
+async def _execute_and_update(
+    repo: RunRepository, user_id: str, project_id: str, run_id: str, pipeline: dict[str, object]
+) -> None:
+    """Background task: run the pipeline and update the run record."""
+    from openfactcheck.engine import execute_pipeline
+
+    await repo.update_status(user_id, project_id, run_id, RunStatus.RUNNING)
+    result = await execute_pipeline(pipeline)
+    if result.success:
+        await repo.update_status(user_id, project_id, run_id, RunStatus.COMPLETED, output=result.output)
+    else:
+        await repo.update_status(
+            user_id, project_id, run_id, RunStatus.FAILED, output=result.output, error=result.error
+        )
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_run(
+    project_id: ResourceId,
+    body: CreateRunRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[RunRepository, Depends(get_run_repo)],
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> RunResponse:
+    """Create and execute a new pipeline run."""
+    pipeline_size = len(json.dumps(body.pipeline).encode())
+    if pipeline_size > MAX_PIPELINE_BYTES:
+        raise AppError("Pipeline exceeds size limit", ErrorCode.VALIDATION_ERROR, status=422)
+
+    run = await repo.create(user.sub, project_id, RunCreate(workspace_id=body.workspace_id, pipeline=body.pipeline))
+
+    if config.mode == "cloud":
+        # TODO: push SQS message for executor Lambda (Phase 1g)
+        pass
+    else:
+        asyncio.create_task(_execute_and_update(repo, user.sub, project_id, run.id, body.pipeline))
+
+    return RunResponse.from_model(run)
+
+
+@router.get("/{run_id}")
+async def get_run(
+    project_id: ResourceId,
+    run_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[RunRepository, Depends(get_run_repo)],
+) -> RunResponse:
+    """Get a single run by ID."""
+    run = await repo.get(user.sub, project_id, run_id)
+    if run is None:
+        raise NotFoundError(f"Run {run_id} not found")
+    return RunResponse.from_model(run)
+
+
+@router.get("/")
+async def list_runs(
+    project_id: ResourceId,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[RunRepository, Depends(get_run_repo)],
+    workspace_id: Annotated[str | None, Query(max_length=20)] = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> list[RunResponse]:
+    """List runs for a project, optionally filtered by workspace."""
+    runs = await repo.list_by_project(user.sub, project_id, workspace_id=workspace_id, limit=limit, offset=offset)
+    return [RunResponse.from_model(r) for r in runs]

--- a/src/openfactcheck/api/schemas/runs.py
+++ b/src/openfactcheck/api/schemas/runs.py
@@ -1,0 +1,45 @@
+"""Run request/response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from openfactcheck.api.models import Run
+
+
+class CreateRunRequest(BaseModel):
+    """Body for POST /api/v1/projects/{pid}/runs."""
+
+    workspace_id: str = Field(max_length=20)
+    pipeline: dict[str, object]
+
+
+class RunResponse(BaseModel):
+    """Single run in API responses."""
+
+    id: str
+    project_id: str
+    workspace_id: str
+    status: str
+    output: str | None = None
+    error: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @staticmethod
+    def from_model(run: Run) -> "RunResponse":
+        """Convert a domain Run to a response schema."""
+        return RunResponse(
+            id=run.id,
+            project_id=run.project_id,
+            workspace_id=run.workspace_id,
+            status=run.status.value,
+            output=run.output,
+            error=run.error,
+            started_at=run.started_at,
+            completed_at=run.completed_at,
+            created_at=run.created_at,
+            updated_at=run.updated_at,
+        )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -10,10 +10,11 @@ from httpx import ASGITransport, AsyncClient
 from openfactcheck.api.app import create_app
 from openfactcheck.api.auth.cognito import DEV_USER
 from openfactcheck.api.config import APIConfig
-from openfactcheck.api.dependencies import get_current_user, get_project_repo, get_workspace_repo
+from openfactcheck.api.dependencies import get_current_user, get_project_repo, get_run_repo, get_workspace_repo
 from openfactcheck.api.models import AuthUser
 from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
 from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+from openfactcheck.api.repositories.sqlite.runs import SqliteRunRepository
 from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
 
 TEST_USER = DEV_USER
@@ -26,6 +27,7 @@ async def client() -> AsyncIterator[AsyncClient]:
     sf = session_factory(engine)
     project_repo = SqliteProjectRepository(sf)
     workspace_repo = SqliteWorkspaceRepository(sf)
+    run_repo = SqliteRunRepository(sf)
 
     config = APIConfig(auth_bypass=True)
     app = create_app(config)
@@ -39,9 +41,13 @@ async def client() -> AsyncIterator[AsyncClient]:
     async def override_workspace_repo() -> SqliteWorkspaceRepository:
         return workspace_repo
 
+    async def override_run_repo() -> SqliteRunRepository:
+        return run_repo
+
     app.dependency_overrides[get_current_user] = override_current_user
     app.dependency_overrides[get_project_repo] = override_project_repo
     app.dependency_overrides[get_workspace_repo] = override_workspace_repo
+    app.dependency_overrides[get_run_repo] = override_run_repo
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac

--- a/tests/api/test_runs.py
+++ b/tests/api/test_runs.py
@@ -1,0 +1,169 @@
+"""Tests for run endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+PROJECTS_BASE = "/api/v1/projects"
+
+SAMPLE_PIPELINE: dict[str, Any] = {
+    "blocks": {
+        "blocks": [
+            {
+                "type": "text_print",
+                "id": "print-1",
+                "inputs": {
+                    "TEXT": {
+                        "block": {
+                            "type": "text",
+                            "id": "text-1",
+                            "fields": {"TEXT": "Hello World"},
+                        },
+                    },
+                },
+            },
+        ],
+    },
+}
+
+
+async def _create_project(client: AsyncClient, name: str = "Test Project") -> str:
+    response = await client.post(f"{PROJECTS_BASE}/", json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+async def _create_workspace(client: AsyncClient, project_id: str, name: str = "Test WS") -> str:
+    response = await client.post(f"{PROJECTS_BASE}/{project_id}/workspaces/", json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _runs_base(project_id: str) -> str:
+    return f"{PROJECTS_BASE}/{project_id}/runs"
+
+
+async def _create_run(client: AsyncClient, project_id: str, workspace_id: str) -> dict[str, Any]:
+    response = await client.post(
+        f"{_runs_base(project_id)}/",
+        json={"workspace_id": workspace_id, "pipeline": SAMPLE_PIPELINE},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# POST /runs
+# ---------------------------------------------------------------------------
+
+
+async def test_create_run(client: AsyncClient) -> None:
+    """POST creates a run with pending status and returns 201."""
+    pid = await _create_project(client)
+    wid = await _create_workspace(client, pid)
+
+    body = await _create_run(client, pid, wid)
+
+    assert body["project_id"] == pid
+    assert body["workspace_id"] == wid
+    assert body["status"] == "pending"
+    assert body["output"] is None
+    assert body["error"] is None
+
+
+async def test_create_run_executes_locally(client: AsyncClient) -> None:
+    """Run executes in background and completes with output."""
+    pid = await _create_project(client)
+    wid = await _create_workspace(client, pid)
+
+    body = await _create_run(client, pid, wid)
+    run_id = body["id"]
+
+    # Give the background task time to complete
+    await asyncio.sleep(0.1)
+
+    response = await client.get(f"{_runs_base(pid)}/{run_id}")
+    assert response.status_code == 200
+    result = response.json()
+
+    assert result["status"] == "completed"
+    assert result["output"] == "Hello World"
+    assert result["error"] is None
+    assert result["started_at"] is not None
+    assert result["completed_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# GET /runs/{run_id}
+# ---------------------------------------------------------------------------
+
+
+async def test_get_run(client: AsyncClient) -> None:
+    """GET returns a run by ID."""
+    pid = await _create_project(client)
+    wid = await _create_workspace(client, pid)
+    created = await _create_run(client, pid, wid)
+
+    response = await client.get(f"{_runs_base(pid)}/{created['id']}")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == created["id"]
+
+
+async def test_get_run_not_found(client: AsyncClient) -> None:
+    """GET returns 404 for nonexistent run."""
+    pid = await _create_project(client)
+
+    response = await client.get(f"{_runs_base(pid)}/does-not-exist")
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /runs
+# ---------------------------------------------------------------------------
+
+
+async def test_list_runs(client: AsyncClient) -> None:
+    """GET /runs lists all runs for a project."""
+    pid = await _create_project(client)
+    wid = await _create_workspace(client, pid)
+    await _create_run(client, pid, wid)
+    await _create_run(client, pid, wid)
+
+    response = await client.get(f"{_runs_base(pid)}/")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+async def test_list_runs_empty(client: AsyncClient) -> None:
+    """GET /runs returns empty list when no runs exist."""
+    pid = await _create_project(client)
+
+    response = await client.get(f"{_runs_base(pid)}/")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_list_runs_filter_by_workspace(client: AsyncClient) -> None:
+    """GET /runs?workspace_id= filters by workspace."""
+    pid = await _create_project(client)
+    wid1 = await _create_workspace(client, pid, "WS 1")
+    wid2 = await _create_workspace(client, pid, "WS 2")
+    await _create_run(client, pid, wid1)
+    await _create_run(client, pid, wid2)
+
+    response = await client.get(f"{_runs_base(pid)}/", params={"workspace_id": wid1})
+
+    assert response.status_code == 200
+    runs = response.json()
+    assert len(runs) == 1
+    assert runs[0]["workspace_id"] == wid1


### PR DESCRIPTION
Endpoints:
- POST /api/v1/projects/{pid}/runs — create and execute a pipeline run
- GET /api/v1/projects/{pid}/runs/{rid} — poll run status/results
- GET /api/v1/projects/{pid}/runs — list runs, optional workspace_id filter

Execution:
- Local mode: asyncio.create_task runs the engine in-process
- Cloud mode: SQS dispatch placeholder (Phase 1g)

Files:
- api/schemas/runs.py — CreateRunRequest, RunResponse
- api/routers/runs.py — endpoints + _execute_and_update background task
- api/dependencies.py — get_run_repo() with mode-based switching
- api/app.py — runs router registered on v1
- 7 API integration tests (create, execute, get, not found, list, filter)