### PR TITLE
refactor: Block class, parser separation, engine docstrings

### DIFF
--- a/src/openfactcheck/api/app.py
+++ b/src/openfactcheck/api/app.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, FastAPI
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.dependencies import get_config
 from openfactcheck.api.middleware import register_middleware
-from openfactcheck.api.routers import health, projects, workspaces, runs
+from openfactcheck.api.routers import health, projects, runs, workspaces
 
 
 def create_app(config: APIConfig | None = None) -> FastAPI:

--- a/src/openfactcheck/engine/__init__.py
+++ b/src/openfactcheck/engine/__init__.py
@@ -1,7 +1,8 @@
 """Graph execution engine — interprets Blockly workspace JSON and executes block handlers."""
 
 import openfactcheck.engine.handlers as handlers  # noqa: F401 — auto-registers all block handlers
+from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import EngineError, UnknownBlockError
 from openfactcheck.engine.executor import ExecutionResult, execute_pipeline
 
-__all__ = ["EngineError", "ExecutionResult", "UnknownBlockError", "execute_pipeline", "handlers"]
+__all__ = ["Block", "EngineError", "ExecutionResult", "UnknownBlockError", "execute_pipeline", "handlers"]

--- a/src/openfactcheck/engine/block.py
+++ b/src/openfactcheck/engine/block.py
@@ -1,0 +1,111 @@
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+"""Typed wrapper around a raw Blockly block dict.
+
+This is the JSON boundary layer for the engine. Raw ``dict[str, Any]`` from
+Blockly workspace serialization is parsed once on construction. After that,
+all access is through typed attributes and methods — no raw dict access leaks
+into the rest of the engine.
+
+Blockly block JSON structure::
+
+    {
+        "type": "text_print",
+        "id": "abc123",
+        "fields": {"TEXT": "hello"},
+        "inputs": {
+            "TEXT": {
+                "block": {"type": "text", "id": "xyz", "fields": {"TEXT": "world"}}
+            }
+        },
+        "next": {
+            "block": {"type": "text_print", "id": "def456", ...}
+        }
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Block:
+    """A single Blockly block with typed access to fields, inputs, and connections.
+
+    Attributes:
+        type: Block type identifier (e.g. ``'text_print'``, ``'text'``).
+        id: Unique block instance ID assigned by Blockly.
+    """
+
+    __slots__ = ("type", "id", "_fields", "_inputs", "_next_data")
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.type: str = str(data.get("type", ""))
+        self.id: str = str(data.get("id", ""))
+        self._fields: dict[str, str] = _parse_fields(data)
+        self._inputs: dict[str, dict[str, Any]] = _parse_inputs(data)
+        self._next_data: dict[str, Any] | None = _parse_next(data)
+
+    def get_field(self, name: str, default: str = "") -> str:
+        """Read a static field value from the block.
+
+        Fields are simple key-value pairs set directly on the block
+        (e.g. the text content in a ``text`` block).
+        """
+        return self._fields.get(name, default)
+
+    def get_input_block(self, name: str) -> Block | None:
+        """Get the block connected to a named value input.
+
+        Value inputs are connection points where another block plugs in
+        to provide a computed value (e.g. the ``TEXT`` input on ``text_print``).
+
+        Returns ``None`` if no block is connected to this input.
+        """
+        input_data = self._inputs.get(name)
+        if input_data is None:
+            return None
+        block_data = input_data.get("block")
+        if not isinstance(block_data, dict):
+            return None
+        return Block(block_data)
+
+    @property
+    def next(self) -> Block | None:
+        """The next block in the statement chain.
+
+        Statement blocks connect vertically — each block's ``next`` points
+        to the block below it. Returns ``None`` at the end of a chain.
+        """
+        if self._next_data is None:
+            return None
+        block_data = self._next_data.get("block")
+        if not isinstance(block_data, dict):
+            return None
+        return Block(block_data)
+
+    def __repr__(self) -> str:
+        return f"Block(type={self.type!r}, id={self.id!r})"
+
+
+def _parse_fields(data: dict[str, Any]) -> dict[str, str]:
+    """Extract ``fields`` as a ``{name: value}`` string dict."""
+    raw = data.get("fields")
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _parse_inputs(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Extract ``inputs`` as a ``{name: input_data}`` dict, filtering non-dicts."""
+    raw = data.get("inputs")
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): v for k, v in raw.items() if isinstance(v, dict)}
+
+
+def _parse_next(data: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract the ``next`` connection data, or ``None`` if absent."""
+    raw = data.get("next")
+    if isinstance(raw, dict):
+        return raw
+    return None

--- a/src/openfactcheck/engine/context.py
+++ b/src/openfactcheck/engine/context.py
@@ -1,32 +1,59 @@
-"""Execution context — carries state through a pipeline run."""
+"""Execution context and engine errors.
+
+:class:`ExecutionContext` is the mutable state object passed to every block
+handler during a pipeline run. It provides:
+
+- **Output capture** — :meth:`~ExecutionContext.print` collects output lines
+  (with truncation at :data:`MAX_OUTPUT_BYTES`).
+- **Variable storage** — ``variables`` dict for blocks that set/get variables.
+- **Block dispatch** — :meth:`~ExecutionContext.execute_block` looks up a block's
+  handler and runs it, enabling recursive execution of connected blocks.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any
 
 from openfactcheck.api.repositories.constants import MAX_OUTPUT_BYTES
 from openfactcheck.engine.handler import BLOCK_HANDLERS
 
+if TYPE_CHECKING:
+    from openfactcheck.engine.block import Block
+
 
 class EngineError(Exception):
-    """Base error for engine execution failures."""
+    """Base exception for all engine execution failures.
+
+    Caught by :func:`~openfactcheck.engine.executor.execute_pipeline` and
+    converted to a failed :class:`~openfactcheck.engine.executor.ExecutionResult`.
+    """
 
 
 class UnknownBlockError(EngineError):
-    """Raised when a block type has no registered handler."""
+    """Raised when a block type has no registered handler.
+
+    This typically means a block was added to the frontend toolbox
+    but no corresponding :class:`~openfactcheck.engine.handler.BlockHandler`
+    subclass exists on the server.
+    """
 
     def __init__(self, block_type: str) -> None:
         super().__init__(f"No handler for block type: {block_type}")
         self.block_type = block_type
 
 
-BlockDict = dict[str, Any]
-
-
 @dataclass
 class ExecutionContext:
-    """Mutable state passed to every block handler during execution."""
+    """Mutable state passed to every block handler during execution.
+
+    Created once per pipeline run by the executor. Handlers read/write
+    through this context rather than managing their own state.
+
+    Attributes:
+        output_lines: Captured print output, one string per line.
+        variables: Shared variable storage for ``variables_set``/``variables_get`` blocks.
+    """
 
     output_lines: list[str] = field(default_factory=lambda: [])
     variables: dict[str, Any] = field(default_factory=lambda: {})
@@ -34,7 +61,11 @@ class ExecutionContext:
     _truncated: bool = False
 
     def print(self, text: str) -> None:
-        """Capture a print output line, respecting the output size limit."""
+        """Capture a line of output from a print block.
+
+        Respects :data:`MAX_OUTPUT_BYTES` — once the limit is reached, a
+        ``[output truncated]`` marker is appended and all further prints are silently dropped.
+        """
         if self._truncated:
             return
         line = str(text)
@@ -46,39 +77,17 @@ class ExecutionContext:
         self._output_bytes += line_bytes
         self.output_lines.append(line)
 
-    def resolve_input(self, block: BlockDict, input_name: str, default: Any = None) -> Any:  # noqa: ANN401
-        """Resolve a value input by executing the connected block."""
-        inputs = get_dict(block, "inputs")
-        if inputs is None:
-            return default
-        input_data = get_dict(inputs, input_name)
-        if input_data is None:
-            return default
-        connected_block = get_dict(input_data, "block")
-        if connected_block is None:
-            return default
-        return execute_block(connected_block, self)
+    def execute_block(self, block: Block) -> Any:  # noqa: ANN401
+        """Dispatch a block to its registered handler and return the result.
 
-    def resolve_field(self, block: BlockDict, field_name: str, default: Any = None) -> Any:  # noqa: ANN401
-        """Read a field value directly from the block."""
-        fields = get_dict(block, "fields")
-        if fields is None:
-            return default
-        return fields.get(field_name, default)
+        This is how handlers execute connected child blocks — e.g. a
+        ``text_print`` handler calls ``ctx.execute_block(input_block)``
+        to evaluate the text value plugged into its input.
 
-
-def get_dict(source: BlockDict, key: str) -> BlockDict | None:
-    """Safely extract a nested dict from a block dict. Returns None if missing or wrong type."""
-    value: object = source.get(key)
-    if isinstance(value, dict):
-        return cast(BlockDict, value)
-    return None
-
-
-def execute_block(block: BlockDict, ctx: ExecutionContext) -> Any:  # noqa: ANN401
-    """Execute a single block and return its value."""
-    block_type: str = str(block.get("type", ""))
-    handler = BLOCK_HANDLERS.get(block_type)
-    if handler is None:
-        raise UnknownBlockError(block_type)
-    return handler.execute(block, ctx)
+        Raises:
+            UnknownBlockError: If no handler is registered for ``block.type``.
+        """
+        handler = BLOCK_HANDLERS.get(block.type)
+        if handler is None:
+            raise UnknownBlockError(block.type)
+        return handler.execute(block, self)

--- a/src/openfactcheck/engine/executor.py
+++ b/src/openfactcheck/engine/executor.py
@@ -1,51 +1,71 @@
-"""Graph executor — walks Blockly workspace JSON and runs block handlers."""
+"""Pipeline executor — the top-level entry point for running a Blockly workspace.
+
+Flow::
+
+    execute_pipeline(workspace_json)
+        → parse_pipeline → list[Block]
+        → for each top-level block:
+            _execute_block_chain(block, ctx)
+                → ctx.execute_block(block)  (dispatches to handler)
+                → follow block.next recursively
+        → collect output → ExecutionResult
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
-from openfactcheck.engine.context import BlockDict, EngineError, ExecutionContext, execute_block, get_dict
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import EngineError, ExecutionContext
+from openfactcheck.engine.parser import parse_pipeline
 
 
 @dataclass
 class ExecutionResult:
-    """Result of a pipeline execution."""
+    """Outcome of a pipeline execution.
+
+    Attributes:
+        success: ``True`` if the pipeline completed without engine errors.
+        output: Captured stdout (newline-joined print output).
+        error: Error message if ``success`` is ``False``, otherwise ``None``.
+    """
 
     success: bool
     output: str
     error: str | None = None
 
 
-def _execute_block_chain(block: BlockDict, ctx: ExecutionContext) -> None:
-    """Execute a block and all its 'next' connected blocks."""
-    execute_block(block, ctx)
-    next_data = get_dict(block, "next")
-    if next_data is None:
-        return
-    next_block = get_dict(next_data, "block")
+def _execute_block_chain(block: Block, ctx: ExecutionContext) -> None:
+    """Execute a block and follow the ``next`` chain until the end.
+
+    This handles Blockly's statement connection model — blocks stack
+    vertically and execute top-to-bottom.
+    """
+    ctx.execute_block(block)
+    next_block = block.next
     if next_block is not None:
         _execute_block_chain(next_block, ctx)
 
 
-async def execute_pipeline(pipeline: BlockDict) -> ExecutionResult:
-    """Execute a Blockly workspace JSON.
+async def execute_pipeline(pipeline: dict[str, Any]) -> ExecutionResult:
+    """Execute a Blockly workspace JSON end-to-end.
 
-    Walks all top-level block chains, executing each block via its registered handler.
+    1. Parses the workspace JSON into a list of top-level :class:`Block` objects.
+    2. Walks each block chain, executing handlers via the :class:`ExecutionContext`.
+    3. Returns an :class:`ExecutionResult` with captured output or error.
+
+    Any :class:`EngineError` raised during execution is caught and returned
+    as a failed result. Other exceptions propagate to the caller.
     """
     ctx = ExecutionContext()
     try:
-        blocks_data = get_dict(pipeline, "blocks")
-        if blocks_data is None:
+        blocks = parse_pipeline(pipeline)
+        if not blocks:
             return ExecutionResult(success=True, output="")
 
-        top_level_blocks: object = blocks_data.get("blocks")
-        if not isinstance(top_level_blocks, list):
-            return ExecutionResult(success=True, output="")
-
-        for item in cast(list[Any], top_level_blocks):
-            if isinstance(item, dict):
-                _execute_block_chain(cast(BlockDict, item), ctx)
+        for block in blocks:
+            _execute_block_chain(block, ctx)
 
         return ExecutionResult(
             success=True,

--- a/src/openfactcheck/engine/handler.py
+++ b/src/openfactcheck/engine/handler.py
@@ -1,4 +1,15 @@
-"""Block handler registry — ABC base class with auto-registration via __init_subclass__."""
+"""Block handler base class with auto-registration.
+
+New handlers are created by subclassing :class:`BlockHandler` and setting
+``block_type``. Registration into :data:`BLOCK_HANDLERS` is automatic via
+``__init_subclass__`` — no decorator or manual registration needed::
+
+    class TextPrintHandler(BlockHandler):
+        block_type = "text_print"
+
+        def execute(self, block: Block, ctx: ExecutionContext) -> None:
+            ctx.print(block.get_field("TEXT"))
+"""
 
 from __future__ import annotations
 
@@ -6,16 +17,23 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
+    from openfactcheck.engine.block import Block
     from openfactcheck.engine.context import ExecutionContext
 
 BLOCK_HANDLERS: dict[str, BlockHandler] = {}
+"""Global registry mapping block type strings to handler instances."""
 
 
 class BlockHandler(ABC):
     """Base class for all block handlers.
 
-    Subclasses must define ``block_type`` and implement ``execute``.
-    Registration is automatic — subclassing is enough.
+    Subclasses must:
+        1. Set ``block_type`` as a class variable (the Blockly block type string).
+        2. Implement :meth:`execute` to define the block's behavior.
+
+    A singleton instance is created and registered automatically when the
+    subclass is defined (via ``__init_subclass__``). Handlers must be stateless
+    — the same instance is reused across all runs.
     """
 
     block_type: ClassVar[str]
@@ -26,6 +44,16 @@ class BlockHandler(ABC):
             BLOCK_HANDLERS[cls.block_type] = cls()
 
     @abstractmethod
-    def execute(self, block: dict[str, Any], ctx: ExecutionContext) -> Any:  # noqa: ANN401
-        """Execute the block and return its value (if any)."""
+    def execute(self, block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
+        """Execute the block and return its output value.
+
+        Args:
+            block: The parsed Blockly block with typed field/input access.
+            ctx: Mutable execution context for output capture, variable storage,
+                 and dispatching child block execution.
+
+        Returns:
+            The block's output value (used by parent blocks via value inputs),
+            or ``None`` for statement-only blocks like ``text_print``.
+        """
         ...

--- a/src/openfactcheck/engine/handlers/text.py
+++ b/src/openfactcheck/engine/handlers/text.py
@@ -1,27 +1,43 @@
-"""Text block handlers — text_print and text."""
+"""Text block handlers.
+
+Handles Blockly's built-in text blocks:
+
+- ``text_print`` — Statement block that prints a value to the output.
+- ``text`` — Value block that returns a string literal.
+"""
 
 from __future__ import annotations
 
-from typing import Any
-
+from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
 from openfactcheck.engine.handler import BlockHandler
 
 
 class TextPrintHandler(BlockHandler):
-    """Print block — outputs the connected text value."""
+    """``text_print`` — prints the value connected to the TEXT input.
+
+    Blockly structure::
+
+        text_print
+        └─ TEXT (value input) → connected block's return value is printed
+    """
 
     block_type = "text_print"
 
-    def execute(self, block: dict[str, Any], ctx: ExecutionContext) -> None:
-        value = ctx.resolve_input(block, "TEXT", default="")
+    def execute(self, block: Block, ctx: ExecutionContext) -> None:
+        input_block = block.get_input_block("TEXT")
+        value = ctx.execute_block(input_block) if input_block else ""
         ctx.print(str(value))
 
 
 class TextHandler(BlockHandler):
-    """Text literal block — returns the field value."""
+    """``text`` — returns the string stored in the TEXT field.
+
+    This is Blockly's basic string literal block. It has no inputs —
+    just a single field containing the user's text.
+    """
 
     block_type = "text"
 
-    def execute(self, block: dict[str, Any], ctx: ExecutionContext) -> str:
-        return ctx.resolve_field(block, "TEXT", default="")
+    def execute(self, block: Block, ctx: ExecutionContext) -> str:
+        return block.get_field("TEXT", default="")

--- a/src/openfactcheck/engine/parser.py
+++ b/src/openfactcheck/engine/parser.py
@@ -1,0 +1,38 @@
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+"""Blockly workspace JSON parser — extracts top-level blocks from workspace state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openfactcheck.engine.block import Block
+
+
+def parse_pipeline(pipeline: dict[str, Any]) -> list[Block]:
+    """Extract the top-level block list from a Blockly workspace JSON.
+
+    Handles both formats:
+        - Real Blockly: ``{ blocks: { blocks: { language_version, blocks: [...] } } }``
+        - Flat:         ``{ blocks: { blocks: [...] } }``
+
+    Returns an empty list if the pipeline has no blocks.
+    """
+    blocks_wrapper = pipeline.get("blocks")
+    if not isinstance(blocks_wrapper, dict):
+        return []
+
+    blocks_inner = blocks_wrapper.get("blocks")
+
+    # Real Blockly format: blocks_inner is a dict with language_version + blocks list
+    if isinstance(blocks_inner, dict):
+        raw_blocks = blocks_inner.get("blocks")
+    # Flat format: blocks_inner is already the list
+    elif isinstance(blocks_inner, list):
+        raw_blocks = blocks_inner
+    else:
+        return []
+
+    if not isinstance(raw_blocks, list):
+        return []
+
+    return [Block(item) for item in raw_blocks if isinstance(item, dict)]

--- a/tests/engine/test_executor.py
+++ b/tests/engine/test_executor.py
@@ -10,8 +10,13 @@ pytestmark = pytest.mark.asyncio(loop_scope="function")
 
 
 def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
-    """Build a minimal Blockly workspace JSON."""
+    """Build a minimal Blockly workspace JSON (flat format)."""
     return {"blocks": {"blocks": list(blocks)}}
+
+
+def _pipeline_real(*blocks: dict[str, Any]) -> dict[str, Any]:
+    """Build a Blockly workspace JSON matching real serialization format."""
+    return {"blocks": {"blocks": {"language_version": 0, "blocks": list(blocks)}}}
 
 
 def _text_print(text: str, next_block: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -90,6 +95,16 @@ async def test_execute_pipeline_text_print(text: str, expected: str) -> None:
 
     assert result.success is True
     assert result.output == expected
+
+
+async def test_execute_pipeline_real_blockly_format() -> None:
+    """Real Blockly serialization format with language_version wrapper works."""
+    pipeline = _pipeline_real(_text_print("Hello from Blockly"))
+
+    result = await execute_pipeline(pipeline)
+
+    assert result.success is True
+    assert result.output == "Hello from Blockly"
 
 
 async def test_execute_pipeline_text_print_no_input() -> None:


### PR DESCRIPTION
- Block class — typed wrapper replacing raw dict access with get_field(), get_input_block(), .next, .type. Parses JSON once on construction.
- Parser extracted from executor — parse_pipeline() handles both Blockly serialization formats (flat + language_version wrapper)
- BlockHandler.execute() now receives Block instead of dict
- ExecutionContext.execute_block() dispatches via Block.type
- Comprehensive docstrings on all engine modules
- Pyright strict on all files except JSON boundary (block.py, parser.py)