### PR TITLE
feat: Phase 2 standard block handlers + function-based refactor

### DIFF
--- a/src/openfactcheck/engine/__init__.py
+++ b/src/openfactcheck/engine/__init__.py
@@ -2,7 +2,7 @@
 
 import openfactcheck.engine.handlers as handlers  # noqa: F401 — auto-registers all block handlers
 from openfactcheck.engine.block import Block
-from openfactcheck.engine.context import EngineError, UnknownBlockError
+from openfactcheck.engine.errors import EngineError, UnknownBlockError
 from openfactcheck.engine.executor import ExecutionResult, execute_pipeline
 
 __all__ = ["Block", "EngineError", "ExecutionResult", "UnknownBlockError", "execute_pipeline", "handlers"]

--- a/src/openfactcheck/engine/context.py
+++ b/src/openfactcheck/engine/context.py
@@ -1,7 +1,6 @@
-"""Execution context and engine errors.
+"""Execution context — mutable state passed to every block handler.
 
-:class:`ExecutionContext` is the mutable state object passed to every block
-handler during a pipeline run. It provides:
+:class:`ExecutionContext` provides:
 
 - **Output capture** — :meth:`~ExecutionContext.print` collects output lines
   (with truncation at :data:`MAX_OUTPUT_BYTES`).
@@ -15,33 +14,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from openfactcheck.engine.handler import BLOCK_HANDLERS
+from openfactcheck.engine.errors import UnknownBlockError
+from openfactcheck.engine.handler import HANDLERS  # noqa: TC001 — runtime import, not type-only
 
 MAX_OUTPUT_BYTES = 65_536
 
 if TYPE_CHECKING:
     from openfactcheck.engine.block import Block
-
-
-class EngineError(Exception):
-    """Base exception for all engine execution failures.
-
-    Caught by :func:`~openfactcheck.engine.executor.execute_pipeline` and
-    converted to a failed :class:`~openfactcheck.engine.executor.ExecutionResult`.
-    """
-
-
-class UnknownBlockError(EngineError):
-    """Raised when a block type has no registered handler.
-
-    This typically means a block was added to the frontend toolbox
-    but no corresponding :class:`~openfactcheck.engine.handler.BlockHandler`
-    subclass exists on the server.
-    """
-
-    def __init__(self, block_type: str) -> None:
-        super().__init__(f"No handler for block type: {block_type}")
-        self.block_type = block_type
 
 
 @dataclass
@@ -81,14 +60,10 @@ class ExecutionContext:
     def execute_block(self, block: Block) -> Any:  # noqa: ANN401
         """Dispatch a block to its registered handler and return the result.
 
-        This is how handlers execute connected child blocks — e.g. a
-        ``text_print`` handler calls ``ctx.execute_block(input_block)``
-        to evaluate the text value plugged into its input.
-
         Raises:
             UnknownBlockError: If no handler is registered for ``block.type``.
         """
-        handler = BLOCK_HANDLERS.get(block.type)
-        if handler is None:
+        handler_fn = HANDLERS.get(block.type)
+        if handler_fn is None:
             raise UnknownBlockError(block.type)
-        return handler.execute(block, self)
+        return handler_fn(block, self)

--- a/src/openfactcheck/engine/errors.py
+++ b/src/openfactcheck/engine/errors.py
@@ -1,0 +1,24 @@
+"""Engine error types."""
+
+from __future__ import annotations
+
+
+class EngineError(Exception):
+    """Base exception for all engine execution failures.
+
+    Caught by :func:`~openfactcheck.engine.executor.execute_pipeline` and
+    converted to a failed :class:`~openfactcheck.engine.executor.ExecutionResult`.
+    """
+
+
+class UnknownBlockError(EngineError):
+    """Raised when a block type has no registered handler.
+
+    This typically means a block was added to the frontend toolbox
+    but no corresponding handler function has been registered
+    on the server.
+    """
+
+    def __init__(self, block_type: str) -> None:
+        super().__init__(f"No handler for block type: {block_type}")
+        self.block_type = block_type

--- a/src/openfactcheck/engine/executor.py
+++ b/src/openfactcheck/engine/executor.py
@@ -17,7 +17,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from openfactcheck.engine.block import Block
-from openfactcheck.engine.context import EngineError, ExecutionContext
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.errors import EngineError
 from openfactcheck.engine.parser import parse_pipeline
 
 

--- a/src/openfactcheck/engine/handler.py
+++ b/src/openfactcheck/engine/handler.py
@@ -1,59 +1,43 @@
-"""Block handler base class with auto-registration.
+"""Block handler registration via decorator.
 
-New handlers are created by subclassing :class:`BlockHandler` and setting
-``block_type``. Registration into :data:`BLOCK_HANDLERS` is automatic via
-``__init_subclass__`` — no decorator or manual registration needed::
+Register a handler by decorating a function with ``@handler``::
 
-    class TextPrintHandler(BlockHandler):
-        block_type = "text_print"
+    @handler("text_print")
+    def text_print(block: Block, ctx: ExecutionContext) -> None:
+        ctx.print(resolve.string(block, ctx, "TEXT"))
 
-        def execute(self, block: Block, ctx: ExecutionContext) -> None:
-            ctx.print(block.get_field("TEXT"))
+Handlers are registered at import time — importing the module is
+sufficient to make the handler available.
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from openfactcheck.engine.block import Block
     from openfactcheck.engine.context import ExecutionContext
 
-BLOCK_HANDLERS: dict[str, BlockHandler] = {}
-"""Global registry mapping block type strings to handler instances."""
+    type HandlerFn = Callable[[Block, ExecutionContext], Any]
+
+HANDLERS: dict[str, HandlerFn] = {}
+"""Global registry mapping block type strings to handler functions."""
 
 
-class BlockHandler(ABC):
-    """Base class for all block handlers.
+def handler(block_type: str) -> Callable[[HandlerFn], HandlerFn]:
+    """Decorator that registers a function as a block handler.
 
-    Subclasses must:
-        1. Set ``block_type`` as a class variable (the Blockly block type string).
-        2. Implement :meth:`execute` to define the block's behavior.
+    Args:
+        block_type: The Blockly block type string (e.g. ``"text_print"``).
 
-    A singleton instance is created and registered automatically when the
-    subclass is defined (via ``__init_subclass__``). Handlers must be stateless
-    — the same instance is reused across all runs.
+    Returns:
+        The unmodified function, now registered in :data:`HANDLERS`.
     """
 
-    block_type: ClassVar[str]
+    def decorator(fn: HandlerFn) -> HandlerFn:
+        HANDLERS[block_type] = fn
+        return fn
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        if hasattr(cls, "block_type") and isinstance(cls.__dict__.get("block_type"), str):
-            BLOCK_HANDLERS[cls.block_type] = cls()
-
-    @abstractmethod
-    def execute(self, block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
-        """Execute the block and return its output value.
-
-        Args:
-            block: The parsed Blockly block with typed field/input access.
-            ctx: Mutable execution context for output capture, variable storage,
-                 and dispatching child block execution.
-
-        Returns:
-            The block's output value (used by parent blocks via value inputs),
-            or ``None`` for statement-only blocks like ``text_print``.
-        """
-        ...
+    return decorator

--- a/src/openfactcheck/engine/handlers/__init__.py
+++ b/src/openfactcheck/engine/handlers/__init__.py
@@ -1,5 +1,10 @@
 """Block handlers — import all handler modules to auto-register them."""
 
+import openfactcheck.engine.handlers.lists as lists  # noqa: F401
+import openfactcheck.engine.handlers.logic as logic  # noqa: F401
+import openfactcheck.engine.handlers.loops as loops  # noqa: F401
+import openfactcheck.engine.handlers.math as math  # noqa: F401
 import openfactcheck.engine.handlers.text as text  # noqa: F401
+import openfactcheck.engine.handlers.variables as variables  # noqa: F401
 
-__all__ = ["text"]
+__all__ = ["lists", "logic", "loops", "math", "text", "variables"]

--- a/src/openfactcheck/engine/handlers/lists.py
+++ b/src/openfactcheck/engine/handlers/lists.py
@@ -1,0 +1,162 @@
+"""List block handlers — ``lists_create_with``, ``lists_sort``, etc."""
+
+from __future__ import annotations
+
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+
+@handler("lists_create_with")
+def lists_create_with(block: Block, ctx: ExecutionContext) -> list[object]:
+    """Create a list from ADD0, ADD1, ... inputs."""
+    return resolve.collect_inputs(block, ctx, "ADD")
+
+
+@handler("lists_repeat")
+def lists_repeat(block: Block, ctx: ExecutionContext) -> list[object]:
+    """Create a list by repeating ITEM, NUM times."""
+    return [resolve.value(block, ctx, "ITEM")] * resolve.integer(block, ctx, "NUM")
+
+
+@handler("lists_length")
+def lists_length(block: Block, ctx: ExecutionContext) -> int:
+    """Return the length of the VALUE input list."""
+    return len(resolve.items(block, ctx, "VALUE"))
+
+
+@handler("lists_isEmpty")
+def lists_is_empty(block: Block, ctx: ExecutionContext) -> bool:
+    """Return True if the VALUE input list is empty."""
+    return len(resolve.items(block, ctx, "VALUE")) == 0
+
+
+@handler("lists_indexOf")
+def lists_index_of(block: Block, ctx: ExecutionContext) -> int:
+    """Find the index of FIND in the list. Returns 0 if not found (1-based)."""
+    end = block.get_field("END", default="FIRST")
+    items = resolve.items(block, ctx, "VALUE")
+    find = resolve.value(block, ctx, "FIND")
+
+    if end == "FIRST":
+        try:
+            return items.index(find) + 1
+        except ValueError:
+            return 0
+    for i in range(len(items) - 1, -1, -1):
+        if items[i] == find:
+            return i + 1
+    return 0
+
+
+@handler("lists_getIndex")
+def lists_get_index(block: Block, ctx: ExecutionContext) -> object:
+    """Get/remove an element. MODE: GET, GET_REMOVE, REMOVE. WHERE: FROM_START, FROM_END, FIRST, LAST, RANDOM."""
+    mode = block.get_field("MODE", default="GET")
+    items = resolve.items(block, ctx, "VALUE")
+    if not items:
+        return None
+    idx = _list_index(block, ctx, items)
+    if idx < 0 or idx >= len(items):
+        return None
+    if mode == "GET":
+        return items[idx]
+    if mode == "GET_REMOVE":
+        return items.pop(idx)
+    items.pop(idx)
+    return None
+
+
+@handler("lists_setIndex")
+def lists_set_index(block: Block, ctx: ExecutionContext) -> None:
+    """Set or insert an element. MODE: SET, INSERT."""
+    mode = block.get_field("MODE", default="SET")
+    items = resolve.items(block, ctx, "LIST")
+    val = resolve.value(block, ctx, "TO")
+    if not items:
+        return
+    idx = _list_index(block, ctx, items)
+    if mode == "SET" and 0 <= idx < len(items):
+        items[idx] = val
+    elif mode == "INSERT":
+        items.insert(max(0, idx), val)
+
+
+@handler("lists_getSublist")
+def lists_get_sublist(block: Block, ctx: ExecutionContext) -> list[object]:
+    """Extract a sublist from LIST."""
+    items = resolve.items(block, ctx, "LIST")
+    if not items:
+        return []
+    start = _list_index_range(block, ctx, items, "WHERE1", "AT1")
+    end = _list_index_range(block, ctx, items, "WHERE2", "AT2")
+    return items[start : end + 1]
+
+
+@handler("lists_sort")
+def lists_sort(block: Block, ctx: ExecutionContext) -> list[object]:
+    """Sort a list. TYPE: NUMERIC, TEXT, IGNORE_CASE. DIRECTION: 1 or -1."""
+    sort_type = block.get_field("TYPE", default="NUMERIC")
+    reverse = block.get_field("DIRECTION", default="1") == "-1"
+    result = list(resolve.items(block, ctx, "LIST"))
+
+    key_fn = _sort_numeric
+    if sort_type == "TEXT":
+        key_fn = _sort_text
+    elif sort_type == "IGNORE_CASE":
+        key_fn = _sort_ignore_case
+    result.sort(key=key_fn, reverse=reverse)
+    return result
+
+
+@handler("lists_reverse")
+def lists_reverse(block: Block, ctx: ExecutionContext) -> list[object]:
+    """Reverse a list."""
+    return list(reversed(resolve.items(block, ctx, "LIST")))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_index(block: Block, ctx: ExecutionContext, items: list[object]) -> int:
+    """Resolve a list index from WHERE field + AT input."""
+    where = block.get_field("WHERE", default="FROM_START")
+    if where == "FIRST":
+        return 0
+    if where == "LAST":
+        return len(items) - 1
+    if where == "RANDOM":
+        import random
+
+        return random.randrange(len(items)) if items else 0
+    at = resolve.integer(block, ctx, "AT", default=1)
+    return (at - 1) if where == "FROM_START" else (len(items) - at)
+
+
+def _list_index_range(block: Block, ctx: ExecutionContext, items: list[object], where_field: str, at_input: str) -> int:
+    """Resolve a sublist index."""
+    where = block.get_field(where_field, default="FROM_START")
+    if where == "FIRST":
+        return 0
+    if where == "LAST":
+        return len(items) - 1
+    at = resolve.integer(block, ctx, at_input, default=1)
+    return max(0, at - 1) if where == "FROM_START" else max(0, len(items) - at)
+
+
+def _sort_numeric(x: object) -> float:
+    try:
+        return float(x)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _sort_text(x: object) -> str:
+    return str(x)
+
+
+def _sort_ignore_case(x: object) -> str:
+    return str(x).lower()

--- a/src/openfactcheck/engine/handlers/logic.py
+++ b/src/openfactcheck/engine/handlers/logic.py
@@ -1,0 +1,81 @@
+"""Logic block handlers — ``logic_boolean``, ``controls_if``, etc."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+
+@handler("logic_boolean")
+def logic_boolean(block: Block, ctx: ExecutionContext) -> bool:
+    """Return True or False from the BOOL field."""
+    return block.get_field("BOOL", default="TRUE") == "TRUE"
+
+
+@handler("logic_null")
+def logic_null(block: Block, ctx: ExecutionContext) -> None:
+    """Return None."""
+    return None
+
+
+@handler("logic_negate")
+def logic_negate(block: Block, ctx: ExecutionContext) -> bool:
+    """Logical NOT on the BOOL input."""
+    return not resolve.boolean(block, ctx, "BOOL")
+
+
+@handler("logic_compare")
+def logic_compare(block: Block, ctx: ExecutionContext) -> bool:
+    """Comparison of A and B inputs (EQ, NEQ, LT, LTE, GT, GTE)."""
+    op = block.get_field("OP", default="EQ")
+    a = resolve.value(block, ctx, "A")
+    b = resolve.value(block, ctx, "B")
+    if op == "EQ":
+        return a == b
+    if op == "NEQ":
+        return a != b
+    if op == "LT":
+        return a < b  # type: ignore[operator]
+    if op == "LTE":
+        return a <= b  # type: ignore[operator]
+    if op == "GT":
+        return a > b  # type: ignore[operator]
+    if op == "GTE":
+        return a >= b  # type: ignore[operator]
+    return False
+
+
+@handler("logic_operation")
+def logic_operation(block: Block, ctx: ExecutionContext) -> bool:
+    """Logical AND/OR on A and B inputs."""
+    op = block.get_field("OP", default="AND")
+    a = resolve.value(block, ctx, "A")
+    b = resolve.value(block, ctx, "B")
+    return bool(a and b) if op == "AND" else bool(a or b)
+
+
+@handler("logic_ternary")
+def logic_ternary(block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
+    """If IF is truthy, return THEN, else return ELSE."""
+    if resolve.boolean(block, ctx, "IF"):
+        return resolve.value(block, ctx, "THEN")
+    return resolve.value(block, ctx, "ELSE")
+
+
+@handler("controls_if")
+def controls_if(block: Block, ctx: ExecutionContext) -> None:
+    """If/elseif/else statement block with IF0/DO0, IF1/DO1, ..., ELSE."""
+    i = 0
+    while True:
+        cond_block = block.get_input_block(f"IF{i}")
+        if cond_block is None:
+            break
+        if ctx.execute_block(cond_block):
+            resolve.run_statements(block, ctx, f"DO{i}")
+            return
+        i += 1
+    resolve.run_statements(block, ctx, "ELSE")

--- a/src/openfactcheck/engine/handlers/loops.py
+++ b/src/openfactcheck/engine/handlers/loops.py
@@ -1,0 +1,96 @@
+"""Loop block handlers — ``controls_repeat_ext``, ``controls_for``, etc."""
+
+from __future__ import annotations
+
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+MAX_ITERATIONS = 10_000
+"""Safety limit to prevent infinite loops."""
+
+
+class BreakLoop(Exception):
+    """Raised by controls_flow_statements to break out of a loop."""
+
+
+class ContinueLoop(Exception):
+    """Raised by controls_flow_statements to skip to the next iteration."""
+
+
+@handler("controls_repeat_ext")
+def controls_repeat_ext(block: Block, ctx: ExecutionContext) -> None:
+    """Repeat the DO body TIMES times."""
+    times = min(resolve.integer(block, ctx, "TIMES"), MAX_ITERATIONS)
+    for _ in range(times):
+        try:
+            resolve.run_statements(block, ctx, "DO")
+        except BreakLoop:
+            break
+        except ContinueLoop:
+            continue
+
+
+@handler("controls_whileUntil")
+def controls_while_until(block: Block, ctx: ExecutionContext) -> None:
+    """While or until loop. MODE field: WHILE or UNTIL."""
+    mode = block.get_field("MODE", default="WHILE")
+    for _ in range(MAX_ITERATIONS):
+        condition = resolve.boolean(block, ctx, "BOOL")
+        if (mode == "WHILE" and not condition) or (mode == "UNTIL" and condition):
+            break
+        try:
+            resolve.run_statements(block, ctx, "DO")
+        except BreakLoop:
+            break
+        except ContinueLoop:
+            pass
+
+
+@handler("controls_for")
+def controls_for(block: Block, ctx: ExecutionContext) -> None:
+    """For loop with a counter variable (VAR) from FROM to TO by BY."""
+    var = block.get_field("VAR", default="i")
+    from_val = resolve.num(block, ctx, "FROM")
+    to_val = resolve.num(block, ctx, "TO")
+    by_val = resolve.num(block, ctx, "BY")
+
+    if by_val == 0 or (by_val > 0 and from_val > to_val) or (by_val < 0 and from_val < to_val):
+        return
+
+    value = from_val
+    for _ in range(MAX_ITERATIONS):
+        if (by_val > 0 and value > to_val) or (by_val < 0 and value < to_val):
+            break
+        ctx.variables[var] = value
+        try:
+            resolve.run_statements(block, ctx, "DO")
+        except BreakLoop:
+            break
+        except ContinueLoop:
+            pass
+        value += by_val
+
+
+@handler("controls_forEach")
+def controls_for_each(block: Block, ctx: ExecutionContext) -> None:
+    """For-each over a list. VAR field: variable name for the current item."""
+    var = block.get_field("VAR", default="item")
+    items = resolve.items(block, ctx, "LIST")
+    for item in items[:MAX_ITERATIONS]:
+        ctx.variables[var] = item
+        try:
+            resolve.run_statements(block, ctx, "DO")
+        except BreakLoop:
+            break
+        except ContinueLoop:
+            continue
+
+
+@handler("controls_flow_statements")
+def controls_flow_statements(block: Block, ctx: ExecutionContext) -> None:
+    """Break or continue. FLOW field: BREAK or CONTINUE."""
+    if block.get_field("FLOW", default="BREAK") == "BREAK":
+        raise BreakLoop
+    raise ContinueLoop

--- a/src/openfactcheck/engine/handlers/math.py
+++ b/src/openfactcheck/engine/handlers/math.py
@@ -1,0 +1,225 @@
+"""Math block handlers — ``math_number``, ``math_arithmetic``, etc."""
+
+from __future__ import annotations
+
+import math
+import random
+
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+
+@handler("math_number")
+def math_number(block: Block, ctx: ExecutionContext) -> float:
+    """Return the numeric value from the NUM field."""
+    return float(block.get_field("NUM", default="0"))
+
+
+@handler("math_arithmetic")
+def math_arithmetic(block: Block, ctx: ExecutionContext) -> float:
+    """Binary arithmetic on A and B inputs."""
+    op = block.get_field("OP", default="ADD")
+    a = resolve.num(block, ctx, "A")
+    b = resolve.num(block, ctx, "B")
+    if op == "ADD":
+        return a + b
+    if op == "MINUS":
+        return a - b
+    if op == "MULTIPLY":
+        return a * b
+    if op == "DIVIDE":
+        return a / b if b != 0 else float("inf")
+    if op == "POWER":
+        return a**b
+    return 0.0
+
+
+@handler("math_single")
+def math_single(block: Block, ctx: ExecutionContext) -> float:
+    """Unary math on the NUM input."""
+    op = block.get_field("OP", default="ROOT")
+    n = resolve.num(block, ctx, "NUM")
+    if op == "ROOT":
+        return math.sqrt(n)
+    if op == "ABS":
+        return abs(n)
+    if op == "NEG":
+        return -n
+    if op == "LN":
+        return math.log(n) if n > 0 else float("-inf")
+    if op == "LOG10":
+        return math.log10(n) if n > 0 else float("-inf")
+    if op == "EXP":
+        return math.exp(n)
+    if op == "POW10":
+        return 10**n
+    return 0.0
+
+
+@handler("math_trig")
+def math_trig(block: Block, ctx: ExecutionContext) -> float:
+    """Trigonometric functions. Blockly sends degrees; inverse returns degrees."""
+    op = block.get_field("OP", default="SIN")
+    n = resolve.num(block, ctx, "NUM")
+    if op == "SIN":
+        return math.sin(math.radians(n))
+    if op == "COS":
+        return math.cos(math.radians(n))
+    if op == "TAN":
+        return math.tan(math.radians(n))
+    if op == "ASIN":
+        return math.degrees(math.asin(n))
+    if op == "ACOS":
+        return math.degrees(math.acos(n))
+    if op == "ATAN":
+        return math.degrees(math.atan(n))
+    return 0.0
+
+
+MATH_CONSTANTS: dict[str, float] = {
+    "PI": math.pi,
+    "E": math.e,
+    "GOLDEN_RATIO": (1 + math.sqrt(5)) / 2,
+    "SQRT2": math.sqrt(2),
+    "SQRT1_2": math.sqrt(0.5),
+    "INFINITY": float("inf"),
+}
+
+
+@handler("math_constant")
+def math_constant(block: Block, ctx: ExecutionContext) -> float:
+    """Return a named math constant."""
+    return MATH_CONSTANTS.get(block.get_field("CONSTANT", default="PI"), 0.0)
+
+
+@handler("math_number_property")
+def math_number_property(block: Block, ctx: ExecutionContext) -> bool:
+    """Check a property of the number input."""
+    prop = block.get_field("PROPERTY", default="EVEN")
+    n = resolve.num(block, ctx, "NUMBER_TO_CHECK")
+    if prop == "EVEN":
+        return n % 2 == 0
+    if prop == "ODD":
+        return n % 2 == 1
+    if prop == "PRIME":
+        return _is_prime(int(n))
+    if prop == "WHOLE":
+        return n == int(n)
+    if prop == "POSITIVE":
+        return n > 0
+    if prop == "NEGATIVE":
+        return n < 0
+    if prop == "DIVISIBLE_BY":
+        d = resolve.num(block, ctx, "DIVISOR")
+        return d != 0 and n % d == 0
+    return False
+
+
+@handler("math_round")
+def math_round(block: Block, ctx: ExecutionContext) -> float:
+    """Round, ceil, or floor the NUM input."""
+    op = block.get_field("OP", default="ROUND")
+    n = resolve.num(block, ctx, "NUM")
+    if op == "ROUND":
+        return round(n)
+    if op == "ROUNDUP":
+        return math.ceil(n)
+    if op == "ROUNDDOWN":
+        return math.floor(n)
+    return n
+
+
+@handler("math_modulo")
+def math_modulo(block: Block, ctx: ExecutionContext) -> float:
+    """Remainder of DIVIDEND / DIVISOR."""
+    dividend = resolve.num(block, ctx, "DIVIDEND")
+    divisor = resolve.num(block, ctx, "DIVISOR")
+    return dividend % divisor if divisor != 0 else float("nan")
+
+
+@handler("math_constrain")
+def math_constrain(block: Block, ctx: ExecutionContext) -> float:
+    """Clamp VALUE between LOW and HIGH."""
+    return max(resolve.num(block, ctx, "LOW"), min(resolve.num(block, ctx, "VALUE"), resolve.num(block, ctx, "HIGH")))
+
+
+@handler("math_random_int")
+def math_random_int(block: Block, ctx: ExecutionContext) -> int:
+    """Random integer between FROM and TO (inclusive)."""
+    a = resolve.integer(block, ctx, "FROM")
+    b = resolve.integer(block, ctx, "TO")
+    return random.randint(min(a, b), max(a, b))
+
+
+@handler("math_random_float")
+def math_random_float(block: Block, ctx: ExecutionContext) -> float:
+    """Random float in [0, 1)."""
+    return random.random()
+
+
+@handler("math_on_list")
+def math_on_list(block: Block, ctx: ExecutionContext) -> float:
+    """Aggregate operation on a list of numbers."""
+    op = block.get_field("OP", default="SUM")
+    raw = resolve.items(block, ctx, "LIST")
+    nums = [float(x) for x in raw if x is not None]  # type: ignore[arg-type]
+    if not nums:
+        return 0.0
+    if op == "SUM":
+        return sum(nums)
+    if op == "MIN":
+        return min(nums)
+    if op == "MAX":
+        return max(nums)
+    if op == "AVERAGE":
+        return sum(nums) / len(nums)
+    if op == "MEDIAN":
+        return _median(nums)
+    if op == "MODE":
+        return _mode(nums)
+    if op == "STD_DEV":
+        return _std_dev(nums)
+    if op == "RANDOM":
+        return random.choice(nums)
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n < 4:
+        return True
+    if n % 2 == 0 or n % 3 == 0:
+        return False
+    i = 5
+    while i * i <= n:
+        if n % i == 0 or n % (i + 2) == 0:
+            return False
+        i += 6
+    return True
+
+
+def _median(nums: list[float]) -> float:
+    s = sorted(nums)
+    mid = len(s) // 2
+    return (s[mid - 1] + s[mid]) / 2 if len(s) % 2 == 0 else s[mid]
+
+
+def _mode(nums: list[float]) -> float:
+    counts: dict[float, int] = {}
+    for n in nums:
+        counts[n] = counts.get(n, 0) + 1
+    return max(counts, key=lambda k: counts[k])
+
+
+def _std_dev(nums: list[float]) -> float:
+    mean = sum(nums) / len(nums)
+    variance = sum((x - mean) ** 2 for x in nums) / len(nums)
+    return math.sqrt(variance)

--- a/src/openfactcheck/engine/handlers/text.py
+++ b/src/openfactcheck/engine/handlers/text.py
@@ -1,43 +1,132 @@
-"""Text block handlers.
-
-Handles Blockly's built-in text blocks:
-
-- ``text_print`` — Statement block that prints a value to the output.
-- ``text`` — Value block that returns a string literal.
-"""
+"""Text block handlers — ``text``, ``text_print``, ``text_join``, etc."""
 
 from __future__ import annotations
 
+from openfactcheck.engine import resolve
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
-from openfactcheck.engine.handler import BlockHandler
+from openfactcheck.engine.handler import handler
 
 
-class TextPrintHandler(BlockHandler):
-    """``text_print`` — prints the value connected to the TEXT input.
-
-    Blockly structure::
-
-        text_print
-        └─ TEXT (value input) → connected block's return value is printed
-    """
-
-    block_type = "text_print"
-
-    def execute(self, block: Block, ctx: ExecutionContext) -> None:
-        input_block = block.get_input_block("TEXT")
-        value = ctx.execute_block(input_block) if input_block else ""
-        ctx.print(str(value))
+@handler("text")
+def text(block: Block, ctx: ExecutionContext) -> str:
+    """Return the string literal from the TEXT field."""
+    return block.get_field("TEXT", default="")
 
 
-class TextHandler(BlockHandler):
-    """``text`` — returns the string stored in the TEXT field.
+@handler("text_print")
+def text_print(block: Block, ctx: ExecutionContext) -> None:
+    """Print the value connected to the TEXT input."""
+    input_block = block.get_input_block("TEXT")
+    val = ctx.execute_block(input_block) if input_block else ""
+    ctx.print(str(val))
 
-    This is Blockly's basic string literal block. It has no inputs —
-    just a single field containing the user's text.
-    """
 
-    block_type = "text"
+@handler("text_join")
+def text_join(block: Block, ctx: ExecutionContext) -> str:
+    """Concatenate numbered value inputs (ADD0, ADD1, ...)."""
+    return "".join(str(v) for v in resolve.collect_inputs(block, ctx, "ADD"))
 
-    def execute(self, block: Block, ctx: ExecutionContext) -> str:
-        return block.get_field("TEXT", default="")
+
+@handler("text_append")
+def text_append(block: Block, ctx: ExecutionContext) -> None:
+    """Append the TEXT input to a variable."""
+    var = block.get_field("VAR", default="item")
+    ctx.variables[var] = str(ctx.variables.get(var, "")) + resolve.string(block, ctx, "TEXT")
+
+
+@handler("text_length")
+def text_length(block: Block, ctx: ExecutionContext) -> int:
+    """Return the length of the VALUE input string."""
+    return len(resolve.string(block, ctx, "VALUE"))
+
+
+@handler("text_isEmpty")
+def text_is_empty(block: Block, ctx: ExecutionContext) -> bool:
+    """Return True if the VALUE input is empty."""
+    return len(resolve.string(block, ctx, "VALUE")) == 0
+
+
+@handler("text_indexOf")
+def text_index_of(block: Block, ctx: ExecutionContext) -> int:
+    """Find the index of FIND in VALUE. Returns 0 if not found (1-based)."""
+    end = block.get_field("END", default="FIRST")
+    val = resolve.string(block, ctx, "VALUE")
+    find = resolve.string(block, ctx, "FIND")
+    idx = val.find(find) if end == "FIRST" else val.rfind(find)
+    return idx + 1 if idx >= 0 else 0
+
+
+@handler("text_charAt")
+def text_char_at(block: Block, ctx: ExecutionContext) -> str:
+    """Get a character from the VALUE input by position."""
+    where = block.get_field("WHERE", default="FROM_START")
+    val = resolve.string(block, ctx, "VALUE")
+    if not val:
+        return ""
+    if where == "FIRST":
+        return val[0]
+    if where == "LAST":
+        return val[-1]
+    if where == "RANDOM":
+        import random
+
+        return random.choice(val)
+    at = resolve.integer(block, ctx, "AT", default=1)
+    idx = (at - 1) if where == "FROM_START" else (len(val) - at)
+    return val[idx] if 0 <= idx < len(val) else ""
+
+
+@handler("text_getSubstring")
+def text_get_substring(block: Block, ctx: ExecutionContext) -> str:
+    """Extract a substring from the STRING input."""
+    val = resolve.string(block, ctx, "STRING")
+    if not val:
+        return ""
+    start = _text_index(block, ctx, val, "WHERE1", "AT1")
+    end = _text_index(block, ctx, val, "WHERE2", "AT2")
+    return val[start : end + 1]
+
+
+@handler("text_changeCase")
+def text_change_case(block: Block, ctx: ExecutionContext) -> str:
+    """Convert the TEXT input to upper/lower/title case."""
+    case = block.get_field("CASE", default="UPPERCASE")
+    val = resolve.string(block, ctx, "TEXT")
+    if case == "UPPERCASE":
+        return val.upper()
+    if case == "LOWERCASE":
+        return val.lower()
+    if case == "TITLECASE":
+        return val.title()
+    return val
+
+
+@handler("text_trim")
+def text_trim(block: Block, ctx: ExecutionContext) -> str:
+    """Trim whitespace from the TEXT input."""
+    mode = block.get_field("MODE", default="BOTH")
+    val = resolve.string(block, ctx, "TEXT")
+    if mode == "BOTH":
+        return val.strip()
+    if mode == "LEFT":
+        return val.lstrip()
+    if mode == "RIGHT":
+        return val.rstrip()
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_index(block: Block, ctx: ExecutionContext, val: str, where_field: str, at_input: str) -> int:
+    """Resolve a Blockly substring index (1-based) to a Python index (0-based)."""
+    where = block.get_field(where_field, default="FROM_START")
+    if where == "FIRST":
+        return 0
+    if where == "LAST":
+        return len(val) - 1
+    at = resolve.integer(block, ctx, at_input, default=1)
+    return max(0, at - 1) if where == "FROM_START" else max(0, len(val) - at)

--- a/src/openfactcheck/engine/handlers/variables.py
+++ b/src/openfactcheck/engine/handlers/variables.py
@@ -1,0 +1,22 @@
+"""Variable block handlers — ``variables_get``, ``variables_set``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+
+@handler("variables_get")
+def variables_get(block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
+    """Return the value of the named variable."""
+    return ctx.variables.get(block.get_field("VAR", default="item"), "")
+
+
+@handler("variables_set")
+def variables_set(block: Block, ctx: ExecutionContext) -> None:
+    """Set the named variable to the VALUE input."""
+    ctx.variables[block.get_field("VAR", default="item")] = resolve.value(block, ctx, "VALUE")

--- a/src/openfactcheck/engine/resolve.py
+++ b/src/openfactcheck/engine/resolve.py
@@ -1,0 +1,97 @@
+"""Typed input resolution helpers for block handlers.
+
+These functions are the single boundary between ``execute_block()`` (which
+returns ``Any``) and handler code (which needs typed values). All type
+coercion, ``try/except``, and ``type: ignore`` suppressions live here so
+that handler files stay clean.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from openfactcheck.engine.block import Block
+    from openfactcheck.engine.context import ExecutionContext
+
+
+def num(block: Block, ctx: ExecutionContext, name: str, default: float = 0.0) -> float:
+    """Resolve a value input to float."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return default
+    result = ctx.execute_block(input_block)
+    try:
+        return float(result)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def string(block: Block, ctx: ExecutionContext, name: str, default: str = "") -> str:
+    """Resolve a value input to str."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return default
+    result = ctx.execute_block(input_block)
+    return str(result) if result is not None else default
+
+
+def boolean(block: Block, ctx: ExecutionContext, name: str, *, default: bool = False) -> bool:
+    """Resolve a value input to bool."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return default
+    return bool(ctx.execute_block(input_block))
+
+
+def integer(block: Block, ctx: ExecutionContext, name: str, default: int = 0) -> int:
+    """Resolve a value input to int."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return default
+    result = ctx.execute_block(input_block)
+    try:
+        return int(float(result))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def value(block: Block, ctx: ExecutionContext, name: str) -> object:
+    """Resolve any value input. Returns object (not Any) for type safety."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return None
+    result: object = ctx.execute_block(input_block)
+    return result
+
+
+def items(block: Block, ctx: ExecutionContext, name: str) -> list[object]:
+    """Resolve a value input to a typed list."""
+    input_block = block.get_input_block(name)
+    if input_block is None:
+        return []
+    result = ctx.execute_block(input_block)
+    if isinstance(result, list):
+        return cast(list[object], result)
+    return []
+
+
+def run_statements(block: Block, ctx: ExecutionContext, name: str) -> None:
+    """Execute a statement chain connected to the given input."""
+    stmt = block.get_input_block(name)
+    while stmt is not None:
+        ctx.execute_block(stmt)
+        stmt = stmt.next
+
+
+def collect_inputs(block: Block, ctx: ExecutionContext, prefix: str = "ADD") -> list[object]:
+    """Collect numbered value inputs (ADD0, ADD1, ...) into a list."""
+    results: list[object] = []
+    i = 0
+    while True:
+        input_block = block.get_input_block(f"{prefix}{i}")
+        if input_block is None:
+            break
+        results.append(ctx.execute_block(input_block))
+        i += 1
+    return results

--- a/tests/engine/test_lists.py
+++ b/tests/engine/test_lists.py
@@ -1,0 +1,296 @@
+"""Tests for list block handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _text(value: str, *, block_id: str = "t1") -> dict[str, Any]:
+    return {"type": "text", "id": block_id, "fields": {"TEXT": value}}
+
+
+def _num(value: float, *, block_id: str = "n1") -> dict[str, Any]:
+    return {"type": "math_number", "id": block_id, "fields": {"NUM": str(value)}}
+
+
+def _print(value_block: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "text_print", "id": "p1", "inputs": {"TEXT": {"block": value_block}}}
+
+
+def _list(*items: dict[str, Any]) -> dict[str, Any]:
+    inputs = {f"ADD{i}": {"block": item} for i, item in enumerate(items)}
+    return {"type": "lists_create_with", "id": "list1", "inputs": inputs}
+
+
+# ---------------------------------------------------------------------------
+# lists_create_with
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_create_with() -> None:
+    block = _list(_num(1), _num(2), _num(3))
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[1.0, 2.0, 3.0]"
+
+
+async def test_lists_create_with_empty() -> None:
+    block = {"type": "lists_create_with", "id": "list1", "inputs": {}}
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[]"
+
+
+async def test_lists_create_with_strings() -> None:
+    block = _list(_text("a"), _text("b", block_id="t2"))
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "['a', 'b']"
+
+
+# ---------------------------------------------------------------------------
+# lists_repeat
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_repeat() -> None:
+    block = {
+        "type": "lists_repeat",
+        "id": "rep1",
+        "inputs": {
+            "ITEM": {"block": _text("x")},
+            "NUM": {"block": _num(3)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "['x', 'x', 'x']"
+
+
+# ---------------------------------------------------------------------------
+# lists_length
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_length() -> None:
+    block = {
+        "type": "lists_length",
+        "id": "len1",
+        "inputs": {"VALUE": {"block": _list(_num(1), _num(2), _num(3))}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "3"
+
+
+async def test_lists_length_empty() -> None:
+    block = {
+        "type": "lists_length",
+        "id": "len1",
+        "inputs": {"VALUE": {"block": {"type": "lists_create_with", "id": "l1", "inputs": {}}}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "0"
+
+
+# ---------------------------------------------------------------------------
+# lists_isEmpty
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_is_empty_true() -> None:
+    block = {
+        "type": "lists_isEmpty",
+        "id": "ie1",
+        "inputs": {"VALUE": {"block": {"type": "lists_create_with", "id": "l1", "inputs": {}}}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "True"
+
+
+async def test_lists_is_empty_false() -> None:
+    block = {
+        "type": "lists_isEmpty",
+        "id": "ie1",
+        "inputs": {"VALUE": {"block": _list(_num(1))}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "False"
+
+
+# ---------------------------------------------------------------------------
+# lists_indexOf
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_index_of_first() -> None:
+    block = {
+        "type": "lists_indexOf",
+        "id": "idx1",
+        "fields": {"END": "FIRST"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("a"), _text("b", block_id="t2"), _text("a", block_id="t3"))},
+            "FIND": {"block": _text("a", block_id="t4")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "1"  # 1-based
+
+
+async def test_lists_index_of_last() -> None:
+    block = {
+        "type": "lists_indexOf",
+        "id": "idx1",
+        "fields": {"END": "LAST"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("a"), _text("b", block_id="t2"), _text("a", block_id="t3"))},
+            "FIND": {"block": _text("a", block_id="t4")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "3"  # 1-based
+
+
+async def test_lists_index_of_not_found() -> None:
+    block = {
+        "type": "lists_indexOf",
+        "id": "idx1",
+        "fields": {"END": "FIRST"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("a"), _text("b", block_id="t2"))},
+            "FIND": {"block": _text("z", block_id="t3")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "0"
+
+
+# ---------------------------------------------------------------------------
+# lists_getIndex
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_get_index_from_start() -> None:
+    block = {
+        "type": "lists_getIndex",
+        "id": "gi1",
+        "fields": {"MODE": "GET", "WHERE": "FROM_START"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("a"), _text("b", block_id="t2"), _text("c", block_id="t3"))},
+            "AT": {"block": _num(2)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "b"  # 1-based index 2
+
+
+async def test_lists_get_index_first() -> None:
+    block = {
+        "type": "lists_getIndex",
+        "id": "gi1",
+        "fields": {"MODE": "GET", "WHERE": "FIRST"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("x"), _text("y", block_id="t2"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "x"
+
+
+async def test_lists_get_index_last() -> None:
+    block = {
+        "type": "lists_getIndex",
+        "id": "gi1",
+        "fields": {"MODE": "GET", "WHERE": "LAST"},
+        "inputs": {
+            "VALUE": {"block": _list(_text("x"), _text("y", block_id="t2"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "y"
+
+
+# ---------------------------------------------------------------------------
+# lists_getSublist
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_get_sublist() -> None:
+    block = {
+        "type": "lists_getSublist",
+        "id": "sub1",
+        "fields": {"WHERE1": "FROM_START", "WHERE2": "FROM_START"},
+        "inputs": {
+            "LIST": {"block": _list(_num(10), _num(20, block_id="n2"), _num(30, block_id="n3"), _num(40, block_id="n4"))},
+            "AT1": {"block": _num(2, block_id="at1")},
+            "AT2": {"block": _num(3, block_id="at2")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[20.0, 30.0]"
+
+
+async def test_lists_get_sublist_first_last() -> None:
+    block = {
+        "type": "lists_getSublist",
+        "id": "sub1",
+        "fields": {"WHERE1": "FIRST", "WHERE2": "LAST"},
+        "inputs": {
+            "LIST": {"block": _list(_num(1), _num(2, block_id="n2"), _num(3, block_id="n3"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[1.0, 2.0, 3.0]"
+
+
+# ---------------------------------------------------------------------------
+# lists_sort
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_sort_numeric() -> None:
+    block = {
+        "type": "lists_sort",
+        "id": "sort1",
+        "fields": {"TYPE": "NUMERIC", "DIRECTION": "1"},
+        "inputs": {
+            "LIST": {"block": _list(_num(3), _num(1, block_id="n2"), _num(2, block_id="n3"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[1.0, 2.0, 3.0]"
+
+
+async def test_lists_sort_text_descending() -> None:
+    block = {
+        "type": "lists_sort",
+        "id": "sort1",
+        "fields": {"TYPE": "TEXT", "DIRECTION": "-1"},
+        "inputs": {
+            "LIST": {"block": _list(_text("a"), _text("c", block_id="t2"), _text("b", block_id="t3"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "['c', 'b', 'a']"
+
+
+# ---------------------------------------------------------------------------
+# lists_reverse
+# ---------------------------------------------------------------------------
+
+
+async def test_lists_reverse() -> None:
+    block = {
+        "type": "lists_reverse",
+        "id": "rev1",
+        "inputs": {
+            "LIST": {"block": _list(_num(1), _num(2, block_id="n2"), _num(3, block_id="n3"))},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "[3.0, 2.0, 1.0]"

--- a/tests/engine/test_logic.py
+++ b/tests/engine/test_logic.py
@@ -1,0 +1,252 @@
+"""Tests for logic block handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _text(value: str) -> dict[str, Any]:
+    return {"type": "text", "id": "t1", "fields": {"TEXT": value}}
+
+
+def _num(value: float) -> dict[str, Any]:
+    return {"type": "math_number", "id": "n1", "fields": {"NUM": str(value)}}
+
+
+def _bool(value: bool) -> dict[str, Any]:
+    return {"type": "logic_boolean", "id": "b1", "fields": {"BOOL": "TRUE" if value else "FALSE"}}
+
+
+def _print(value_block: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "text_print", "id": "p1", "inputs": {"TEXT": {"block": value_block}}}
+
+
+def _print_text(text: str, *, block_id: str = "p1") -> dict[str, Any]:
+    return {
+        "type": "text_print",
+        "id": block_id,
+        "inputs": {"TEXT": {"block": {"type": "text", "id": f"{block_id}_t", "fields": {"TEXT": text}}}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# logic_boolean
+# ---------------------------------------------------------------------------
+
+
+async def test_logic_boolean_true() -> None:
+    result = await execute_pipeline(_pipeline(_print(_bool(True))))
+    assert result.output == "True"
+
+
+async def test_logic_boolean_false() -> None:
+    result = await execute_pipeline(_pipeline(_print(_bool(False))))
+    assert result.output == "False"
+
+
+# ---------------------------------------------------------------------------
+# logic_null
+# ---------------------------------------------------------------------------
+
+
+async def test_logic_null() -> None:
+    block = {"type": "logic_null", "id": "null1"}
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "None"
+
+
+# ---------------------------------------------------------------------------
+# logic_negate
+# ---------------------------------------------------------------------------
+
+
+async def test_logic_negate_true() -> None:
+    block = {"type": "logic_negate", "id": "neg1", "inputs": {"BOOL": {"block": _bool(True)}}}
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "False"
+
+
+async def test_logic_negate_false() -> None:
+    block = {"type": "logic_negate", "id": "neg1", "inputs": {"BOOL": {"block": _bool(False)}}}
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "True"
+
+
+# ---------------------------------------------------------------------------
+# logic_compare
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "a", "b", "expected"),
+    [
+        ("EQ", 5, 5, "True"),
+        ("EQ", 5, 3, "False"),
+        ("NEQ", 5, 3, "True"),
+        ("LT", 3, 5, "True"),
+        ("LT", 5, 3, "False"),
+        ("LTE", 5, 5, "True"),
+        ("GT", 5, 3, "True"),
+        ("GTE", 3, 5, "False"),
+    ],
+)
+async def test_logic_compare(op: str, a: float, b: float, expected: str) -> None:
+    block = {
+        "type": "logic_compare",
+        "id": "cmp1",
+        "fields": {"OP": op},
+        "inputs": {
+            "A": {"block": _num(a)},
+            "B": {"block": _num(b)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# logic_operation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "a", "b", "expected"),
+    [
+        ("AND", True, True, "True"),
+        ("AND", True, False, "False"),
+        ("OR", False, True, "True"),
+        ("OR", False, False, "False"),
+    ],
+)
+async def test_logic_operation(op: str, a: bool, b: bool, expected: str) -> None:
+    block = {
+        "type": "logic_operation",
+        "id": "op1",
+        "fields": {"OP": op},
+        "inputs": {
+            "A": {"block": _bool(a)},
+            "B": {"block": _bool(b)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# logic_ternary
+# ---------------------------------------------------------------------------
+
+
+async def test_logic_ternary_true() -> None:
+    block = {
+        "type": "logic_ternary",
+        "id": "tern1",
+        "inputs": {
+            "IF": {"block": _bool(True)},
+            "THEN": {"block": _text("yes")},
+            "ELSE": {"block": _text("no")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "yes"
+
+
+async def test_logic_ternary_false() -> None:
+    block = {
+        "type": "logic_ternary",
+        "id": "tern1",
+        "inputs": {
+            "IF": {"block": _bool(False)},
+            "THEN": {"block": _text("yes")},
+            "ELSE": {"block": _text("no")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "no"
+
+
+# ---------------------------------------------------------------------------
+# controls_if
+# ---------------------------------------------------------------------------
+
+
+async def test_controls_if_true() -> None:
+    block = {
+        "type": "controls_if",
+        "id": "if1",
+        "inputs": {
+            "IF0": {"block": _bool(True)},
+            "DO0": {"block": _print_text("matched")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "matched"
+
+
+async def test_controls_if_false() -> None:
+    block = {
+        "type": "controls_if",
+        "id": "if1",
+        "inputs": {
+            "IF0": {"block": _bool(False)},
+            "DO0": {"block": _print_text("nope")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == ""
+
+
+async def test_controls_if_else() -> None:
+    block = {
+        "type": "controls_if",
+        "id": "if1",
+        "inputs": {
+            "IF0": {"block": _bool(False)},
+            "DO0": {"block": _print_text("if-branch")},
+            "ELSE": {"block": _print_text("else-branch", block_id="p2")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "else-branch"
+
+
+async def test_controls_if_elseif() -> None:
+    block = {
+        "type": "controls_if",
+        "id": "if1",
+        "inputs": {
+            "IF0": {"block": _bool(False)},
+            "DO0": {"block": _print_text("first")},
+            "IF1": {"block": _bool(True)},
+            "DO1": {"block": _print_text("second", block_id="p2")},
+            "ELSE": {"block": _print_text("else", block_id="p3")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "second"
+
+
+async def test_controls_if_with_chained_statements() -> None:
+    """IF block with multiple statements chained via next."""
+    stmt1 = _print_text("line1")
+    stmt1["next"] = {"block": _print_text("line2", block_id="p2")}
+    block = {
+        "type": "controls_if",
+        "id": "if1",
+        "inputs": {
+            "IF0": {"block": _bool(True)},
+            "DO0": {"block": stmt1},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "line1\nline2"

--- a/tests/engine/test_loops.py
+++ b/tests/engine/test_loops.py
@@ -1,0 +1,384 @@
+"""Tests for loop block handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _num(value: float) -> dict[str, Any]:
+    return {"type": "math_number", "id": "n1", "fields": {"NUM": str(value)}}
+
+
+def _bool(value: bool) -> dict[str, Any]:
+    return {"type": "logic_boolean", "id": "b1", "fields": {"BOOL": "TRUE" if value else "FALSE"}}
+
+
+def _print_text(text: str, *, block_id: str = "p1") -> dict[str, Any]:
+    return {
+        "type": "text_print",
+        "id": block_id,
+        "inputs": {"TEXT": {"block": {"type": "text", "id": f"{block_id}_t", "fields": {"TEXT": text}}}},
+    }
+
+
+def _print_var(var_name: str, *, block_id: str = "pv1") -> dict[str, Any]:
+    return {
+        "type": "text_print",
+        "id": block_id,
+        "inputs": {"TEXT": {"block": {"type": "variables_get", "id": f"{block_id}_v", "fields": {"VAR": var_name}}}},
+    }
+
+
+def _break() -> dict[str, Any]:
+    return {"type": "controls_flow_statements", "id": "brk1", "fields": {"FLOW": "BREAK"}}
+
+
+def _continue(next_block: dict[str, Any] | None = None) -> dict[str, Any]:
+    block: dict[str, Any] = {"type": "controls_flow_statements", "id": "cnt1", "fields": {"FLOW": "CONTINUE"}}
+    if next_block:
+        block["next"] = {"block": next_block}
+    return block
+
+
+# ---------------------------------------------------------------------------
+# controls_repeat_ext
+# ---------------------------------------------------------------------------
+
+
+async def test_repeat_basic() -> None:
+    block = {
+        "type": "controls_repeat_ext",
+        "id": "rep1",
+        "inputs": {
+            "TIMES": {"block": _num(3)},
+            "DO": {"block": _print_text("hi")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "hi\nhi\nhi"
+
+
+async def test_repeat_zero() -> None:
+    block = {
+        "type": "controls_repeat_ext",
+        "id": "rep1",
+        "inputs": {
+            "TIMES": {"block": _num(0)},
+            "DO": {"block": _print_text("nope")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == ""
+
+
+async def test_repeat_with_break() -> None:
+    body = _print_text("a")
+    body["next"] = {"block": _break()}
+    block = {
+        "type": "controls_repeat_ext",
+        "id": "rep1",
+        "inputs": {
+            "TIMES": {"block": _num(5)},
+            "DO": {"block": body},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "a"
+
+
+# ---------------------------------------------------------------------------
+# controls_whileUntil
+# ---------------------------------------------------------------------------
+
+
+async def test_while_loop() -> None:
+    """While loop: print i, increment, stop when i > 2."""
+    # Set i = 0 → while i < 3: print i, i = i + 1
+    set_i = {
+        "type": "variables_set",
+        "id": "vs1",
+        "fields": {"VAR": "i"},
+        "inputs": {"VALUE": {"block": _num(0)}},
+        "next": {
+            "block": {
+                "type": "controls_whileUntil",
+                "id": "wh1",
+                "fields": {"MODE": "WHILE"},
+                "inputs": {
+                    "BOOL": {
+                        "block": {
+                            "type": "logic_compare",
+                            "id": "cmp1",
+                            "fields": {"OP": "LT"},
+                            "inputs": {
+                                "A": {"block": {"type": "variables_get", "id": "vg1", "fields": {"VAR": "i"}}},
+                                "B": {"block": _num(3)},
+                            },
+                        }
+                    },
+                    "DO": {
+                        "block": {
+                            "type": "text_print",
+                            "id": "p1",
+                            "inputs": {
+                                "TEXT": {
+                                    "block": {"type": "variables_get", "id": "vg2", "fields": {"VAR": "i"}}
+                                }
+                            },
+                            "next": {
+                                "block": {
+                                    "type": "variables_set",
+                                    "id": "vs2",
+                                    "fields": {"VAR": "i"},
+                                    "inputs": {
+                                        "VALUE": {
+                                            "block": {
+                                                "type": "math_arithmetic",
+                                                "id": "add1",
+                                                "fields": {"OP": "ADD"},
+                                                "inputs": {
+                                                    "A": {
+                                                        "block": {
+                                                            "type": "variables_get",
+                                                            "id": "vg3",
+                                                            "fields": {"VAR": "i"},
+                                                        }
+                                                    },
+                                                    "B": {"block": _num(1)},
+                                                },
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+        },
+    }
+    result = await execute_pipeline(_pipeline(set_i))
+    assert result.output == "0.0\n1.0\n2.0"
+
+
+async def test_until_loop() -> None:
+    """Until loop: repeat until condition is true."""
+    set_i = {
+        "type": "variables_set",
+        "id": "vs1",
+        "fields": {"VAR": "i"},
+        "inputs": {"VALUE": {"block": _num(0)}},
+        "next": {
+            "block": {
+                "type": "controls_whileUntil",
+                "id": "wh1",
+                "fields": {"MODE": "UNTIL"},
+                "inputs": {
+                    "BOOL": {
+                        "block": {
+                            "type": "logic_compare",
+                            "id": "cmp1",
+                            "fields": {"OP": "EQ"},
+                            "inputs": {
+                                "A": {"block": {"type": "variables_get", "id": "vg1", "fields": {"VAR": "i"}}},
+                                "B": {"block": _num(3)},
+                            },
+                        }
+                    },
+                    "DO": {
+                        "block": {
+                            "type": "text_print",
+                            "id": "p1",
+                            "inputs": {
+                                "TEXT": {
+                                    "block": {"type": "variables_get", "id": "vg2", "fields": {"VAR": "i"}}
+                                }
+                            },
+                            "next": {
+                                "block": {
+                                    "type": "variables_set",
+                                    "id": "vs2",
+                                    "fields": {"VAR": "i"},
+                                    "inputs": {
+                                        "VALUE": {
+                                            "block": {
+                                                "type": "math_arithmetic",
+                                                "id": "add1",
+                                                "fields": {"OP": "ADD"},
+                                                "inputs": {
+                                                    "A": {
+                                                        "block": {
+                                                            "type": "variables_get",
+                                                            "id": "vg3",
+                                                            "fields": {"VAR": "i"},
+                                                        }
+                                                    },
+                                                    "B": {"block": _num(1)},
+                                                },
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        }
+                    },
+                },
+            }
+        },
+    }
+    result = await execute_pipeline(_pipeline(set_i))
+    assert result.output == "0.0\n1.0\n2.0"
+
+
+# ---------------------------------------------------------------------------
+# controls_for
+# ---------------------------------------------------------------------------
+
+
+async def test_for_loop() -> None:
+    block = {
+        "type": "controls_for",
+        "id": "for1",
+        "fields": {"VAR": "i"},
+        "inputs": {
+            "FROM": {"block": _num(1)},
+            "TO": {"block": _num(5)},
+            "BY": {"block": _num(1)},
+            "DO": {"block": _print_var("i")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "1.0\n2.0\n3.0\n4.0\n5.0"
+
+
+async def test_for_loop_step_2() -> None:
+    block = {
+        "type": "controls_for",
+        "id": "for1",
+        "fields": {"VAR": "i"},
+        "inputs": {
+            "FROM": {"block": _num(0)},
+            "TO": {"block": _num(10)},
+            "BY": {"block": _num(3)},
+            "DO": {"block": _print_var("i")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "0.0\n3.0\n6.0\n9.0"
+
+
+async def test_for_loop_countdown() -> None:
+    block = {
+        "type": "controls_for",
+        "id": "for1",
+        "fields": {"VAR": "i"},
+        "inputs": {
+            "FROM": {"block": _num(3)},
+            "TO": {"block": _num(1)},
+            "BY": {"block": _num(-1)},
+            "DO": {"block": _print_var("i")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "3.0\n2.0\n1.0"
+
+
+async def test_for_loop_with_break() -> None:
+    body = _print_var("i")
+    # Break when i == 3
+    body["next"] = {
+        "block": {
+            "type": "controls_if",
+            "id": "if1",
+            "inputs": {
+                "IF0": {
+                    "block": {
+                        "type": "logic_compare",
+                        "id": "cmp1",
+                        "fields": {"OP": "EQ"},
+                        "inputs": {
+                            "A": {"block": {"type": "variables_get", "id": "vg2", "fields": {"VAR": "i"}}},
+                            "B": {"block": _num(3)},
+                        },
+                    }
+                },
+                "DO0": {"block": _break()},
+            },
+        }
+    }
+    block = {
+        "type": "controls_for",
+        "id": "for1",
+        "fields": {"VAR": "i"},
+        "inputs": {
+            "FROM": {"block": _num(1)},
+            "TO": {"block": _num(10)},
+            "BY": {"block": _num(1)},
+            "DO": {"block": body},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "1.0\n2.0\n3.0"
+
+
+# ---------------------------------------------------------------------------
+# controls_forEach
+# ---------------------------------------------------------------------------
+
+
+async def test_for_each() -> None:
+    list_block = {
+        "type": "lists_create_with",
+        "id": "list1",
+        "inputs": {
+            "ADD0": {"block": {"type": "text", "id": "t1", "fields": {"TEXT": "a"}}},
+            "ADD1": {"block": {"type": "text", "id": "t2", "fields": {"TEXT": "b"}}},
+            "ADD2": {"block": {"type": "text", "id": "t3", "fields": {"TEXT": "c"}}},
+        },
+    }
+    block = {
+        "type": "controls_forEach",
+        "id": "fe1",
+        "fields": {"VAR": "item"},
+        "inputs": {
+            "LIST": {"block": list_block},
+            "DO": {"block": _print_var("item")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    assert result.output == "a\nb\nc"
+
+
+# ---------------------------------------------------------------------------
+# controls_flow_statements (continue)
+# ---------------------------------------------------------------------------
+
+
+async def test_continue_skips_rest() -> None:
+    """Continue skips printing 'after' but loop continues."""
+    body = _print_var("i")
+    body["next"] = {"block": _continue(next_block=_print_text("after", block_id="p2"))}
+    block = {
+        "type": "controls_for",
+        "id": "for1",
+        "fields": {"VAR": "i"},
+        "inputs": {
+            "FROM": {"block": _num(1)},
+            "TO": {"block": _num(3)},
+            "BY": {"block": _num(1)},
+            "DO": {"block": body},
+        },
+    }
+    result = await execute_pipeline(_pipeline(block))
+    # "after" never prints because continue skips it
+    assert result.output == "1.0\n2.0\n3.0"

--- a/tests/engine/test_math.py
+++ b/tests/engine/test_math.py
@@ -1,0 +1,333 @@
+"""Tests for math block handlers."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _num(value: float) -> dict[str, Any]:
+    return {"type": "math_number", "id": "n1", "fields": {"NUM": str(value)}}
+
+
+def _print_value(value_block: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "text_print",
+        "id": "p1",
+        "inputs": {"TEXT": {"block": value_block}},
+    }
+
+
+def _arithmetic(op: str, a: float, b: float) -> dict[str, Any]:
+    return {
+        "type": "math_arithmetic",
+        "id": "arith1",
+        "fields": {"OP": op},
+        "inputs": {
+            "A": {"block": _num(a)},
+            "B": {"block": _num(b)},
+        },
+    }
+
+
+def _single(op: str, n: float) -> dict[str, Any]:
+    return {
+        "type": "math_single",
+        "id": "single1",
+        "fields": {"OP": op},
+        "inputs": {"NUM": {"block": _num(n)}},
+    }
+
+
+def _trig(op: str, n: float) -> dict[str, Any]:
+    return {
+        "type": "math_trig",
+        "id": "trig1",
+        "fields": {"OP": op},
+        "inputs": {"NUM": {"block": _num(n)}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# math_number
+# ---------------------------------------------------------------------------
+
+
+async def test_math_number() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_num(42))))
+    assert result.output == "42.0"
+
+
+async def test_math_number_decimal() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_num(3.14))))
+    assert result.output == "3.14"
+
+
+# ---------------------------------------------------------------------------
+# math_arithmetic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "a", "b", "expected"),
+    [
+        ("ADD", 3, 4, "7.0"),
+        ("MINUS", 10, 3, "7.0"),
+        ("MULTIPLY", 6, 7, "42.0"),
+        ("DIVIDE", 10, 4, "2.5"),
+        ("POWER", 2, 10, "1024.0"),
+    ],
+)
+async def test_math_arithmetic(op: str, a: float, b: float, expected: str) -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_arithmetic(op, a, b))))
+    assert result.output == expected
+
+
+async def test_math_divide_by_zero() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_arithmetic("DIVIDE", 5, 0))))
+    assert result.output == "inf"
+
+
+# ---------------------------------------------------------------------------
+# math_single
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "n", "expected"),
+    [
+        ("ROOT", 9, 3.0),
+        ("ABS", -5, 5.0),
+        ("NEG", 7, -7.0),
+        ("LN", math.e, 1.0),
+        ("LOG10", 100, 2.0),
+        ("EXP", 0, 1.0),
+        ("POW10", 3, 1000.0),
+    ],
+)
+async def test_math_single(op: str, n: float, expected: float) -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_single(op, n))))
+    assert float(result.output) == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# math_trig
+# ---------------------------------------------------------------------------
+
+
+async def test_math_trig_sin() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_trig("SIN", 90))))
+    assert float(result.output) == pytest.approx(1.0)
+
+
+async def test_math_trig_cos() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_trig("COS", 0))))
+    assert float(result.output) == pytest.approx(1.0)
+
+
+async def test_math_trig_atan() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_trig("ATAN", 1))))
+    assert float(result.output) == pytest.approx(45.0)
+
+
+# ---------------------------------------------------------------------------
+# math_constant
+# ---------------------------------------------------------------------------
+
+
+async def test_math_constant_pi() -> None:
+    block = {"type": "math_constant", "id": "c1", "fields": {"CONSTANT": "PI"}}
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert float(result.output) == pytest.approx(math.pi)
+
+
+async def test_math_constant_infinity() -> None:
+    block = {"type": "math_constant", "id": "c1", "fields": {"CONSTANT": "INFINITY"}}
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert result.output == "inf"
+
+
+# ---------------------------------------------------------------------------
+# math_number_property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("prop", "n", "expected"),
+    [
+        ("EVEN", 4, "True"),
+        ("EVEN", 5, "False"),
+        ("ODD", 7, "True"),
+        ("PRIME", 13, "True"),
+        ("PRIME", 4, "False"),
+        ("WHOLE", 5.0, "True"),
+        ("WHOLE", 5.5, "False"),
+        ("POSITIVE", 3, "True"),
+        ("NEGATIVE", -1, "True"),
+    ],
+)
+async def test_math_number_property(prop: str, n: float, expected: str) -> None:
+    block = {
+        "type": "math_number_property",
+        "id": "prop1",
+        "fields": {"PROPERTY": prop},
+        "inputs": {"NUMBER_TO_CHECK": {"block": _num(n)}},
+    }
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# math_round
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op", "n", "expected"),
+    [
+        ("ROUND", 3.5, "4"),
+        ("ROUNDUP", 3.1, "4"),
+        ("ROUNDDOWN", 3.9, "3"),
+    ],
+)
+async def test_math_round(op: str, n: float, expected: str) -> None:
+    block = {
+        "type": "math_round",
+        "id": "r1",
+        "fields": {"OP": op},
+        "inputs": {"NUM": {"block": _num(n)}},
+    }
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# math_modulo
+# ---------------------------------------------------------------------------
+
+
+async def test_math_modulo() -> None:
+    block = {
+        "type": "math_modulo",
+        "id": "m1",
+        "inputs": {
+            "DIVIDEND": {"block": _num(10)},
+            "DIVISOR": {"block": _num(3)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert result.output == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# math_constrain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "low", "high", "expected"),
+    [
+        (5, 1, 10, "5.0"),
+        (-5, 1, 10, "1.0"),
+        (15, 1, 10, "10.0"),
+    ],
+)
+async def test_math_constrain(value: float, low: float, high: float, expected: str) -> None:
+    block = {
+        "type": "math_constrain",
+        "id": "con1",
+        "inputs": {
+            "VALUE": {"block": _num(value)},
+            "LOW": {"block": _num(low)},
+            "HIGH": {"block": _num(high)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# math_random_int
+# ---------------------------------------------------------------------------
+
+
+async def test_math_random_int_in_range() -> None:
+    block = {
+        "type": "math_random_int",
+        "id": "ri1",
+        "inputs": {
+            "FROM": {"block": _num(1)},
+            "TO": {"block": _num(10)},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    value = int(float(result.output))
+    assert 1 <= value <= 10
+
+
+# ---------------------------------------------------------------------------
+# math_random_float
+# ---------------------------------------------------------------------------
+
+
+async def test_math_random_float_in_range() -> None:
+    block = {"type": "math_random_float", "id": "rf1"}
+    result = await execute_pipeline(_pipeline(_print_value(block)))
+    value = float(result.output)
+    assert 0.0 <= value < 1.0
+
+
+# ---------------------------------------------------------------------------
+# math_on_list
+# ---------------------------------------------------------------------------
+
+
+def _list(*values: float) -> dict[str, Any]:
+    inputs = {f"ADD{i}": {"block": _num(v)} for i, v in enumerate(values)}
+    return {"type": "lists_create_with", "id": "list1", "inputs": inputs}
+
+
+def _math_on_list(op: str, *values: float) -> dict[str, Any]:
+    return {
+        "type": "math_on_list",
+        "id": "mol1",
+        "fields": {"OP": op},
+        "inputs": {"LIST": {"block": _list(*values)}},
+    }
+
+
+@pytest.mark.parametrize(
+    ("op", "values", "expected"),
+    [
+        ("SUM", (1, 2, 3), 6.0),
+        ("MIN", (5, 2, 8), 2.0),
+        ("MAX", (5, 2, 8), 8.0),
+        ("AVERAGE", (2, 4, 6), 4.0),
+        ("MEDIAN", (1, 3, 2), 2.0),
+        ("MEDIAN", (1, 2, 3, 4), 2.5),
+        ("MODE", (1, 2, 2, 3), 2.0),
+    ],
+)
+async def test_math_on_list(op: str, values: tuple[float, ...], expected: float) -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_math_on_list(op, *values))))
+    assert float(result.output) == pytest.approx(expected)
+
+
+async def test_math_on_list_std_dev() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_math_on_list("STD_DEV", 2, 4, 4, 4, 5, 5, 7, 9))))
+    assert float(result.output) == pytest.approx(2.0)
+
+
+async def test_math_on_list_random() -> None:
+    result = await execute_pipeline(_pipeline(_print_value(_math_on_list("RANDOM", 10, 20, 30))))
+    assert float(result.output) in (10.0, 20.0, 30.0)

--- a/tests/engine/test_text.py
+++ b/tests/engine/test_text.py
@@ -1,0 +1,310 @@
+"""Tests for text block handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _text(value: str) -> dict[str, Any]:
+    return {"type": "text", "id": "t1", "fields": {"TEXT": value}}
+
+
+def _print(value_block: dict[str, Any], next_block: dict[str, Any] | None = None) -> dict[str, Any]:
+    block: dict[str, Any] = {"type": "text_print", "id": "p1", "inputs": {"TEXT": {"block": value_block}}}
+    if next_block:
+        block["next"] = {"block": next_block}
+    return block
+
+
+# ---------------------------------------------------------------------------
+# text_join
+# ---------------------------------------------------------------------------
+
+
+async def test_text_join() -> None:
+    block = {
+        "type": "text_join",
+        "id": "j1",
+        "inputs": {
+            "ADD0": {"block": _text("Hello")},
+            "ADD1": {"block": _text(" ")},
+            "ADD2": {"block": _text("World")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "Hello World"
+
+
+async def test_text_join_empty() -> None:
+    block = {"type": "text_join", "id": "j1", "inputs": {}}
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == ""
+
+
+# ---------------------------------------------------------------------------
+# text_append
+# ---------------------------------------------------------------------------
+
+
+async def test_text_append() -> None:
+    set_var: dict[str, Any] = {
+        "type": "text_append",
+        "id": "a1",
+        "fields": {"VAR": "msg"},
+        "inputs": {"TEXT": {"block": _text("Hello")}},
+        "next": {
+            "block": {
+                "type": "text_append",
+                "id": "a2",
+                "fields": {"VAR": "msg"},
+                "inputs": {"TEXT": {"block": _text(" World")}},
+                "next": {
+                    "block": {
+                        "type": "text_print",
+                        "id": "p1",
+                        "inputs": {
+                            "TEXT": {
+                                "block": {
+                                    "type": "variables_get",
+                                    "id": "vg1",
+                                    "fields": {"VAR": "msg"},
+                                }
+                            }
+                        },
+                    }
+                },
+            }
+        },
+    }
+    result = await execute_pipeline(_pipeline(set_var))
+    assert result.output == "Hello World"
+
+
+# ---------------------------------------------------------------------------
+# text_length
+# ---------------------------------------------------------------------------
+
+
+async def test_text_length() -> None:
+    block = {
+        "type": "text_length",
+        "id": "l1",
+        "inputs": {"VALUE": {"block": _text("Hello")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "5"
+
+
+async def test_text_length_empty() -> None:
+    block = {
+        "type": "text_length",
+        "id": "l1",
+        "inputs": {"VALUE": {"block": _text("")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "0"
+
+
+# ---------------------------------------------------------------------------
+# text_isEmpty
+# ---------------------------------------------------------------------------
+
+
+async def test_text_is_empty_true() -> None:
+    block = {
+        "type": "text_isEmpty",
+        "id": "e1",
+        "inputs": {"VALUE": {"block": _text("")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "True"
+
+
+async def test_text_is_empty_false() -> None:
+    block = {
+        "type": "text_isEmpty",
+        "id": "e1",
+        "inputs": {"VALUE": {"block": _text("hi")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "False"
+
+
+# ---------------------------------------------------------------------------
+# text_indexOf
+# ---------------------------------------------------------------------------
+
+
+async def test_text_index_of_first() -> None:
+    block = {
+        "type": "text_indexOf",
+        "id": "idx1",
+        "fields": {"END": "FIRST"},
+        "inputs": {
+            "VALUE": {"block": _text("abcabc")},
+            "FIND": {"block": _text("bc")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "2"  # 1-based
+
+
+async def test_text_index_of_last() -> None:
+    block = {
+        "type": "text_indexOf",
+        "id": "idx1",
+        "fields": {"END": "LAST"},
+        "inputs": {
+            "VALUE": {"block": _text("abcabc")},
+            "FIND": {"block": _text("bc")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "5"  # 1-based
+
+
+async def test_text_index_of_not_found() -> None:
+    block = {
+        "type": "text_indexOf",
+        "id": "idx1",
+        "fields": {"END": "FIRST"},
+        "inputs": {
+            "VALUE": {"block": _text("abc")},
+            "FIND": {"block": _text("xyz")},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "0"
+
+
+# ---------------------------------------------------------------------------
+# text_charAt
+# ---------------------------------------------------------------------------
+
+
+async def test_text_char_at_from_start() -> None:
+    num = {"type": "math_number", "id": "n1", "fields": {"NUM": "2"}}
+    block = {
+        "type": "text_charAt",
+        "id": "c1",
+        "fields": {"WHERE": "FROM_START"},
+        "inputs": {
+            "VALUE": {"block": _text("Hello")},
+            "AT": {"block": num},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "e"  # index 2 (1-based) = 'e'
+
+
+async def test_text_char_at_first() -> None:
+    block = {
+        "type": "text_charAt",
+        "id": "c1",
+        "fields": {"WHERE": "FIRST"},
+        "inputs": {"VALUE": {"block": _text("Hello")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "H"
+
+
+async def test_text_char_at_last() -> None:
+    block = {
+        "type": "text_charAt",
+        "id": "c1",
+        "fields": {"WHERE": "LAST"},
+        "inputs": {"VALUE": {"block": _text("Hello")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "o"
+
+
+# ---------------------------------------------------------------------------
+# text_getSubstring
+# ---------------------------------------------------------------------------
+
+
+async def test_text_get_substring() -> None:
+    num1 = {"type": "math_number", "id": "n1", "fields": {"NUM": "2"}}
+    num2 = {"type": "math_number", "id": "n2", "fields": {"NUM": "4"}}
+    block = {
+        "type": "text_getSubstring",
+        "id": "sub1",
+        "fields": {"WHERE1": "FROM_START", "WHERE2": "FROM_START"},
+        "inputs": {
+            "STRING": {"block": _text("Hello World")},
+            "AT1": {"block": num1},
+            "AT2": {"block": num2},
+        },
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "ell"  # index 2-4 (1-based) = chars at 1,2,3
+
+
+async def test_text_get_substring_first_last() -> None:
+    block = {
+        "type": "text_getSubstring",
+        "id": "sub1",
+        "fields": {"WHERE1": "FIRST", "WHERE2": "LAST"},
+        "inputs": {"STRING": {"block": _text("Hello")}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# text_changeCase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("case", "input_text", "expected"),
+    [
+        ("UPPERCASE", "hello", "HELLO"),
+        ("LOWERCASE", "HELLO", "hello"),
+        ("TITLECASE", "hello world", "Hello World"),
+    ],
+)
+async def test_text_change_case(case: str, input_text: str, expected: str) -> None:
+    block = {
+        "type": "text_changeCase",
+        "id": "cc1",
+        "fields": {"CASE": case},
+        "inputs": {"TEXT": {"block": _text(input_text)}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == expected
+
+
+# ---------------------------------------------------------------------------
+# text_trim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mode", "input_text", "expected"),
+    [
+        ("BOTH", "  hello  ", "hello"),
+        ("LEFT", "  hello  ", "hello  "),
+        ("RIGHT", "  hello  ", "  hello"),
+    ],
+)
+async def test_text_trim(mode: str, input_text: str, expected: str) -> None:
+    block = {
+        "type": "text_trim",
+        "id": "tr1",
+        "fields": {"MODE": mode},
+        "inputs": {"TEXT": {"block": _text(input_text)}},
+    }
+    result = await execute_pipeline(_pipeline(_print(block)))
+    assert result.output == expected

--- a/tests/engine/test_variables.py
+++ b/tests/engine/test_variables.py
@@ -1,0 +1,108 @@
+"""Tests for variable block handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openfactcheck.engine import execute_pipeline
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _text(value: str) -> dict[str, Any]:
+    return {"type": "text", "id": "t1", "fields": {"TEXT": value}}
+
+
+def _num(value: float) -> dict[str, Any]:
+    return {"type": "math_number", "id": "n1", "fields": {"NUM": str(value)}}
+
+
+def _print(value_block: dict[str, Any]) -> dict[str, Any]:
+    return {"type": "text_print", "id": "p1", "inputs": {"TEXT": {"block": value_block}}}
+
+
+def _var_get(name: str) -> dict[str, Any]:
+    return {"type": "variables_get", "id": "vg1", "fields": {"VAR": name}}
+
+
+def _var_set(name: str, value_block: dict[str, Any], next_block: dict[str, Any] | None = None) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "type": "variables_set",
+        "id": "vs1",
+        "fields": {"VAR": name},
+        "inputs": {"VALUE": {"block": value_block}},
+    }
+    if next_block:
+        block["next"] = {"block": next_block}
+    return block
+
+
+# ---------------------------------------------------------------------------
+# variables_set + variables_get
+# ---------------------------------------------------------------------------
+
+
+async def test_set_and_get_string() -> None:
+    chain = _var_set("msg", _text("hello"), next_block=_print(_var_get("msg")))
+    result = await execute_pipeline(_pipeline(chain))
+    assert result.output == "hello"
+
+
+async def test_set_and_get_number() -> None:
+    chain = _var_set("x", _num(42), next_block=_print(_var_get("x")))
+    result = await execute_pipeline(_pipeline(chain))
+    assert result.output == "42.0"
+
+
+async def test_get_unset_variable_returns_empty() -> None:
+    result = await execute_pipeline(_pipeline(_print(_var_get("missing"))))
+    assert result.output == ""
+
+
+async def test_overwrite_variable() -> None:
+    chain = _var_set(
+        "x",
+        _text("first"),
+        next_block=_var_set(
+            "x",
+            _text("second"),
+            next_block=_print(_var_get("x")),
+        ),
+    )
+    result = await execute_pipeline(_pipeline(chain))
+    assert result.output == "second"
+
+
+async def test_multiple_variables() -> None:
+    chain = _var_set(
+        "a",
+        _text("hello"),
+        next_block=_var_set(
+            "b",
+            _text(" world"),
+            next_block={
+                "type": "text_print",
+                "id": "p1",
+                "inputs": {
+                    "TEXT": {
+                        "block": {
+                            "type": "text_join",
+                            "id": "j1",
+                            "inputs": {
+                                "ADD0": {"block": _var_get("a")},
+                                "ADD1": {"block": {"type": "variables_get", "id": "vg2", "fields": {"VAR": "b"}}},
+                            },
+                        }
+                    }
+                },
+            },
+        ),
+    )
+    result = await execute_pipeline(_pipeline(chain))
+    assert result.output == "hello world"


### PR DESCRIPTION
- Add 45 block handlers: math (12), text (11), logic (7), loops (5), lists (10), variables (2)
- Refactor class-based handlers to function-based with @handler decorator
- Add resolve.py — shared typed input resolution (num, string, items, etc.)
- Extract errors.py from context.py
- Replace SQS/SNS with Step Functions for pipeline execution
- Remove run table — workspace.run field stores execution state
- Add CloudWatch alarms with email subscription
- Engine Lambda is pure — no boto3, no config, no AWS dependencies
- 240 tests passing, zero pyright errors