### PR TITLE
Refactor API layer: lint rules, model validators, type safety

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pydantic-settings[yaml]>=2.9",
     "langgraph>=1.1",
     "langchain-core>=1.2",
+    "langchain-litellm>=0.6",
     "litellm>=1.83",
 ]
 
@@ -67,6 +68,30 @@ include = ["src"]
 venvPath = "."
 venv = ".venv"
 
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/api/repositories/dynamodb"
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/api/repositories/sqlite"
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportAttributeAccessIssue = false
+
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/api/routers"
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/engine"
+reportOperatorIssue = false
+reportUnknownVariableType = false
+reportUnknownMemberType = false
+reportUnknownArgumentType = false
+reportArgumentType = false
+
 ###############################################################################
 # Linting
 ###############################################################################
@@ -76,11 +101,95 @@ indent-width = 4
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "UP", "I", "T20", "LOG", "ANN", "FA"]
-ignore = ["E712", "ANN401"]
+select = [
+    # --- Correctness ---
+    "E",     ## pycodestyle errors
+    "W",     ## pycodestyle warnings
+    "F",     ## Pyflakes
+    "ASYNC", ## flake8-async
+    "S",     ## flake8-bandit
+    "BLE",   ## flake8-blind-except
+    "B",     ## flake8-bugbear
+    "A",     ## flake8-builtins
+    "DTZ",   ## flake8-datetimez
+    "T10",   ## flake8-debugger
+    "FAST",  ## FastAPI
+    "ISC",   ## flake8-implicit-str-concat
+    "INP",   ## flake8-no-pep420
+    "PGH",   ## pygrep-hooks
+    "PLE",   ## Pylint Error
+    "PLW",   ## Pylint Warning
+    # --- Style ---
+    "N",     ## pep8-naming
+    "UP",    ## pyupgrade
+    "I",     ## isort
+    "ANN",   ## flake8-annotations
+    "FA",    ## flake8-future-annotations
+    "FBT",   ## flake8-boolean-trap
+    "COM",   ## flake8-commas
+    "C4",    ## flake8-comprehensions
+    "ERA",   ## eradicate
+    "FIX",   ## flake8-fixme
+    "ICN",   ## flake8-import-conventions
+    "LOG",   ## flake8-logging
+    "G",     ## flake8-logging-format
+    "PIE",   ## flake8-pie
+    "T20",   ## flake8-print
+    "RSE",   ## flake8-raise
+    "RET",   ## flake8-return
+    "SLF",   ## flake8-self
+    "SIM",   ## flake8-simplify
+    "TID",   ## flake8-tidy-imports
+    "TC",    ## flake8-type-checking
+    "ARG",   ## flake8-unused-arguments
+    "PTH",   ## flake8-use-pathlib
+    "FLY",   ## flynt
+    "FURB",  ## refurb
+    "RUF",   ## Ruff-specific rules
+    # --- Complexity ---
+    "C90",   ## mccabe
+    "PLC",   ## Pylint Convention
+    "PLR",   ## Pylint Refactor
+    "PERF",  ## Perflint
+    "TRY",   ## tryceratops
+    # --- Testing ---
+    "PT",    ## flake8-pytest-style
+]
+ignore = [
+    # --- Docs (temporarily disabled) ---
+    "D",     ## pydocstyle
+    "DOC",   ## pydoclint
+    # --- Not relevant ---
+    "AIR",   ## Airflow
+    "CPY",   ## flake8-copyright
+    "DJ",    ## flake8-django
+    "EXE",   ## flake8-executable
+"INT",   ## flake8-gettext
+    "NPY",   ## NumPy-specific rules
+    "PD",    ## pandas-vet
+    "PYI",   ## flake8-pyi
+    # --- By choice ---
+"S104",  ## possible-binding-to-all-interfaces (server config needs 0.0.0.0)
+    "TRY003", ## raise-vanilla-args (same rationale as EM)
+    "EM",    ## flake8-errmsg
+"COM812", ## missing-trailing-comma (formatter handles this)
+    "Q",     ## flake8-quotes (formatter handles this)
+    "SLOT",  ## flake8-slots (Pydantic handles this)
+    "TD",    ## flake8-todos (using TODO.md instead)
+    "YTT",   ## flake8-2020 (not doing version checks)
+]
 fixable = ["ALL"]
 unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"src/openfactcheck/api/*" = [
+    "TCH",  ## Pydantic needs to evaluate types at runtime.
+]
+"src/openfactcheck/engine/handlers/*" = [
+    "PLR0911",  ## dispatch-style handlers have many return statements.
+    "S311",     ## Blockly handlers use random for non-crypto purposes.
+]
 
 ###############################################################################
 # Formatting
@@ -104,6 +213,7 @@ dev = [
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
     "pytest-asyncio>=0.26",
+    "pytest-mock>=3.14",
     "httpx>=0.28",
     "boto3-stubs[dynamodb]>=1.35",
     "moto[dynamodb]>=5.1",

--- a/src/openfactcheck/api/auth/__init__.py
+++ b/src/openfactcheck/api/auth/__init__.py
@@ -1,8 +1,11 @@
-"""Authentication — Cognito JWT verification and dev bypass."""
+"""Authentication — token verification implementations."""
 
-from openfactcheck.api.auth.cognito import CognitoVerifier, DevVerifier
+from openfactcheck.api.auth.cognito import CognitoVerifier
+from openfactcheck.api.auth.dev import DevVerifier
+from openfactcheck.api.auth.protocols import TokenVerifier
 
 __all__ = [
     "CognitoVerifier",
     "DevVerifier",
+    "TokenVerifier",
 ]

--- a/src/openfactcheck/api/auth/cognito.py
+++ b/src/openfactcheck/api/auth/cognito.py
@@ -1,18 +1,10 @@
-"""Cognito JWT verification and dev bypass."""
-
-from typing import Protocol
+"""Cognito JWT verification — validates ID tokens against JWKS."""
 
 import jwt
 from jwt import PyJWKClient
 
 from openfactcheck.api.errors import AuthError
 from openfactcheck.api.models import AuthUser
-
-
-class TokenVerifier(Protocol):
-    """Interface for verifying an Authorization bearer token."""
-
-    def verify(self, token: str) -> AuthUser: ...
 
 
 class CognitoVerifier:
@@ -62,18 +54,3 @@ class CognitoVerifier:
             name = ""
 
         return AuthUser(sub=sub, email=email, name=name)
-
-
-DEV_USER = AuthUser(
-    sub="dev-user-00000000",
-    email="dev@localhost",
-    name="Dev User",
-)
-
-
-class DevVerifier:
-    """Bypass verifier for local development. Always returns a fixed dev user."""
-
-    def verify(self, token: str) -> AuthUser:  # noqa: ARG002
-        """Return the hardcoded dev user regardless of the token value."""
-        return DEV_USER

--- a/src/openfactcheck/api/auth/dev.py
+++ b/src/openfactcheck/api/auth/dev.py
@@ -1,0 +1,17 @@
+"""Dev bypass verifier — always returns a fixed user, no token validation."""
+
+from openfactcheck.api.models import AuthUser
+
+DEV_USER = AuthUser(
+    sub="dev-user-00000000",
+    email="dev@localhost",
+    name="Dev User",
+)
+
+
+class DevVerifier:
+    """Bypass verifier for local development. Always returns a fixed dev user."""
+
+    def verify(self, token: str) -> AuthUser:  # noqa: ARG002 - required by TokenVerifier protocol.
+        """Return the hardcoded dev user regardless of the token value."""
+        return DEV_USER

--- a/src/openfactcheck/api/auth/protocols.py
+++ b/src/openfactcheck/api/auth/protocols.py
@@ -1,0 +1,11 @@
+"""Token verifier protocol — interface for all auth implementations."""
+
+from typing import Protocol
+
+from openfactcheck.api.models import AuthUser
+
+
+class TokenVerifier(Protocol):
+    """Interface for verifying an Authorization bearer token."""
+
+    def verify(self, token: str) -> AuthUser: ...

--- a/src/openfactcheck/api/dependencies.py
+++ b/src/openfactcheck/api/dependencies.py
@@ -1,16 +1,24 @@
 """FastAPI dependency injection — settings, auth, repositories."""
 
-import asyncio
 from functools import lru_cache
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import Depends, Header
 
-from openfactcheck.api.auth.cognito import CognitoVerifier, DevVerifier, TokenVerifier
+from openfactcheck.api.auth.cognito import CognitoVerifier
+from openfactcheck.api.auth.dev import DevVerifier
+from openfactcheck.api.auth.protocols import TokenVerifier
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.errors import AuthError
 from openfactcheck.api.models import AuthUser
-from openfactcheck.api.repositories.protocols import ProjectRepository, WorkspaceRepository
+from openfactcheck.api.repositories.protocols import (
+    ProjectRepository,
+    WorkspaceRepository,
+)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 
 
 @lru_cache(maxsize=1)
@@ -19,40 +27,36 @@ def get_config() -> APIConfig:
     return APIConfig()
 
 
-_verifier: TokenVerifier | None = None
-_project_repo: ProjectRepository | None = None
-_workspace_repo: WorkspaceRepository | None = None
-_sqlite_session_factory: Any = None
-_sqlite_lock = asyncio.Lock()
+class _State:
+    """Lazy singletons for dependency injection."""
+
+    verifier: TokenVerifier | None = None
+    project_repo: ProjectRepository | None = None
+    workspace_repo: WorkspaceRepository | None = None
 
 
-async def _get_sqlite_session_factory(config: APIConfig) -> Any:  # noqa: ANN401
-    """Return a shared SQLite session factory, creating the engine once (thread-safe)."""
-    global _sqlite_session_factory  # noqa: PLW0603
-    if _sqlite_session_factory is not None:
-        return _sqlite_session_factory
-    async with _sqlite_lock:
-        if _sqlite_session_factory is None:
-            from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
-
-            engine = await create_engine_and_tables(config.sqlite_path)
-            _sqlite_session_factory = session_factory(engine)
-    return _sqlite_session_factory
+_state = _State()
 
 
-async def get_verifier(config: Annotated[APIConfig, Depends(get_config)]) -> TokenVerifier:
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+async def get_verifier(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> TokenVerifier:
     """Return the token verifier, creating it on first call."""
-    global _verifier  # noqa: PLW0603
-    if _verifier is None:
+    if _state.verifier is None:
         if config.auth_bypass and config.debug:
-            _verifier = DevVerifier()
+            _state.verifier = DevVerifier()
         else:
-            _verifier = CognitoVerifier(
+            _state.verifier = CognitoVerifier(
                 region=config.cognito_region,
                 user_pool_id=config.cognito_user_pool_id,
                 client_id=config.cognito_client_id,
             )
-    return _verifier
+    return _state.verifier
 
 
 async def get_current_user(
@@ -67,44 +71,70 @@ async def get_current_user(
     if authorization is None:
         raise AuthError("Missing Authorization header")
 
-    parts = authorization.split(" ", maxsplit=1)
-    if len(parts) != 2 or parts[0].lower() != "bearer":
+    try:
+        scheme, token = authorization.split(" ", maxsplit=1)
+    except ValueError:
+        raise AuthError("Authorization header must be: Bearer <token>") from None
+    if scheme.lower() != "bearer":
         raise AuthError("Authorization header must be: Bearer <token>")
 
-    return verifier.verify(parts[1])
+    return verifier.verify(token)
+
+
+# ---------------------------------------------------------------------------
+# Repositories
+# ---------------------------------------------------------------------------
+
+
+async def _init_repos(config: APIConfig) -> None:
+    """Wire up all repository singletons based on config mode."""
+    if config.mode == "cloud":
+        from openfactcheck.api.repositories.dynamodb.projects import (  # noqa: PLC0415 - lazy import for optional backend.
+            DynamoProjectRepository,
+        )
+        from openfactcheck.api.repositories.dynamodb.workspaces import (  # noqa: PLC0415 - lazy import for optional backend.
+            DynamoWorkspaceRepository,
+        )
+
+        _state.project_repo = DynamoProjectRepository(config.dynamodb_table_name, config.dynamodb_region)
+        _state.workspace_repo = DynamoWorkspaceRepository(config.dynamodb_table_name, config.dynamodb_region)
+    else:
+        from openfactcheck.api.repositories.sqlite.engine import (  # noqa: PLC0415 - lazy import for optional backend.
+            create_engine,
+            create_session_factory,
+            create_tables,
+        )
+        from openfactcheck.api.repositories.sqlite.projects import (  # noqa: PLC0415 - lazy import for optional backend.
+            SqliteProjectRepository,
+        )
+        from openfactcheck.api.repositories.sqlite.workspaces import (  # noqa: PLC0415 - lazy import for optional backend.
+            SqliteWorkspaceRepository,
+        )
+
+        engine = create_engine(config.sqlite_path)
+        await create_tables(engine)
+        sf = create_session_factory(engine)
+        _state.project_repo = SqliteProjectRepository(sf)
+        _state.workspace_repo = SqliteWorkspaceRepository(sf)
 
 
 async def get_project_repo(
     config: Annotated[APIConfig, Depends(get_config)],
 ) -> ProjectRepository:
-    """Return the project repository, creating it on first call."""
-    global _project_repo  # noqa: PLW0603
-    if _project_repo is None:
-        if config.mode == "cloud":
-            from openfactcheck.api.repositories.dynamodb.projects import DynamoProjectRepository
-
-            _project_repo = DynamoProjectRepository(config.dynamodb_table_name, config.dynamodb_region)
-        else:
-            from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
-
-            sf = await _get_sqlite_session_factory(config)
-            _project_repo = SqliteProjectRepository(sf)
-    return _project_repo
+    """Return the project repository."""
+    if _state.project_repo is None:
+        await _init_repos(config)
+    if _state.project_repo is None:
+        raise RuntimeError("Failed to initialize project repository")
+    return _state.project_repo
 
 
 async def get_workspace_repo(
     config: Annotated[APIConfig, Depends(get_config)],
 ) -> WorkspaceRepository:
-    """Return the workspace repository, creating it on first call."""
-    global _workspace_repo  # noqa: PLW0603
-    if _workspace_repo is None:
-        if config.mode == "cloud":
-            from openfactcheck.api.repositories.dynamodb.workspaces import DynamoWorkspaceRepository
-
-            _workspace_repo = DynamoWorkspaceRepository(config.dynamodb_table_name, config.dynamodb_region)
-        else:
-            from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
-
-            sf = await _get_sqlite_session_factory(config)
-            _workspace_repo = SqliteWorkspaceRepository(sf)
-    return _workspace_repo
+    """Return the workspace repository."""
+    if _state.workspace_repo is None:
+        await _init_repos(config)
+    if _state.workspace_repo is None:
+        raise RuntimeError("Failed to initialize workspace repository")
+    return _state.workspace_repo

--- a/src/openfactcheck/api/middleware.py
+++ b/src/openfactcheck/api/middleware.py
@@ -38,8 +38,8 @@ async def generic_error_handler(_request: Request, exc: Exception) -> JSONRespon
 
 def register_middleware(app: FastAPI, cors_origins: list[str]) -> None:
     """Register all middleware and exception handlers on the app."""
-    app.add_exception_handler(AppError, app_error_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(Exception, generic_error_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(AppError, app_error_handler)  # pyright: ignore[reportArgumentType] - Starlette handler type is broader than actual dispatch.
+    app.add_exception_handler(Exception, generic_error_handler)  # pyright: ignore[reportArgumentType] - Starlette handler type is broader than actual dispatch.
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/openfactcheck/api/models/__init__.py
+++ b/src/openfactcheck/api/models/__init__.py
@@ -3,23 +3,23 @@
 from openfactcheck.api.models.project import Project, ProjectCreate, ProjectUpdate
 from openfactcheck.api.models.user import AuthUser
 from openfactcheck.api.models.workspace import (
-    RunStatus,
     Workspace,
     WorkspaceCreate,
     WorkspaceRun,
+    WorkspaceRunStatus,
     WorkspaceSettings,
     WorkspaceUpdate,
 )
 
 __all__ = [
     "AuthUser",
-    "RunStatus",
     "Project",
     "ProjectCreate",
     "ProjectUpdate",
     "Workspace",
     "WorkspaceCreate",
     "WorkspaceRun",
+    "WorkspaceRunStatus",
     "WorkspaceSettings",
     "WorkspaceUpdate",
 ]

--- a/src/openfactcheck/api/models/project.py
+++ b/src/openfactcheck/api/models/project.py
@@ -2,22 +2,39 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from openfactcheck.api.models.validators import normalize_datetime, to_camel
+
+# ---------------------------------------------------------------------------
+# Project
+# ---------------------------------------------------------------------------
 
 
 class Project(BaseModel):
     """A user's fact-checking project."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
+
     id: str
     user_id: str
     name: str
-    description: str
+    description: str = ""
     created_at: datetime
     updated_at: datetime
+
+    _normalize_datetime = field_validator("created_at", "updated_at", mode="before")(normalize_datetime)
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
 
 
 class ProjectCreate(BaseModel):
     """Fields required to create a new project."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     name: str = Field(min_length=1, max_length=255)
     description: str = Field(default="", max_length=10000)
@@ -25,6 +42,8 @@ class ProjectCreate(BaseModel):
 
 class ProjectUpdate(BaseModel):
     """Fields that can be updated on a project. All optional."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=10000)

--- a/src/openfactcheck/api/models/types.py
+++ b/src/openfactcheck/api/models/types.py
@@ -1,0 +1,8 @@
+"""Shared type aliases for API models."""
+
+from __future__ import annotations
+
+type JSONString = str
+type JSONScalar = str | int | float | bool | None
+type JSONValue = JSONScalar | dict[str, JSONValue] | list[JSONValue]
+type JSONObject = dict[str, JSONValue]

--- a/src/openfactcheck/api/models/validators.py
+++ b/src/openfactcheck/api/models/validators.py
@@ -1,0 +1,24 @@
+"""Shared Pydantic validators and config helpers for model fields."""
+
+from datetime import UTC, datetime
+
+
+def to_camel(s: str) -> str:
+    """Convert snake_case to camelCase."""
+    parts = s.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+def normalize_datetime(v: datetime | str) -> datetime:
+    """Parse ISO strings and ensure all datetimes are UTC."""
+    dt = datetime.fromisoformat(v) if isinstance(v, str) else v
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def normalize_datetime_optional(v: datetime | str | None) -> datetime | None:
+    """Parse ISO strings and ensure all datetimes are UTC. Accepts None."""
+    if v is None:
+        return None
+    return normalize_datetime(v)

--- a/src/openfactcheck/api/models/workspace.py
+++ b/src/openfactcheck/api/models/workspace.py
@@ -1,12 +1,22 @@
 """Workspace domain model."""
 
+from __future__ import annotations
+
+import json
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from openfactcheck.api.models.types import JSONObject, JSONString, JSONValue
+from openfactcheck.api.models.validators import normalize_datetime, normalize_datetime_optional, to_camel
+
+# ---------------------------------------------------------------------------
+# WorkspaceRun
+# ---------------------------------------------------------------------------
 
 
-class RunStatus(StrEnum):
+class WorkspaceRunStatus(StrEnum):
     """Lifecycle states for a pipeline run."""
 
     RUNNING = "running"
@@ -17,21 +27,74 @@ class RunStatus(StrEnum):
 class WorkspaceRun(BaseModel):
     """Latest pipeline run state for a workspace."""
 
-    status: RunStatus
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    status: WorkspaceRunStatus
     output: str = ""
     error: str = ""
     started_at: datetime | None = None
     completed_at: datetime | None = None
 
+    _normalize_datetime = field_validator("started_at", "completed_at", mode="before")(normalize_datetime_optional)
+
+    def _check_running(self) -> None:
+        if self.started_at is None:
+            raise ValueError("Running run must have started_at")
+        if self.completed_at is not None:
+            raise ValueError("Running run must not have completed_at")
+        if self.error:
+            raise ValueError("Running run must not have error")
+
+    def _check_completed(self) -> None:
+        if self.completed_at is None:
+            raise ValueError("Completed run must have completed_at")
+        if self.error:
+            raise ValueError("Completed run must not have error")
+
+    def _check_failed(self) -> None:
+        if self.completed_at is None:
+            raise ValueError("Failed run must have completed_at")
+        if not self.error:
+            raise ValueError("Failed run must have error")
+
+    @model_validator(mode="after")
+    def _check_state_invariants(self) -> WorkspaceRun:
+        match self.status:
+            case WorkspaceRunStatus.RUNNING:
+                self._check_running()
+            case WorkspaceRunStatus.COMPLETED:
+                self._check_completed()
+            case WorkspaceRunStatus.FAILED:
+                self._check_failed()
+
+        if self.started_at and self.completed_at and self.completed_at < self.started_at:
+            raise ValueError("completed_at must be >= started_at")
+
+        return self
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceSettings
+# ---------------------------------------------------------------------------
+
 
 class WorkspaceSettings(BaseModel):
     """Optional per-workspace configuration."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     verbose_mode: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
 
 
 class Workspace(BaseModel):
     """A workspace within a project, containing a single pipeline configuration."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
 
     id: str
     user_id: str
@@ -39,16 +102,55 @@ class Workspace(BaseModel):
     name: str
     description: str = ""
     locked: bool = False
-    sort_order: int
-    settings: WorkspaceSettings = Field(default_factory=WorkspaceSettings)
-    content: dict[str, object] | None = None
-    run: WorkspaceRun | None = None
+    sort_order: int = 0
+    settings: WorkspaceSettings = Field(
+        default_factory=WorkspaceSettings, validation_alias=AliasChoices("settings", "settings_json")
+    )
+    content: JSONObject | None = Field(default=None, validation_alias=AliasChoices("content", "content_json"))
+    run: WorkspaceRun | None = Field(default=None, validation_alias=AliasChoices("run", "run_json"))
     created_at: datetime
     updated_at: datetime
+
+    _normalize_datetime = field_validator("created_at", "updated_at", mode="before")(normalize_datetime)
+
+    @field_validator("settings", mode="before")
+    @classmethod
+    def _parse_settings(cls, v: JSONString | JSONObject | WorkspaceSettings) -> WorkspaceSettings:
+        if isinstance(v, str):
+            return WorkspaceSettings.model_validate_json(v)
+        if isinstance(v, dict):
+            return WorkspaceSettings.model_validate(v)
+        return v
+
+    @field_validator("content", mode="before")
+    @classmethod
+    def _parse_content(cls, v: JSONString | JSONObject | None) -> JSONObject | None:
+        if isinstance(v, str):
+            parsed: JSONValue = json.loads(v)
+            if not isinstance(parsed, dict):
+                raise ValueError(f"Expected JSON object, got {type(parsed).__name__}")  # noqa: TRY004 - Pydantic validators must raise ValueError.
+            return parsed
+        return v
+
+    @field_validator("run", mode="before")
+    @classmethod
+    def _parse_run(cls, v: JSONString | JSONObject | WorkspaceRun | None) -> WorkspaceRun | None:
+        if isinstance(v, str):
+            return WorkspaceRun.model_validate_json(v)
+        if isinstance(v, dict):
+            return WorkspaceRun.model_validate(v)
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
 
 
 class WorkspaceCreate(BaseModel):
     """Fields required to create a new workspace."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     name: str = Field(min_length=1, max_length=255)
     description: str = Field(default="", max_length=10000)
@@ -57,8 +159,10 @@ class WorkspaceCreate(BaseModel):
 class WorkspaceUpdate(BaseModel):
     """Fields that can be updated on a workspace. All optional."""
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
     name: str | None = Field(default=None, min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=10000)
     locked: bool | None = None
     settings: WorkspaceSettings | None = None
-    content: dict[str, object] | None = None
+    content: JSONObject | None = None

--- a/src/openfactcheck/api/repositories/__init__.py
+++ b/src/openfactcheck/api/repositories/__init__.py
@@ -1,6 +1,9 @@
 """Repository layer — data access protocols and implementations."""
 
-from openfactcheck.api.repositories.protocols import ProjectRepository, WorkspaceRepository
+from openfactcheck.api.repositories.protocols import (
+    ProjectRepository,
+    WorkspaceRepository,
+)
 
 __all__ = [
     "ProjectRepository",

--- a/src/openfactcheck/api/repositories/dynamodb/base.py
+++ b/src/openfactcheck/api/repositories/dynamodb/base.py
@@ -1,11 +1,10 @@
-# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
 """Generic DynamoDB repository base — models own their keys, base handles CRUD."""
 
 import asyncio
-from typing import Any
 
 from openfactcheck.api.repositories.dynamodb.client import get_table
 from openfactcheck.api.repositories.dynamodb.helpers import build_update_expression
+from openfactcheck.api.repositories.dynamodb.types import DynamoItem
 
 
 class BaseDynamoRepository:
@@ -17,34 +16,38 @@ class BaseDynamoRepository:
     def __init__(self, table_name: str, region_name: str = "us-east-1") -> None:
         self._table = get_table(table_name, region_name)
 
-    # -------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
     # Core operations
-    # -------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
 
-    async def _put(self, item: dict[str, Any]) -> None:
+    async def _put(self, item: DynamoItem) -> None:
         """Write an item to the table."""
-        await asyncio.to_thread(self._table.put_item, Item=item)
 
-    async def _get(self, pk: str, sk: str) -> dict[str, Any] | None:
+        def _do() -> None:
+            self._table.put_item(Item=item)
+
+        await asyncio.to_thread(_do)
+
+    async def _get(self, pk: str, sk: str) -> DynamoItem | None:
         """Get a single item by PK + SK."""
 
-        def _do() -> dict[str, Any] | None:
+        def _do() -> DynamoItem | None:
             response = self._table.get_item(Key={"PK": pk, "SK": sk})
             return response.get("Item")
 
         return await asyncio.to_thread(_do)
 
-    async def _update(self, pk: str, sk: str, values: dict[str, Any]) -> dict[str, Any] | None:
+    async def _update(self, pk: str, sk: str, values: DynamoItem) -> DynamoItem | None:
         """Update an item. Returns updated attributes or None if not found."""
-        update_expr, attr_names, attr_values = build_update_expression(values)
+        update = build_update_expression(values)
 
-        def _do() -> dict[str, Any] | None:
+        def _do() -> DynamoItem | None:
             try:
-                response: dict[str, Any] = self._table.update_item(
+                response = self._table.update_item(
                     Key={"PK": pk, "SK": sk},
-                    UpdateExpression=update_expr,
-                    ExpressionAttributeNames=attr_names,
-                    ExpressionAttributeValues=attr_values,
+                    UpdateExpression=update.expression,
+                    ExpressionAttributeNames=update.attr_names,
+                    ExpressionAttributeValues=update.attr_values,
                     ConditionExpression="attribute_exists(PK)",
                     ReturnValues="ALL_NEW",
                 )
@@ -69,20 +72,20 @@ class BaseDynamoRepository:
 
         return await asyncio.to_thread(_do)
 
-    # -------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
     # Query operations
-    # -------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------
 
     async def _query_by_pk(
         self,
         pk: str,
         sk_prefix: str | None = None,
         projection: str | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[DynamoItem]:
         """Query base table by PK, optionally filtering SK by prefix."""
 
-        def _do() -> list[dict[str, Any]]:
-            kwargs: dict[str, Any] = {
+        def _do() -> list[DynamoItem]:
+            kwargs: DynamoItem = {
                 "KeyConditionExpression": "PK = :pk",
                 "ExpressionAttributeValues": {":pk": pk},
             }
@@ -97,10 +100,10 @@ class BaseDynamoRepository:
 
         return await asyncio.to_thread(_do)
 
-    async def _query_gsi(self, index_name: str, key_name: str, key_value: str) -> list[dict[str, Any]]:
+    async def _query_gsi(self, index_name: str, key_name: str, key_value: str) -> list[DynamoItem]:
         """Query a GSI by its partition key."""
 
-        def _do() -> list[dict[str, Any]]:
+        def _do() -> list[DynamoItem]:
             response = self._table.query(
                 IndexName=index_name,
                 KeyConditionExpression=f"{key_name} = :val",
@@ -110,7 +113,7 @@ class BaseDynamoRepository:
 
         return await asyncio.to_thread(_do)
 
-    async def _batch_delete(self, items: list[dict[str, Any]]) -> None:
+    async def _batch_delete(self, items: list[DynamoItem]) -> None:
         """Batch delete items that have PK and SK attributes."""
 
         def _do() -> None:

--- a/src/openfactcheck/api/repositories/dynamodb/client.py
+++ b/src/openfactcheck/api/repositories/dynamodb/client.py
@@ -1,12 +1,21 @@
-# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
 """boto3 DynamoDB table resource factory."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import boto3
 
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb.service_resource import DynamoDBServiceResource, Table
 
-def get_table(table_name: str, region_name: str = "us-east-1") -> Any:  # noqa: ANN401
+
+def get_table(table_name: str, region_name: str = "us-east-1") -> Table:
     """Return a boto3 DynamoDB Table resource."""
-    resource = boto3.resource("dynamodb", region_name=region_name)
+
+    resource: DynamoDBServiceResource = boto3.resource(
+        "dynamodb",
+        region_name=region_name,
+    )
+
     return resource.Table(table_name)

--- a/src/openfactcheck/api/repositories/dynamodb/helpers.py
+++ b/src/openfactcheck/api/repositories/dynamodb/helpers.py
@@ -1,36 +1,41 @@
 """Shared helpers for DynamoDB repository implementations."""
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import NamedTuple
+
+from openfactcheck.api.repositories.dynamodb.types import AttrNames, AttrValues, DynamoItem
+
+
+class UpdateExpression(NamedTuple):
+    """DynamoDB SET update expression with attribute name/value mappings."""
+
+    expression: str
+    attr_names: AttrNames
+    attr_values: AttrValues
 
 
 def build_update_expression(
-    values: dict[str, Any],
+    values: DynamoItem,
     timestamp_field: str = "updatedAt",
-) -> tuple[str, dict[str, str], dict[str, Any]]:
+) -> UpdateExpression:
     """Build a DynamoDB SET update expression from a values dict.
 
     Automatically appends an updatedAt timestamp.
-
-    Returns:
-        (update_expression, attr_names, attr_values)
     """
     update_parts: list[str] = []
-    attr_names: dict[str, str] = {}
-    attr_values: dict[str, Any] = {}
+    attr_names: AttrNames = {}
+    attr_values: AttrValues = {}
 
-    for field, value in values.items():
+    def _add(field: str, value: object) -> None:
         alias = f"#{field}"
         placeholder = f":{field}"
         update_parts.append(f"{alias} = {placeholder}")
         attr_names[alias] = field
         attr_values[placeholder] = value
 
-    now = datetime.now(UTC)
-    alias = f"#{timestamp_field}"
-    placeholder = f":{timestamp_field}"
-    update_parts.append(f"{alias} = {placeholder}")
-    attr_names[alias] = timestamp_field
-    attr_values[placeholder] = now.isoformat()
+    for field, value in values.items():
+        _add(field, value)
 
-    return "SET " + ", ".join(update_parts), attr_names, attr_values
+    _add(timestamp_field, datetime.now(UTC).isoformat())
+
+    return UpdateExpression("SET " + ", ".join(update_parts), attr_names, attr_values)

--- a/src/openfactcheck/api/repositories/dynamodb/projects.py
+++ b/src/openfactcheck/api/repositories/dynamodb/projects.py
@@ -1,24 +1,16 @@
-# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
 """DynamoDB implementation of the project repository."""
 
 from datetime import UTC, datetime
-from typing import Any
 
 from openfactcheck.api.models import Project, ProjectCreate, ProjectUpdate
 from openfactcheck.api.repositories.constants import MAX_PROJECTS_PER_USER, generate_id
 from openfactcheck.api.repositories.dynamodb.base import BaseDynamoRepository
-from openfactcheck.api.repositories.dynamodb.keys import project_pk, project_sk, workspace_pk
-
-
-def _item_to_model(item: dict[str, Any]) -> Project:
-    return Project(
-        id=item["id"],
-        user_id=item["userId"],
-        name=item["name"],
-        description=item.get("description", ""),
-        created_at=datetime.fromisoformat(item["createdAt"]),
-        updated_at=datetime.fromisoformat(item["updatedAt"]),
-    )
+from openfactcheck.api.repositories.dynamodb.keys import (
+    project_pk,
+    project_sk,
+    workspace_pk,
+)
+from openfactcheck.api.repositories.dynamodb.types import DynamoItem
 
 
 class DynamoProjectRepository(BaseDynamoRepository):
@@ -26,12 +18,12 @@ class DynamoProjectRepository(BaseDynamoRepository):
 
     async def list_by_user(self, user_id: str, limit: int = 50, offset: int = 0) -> list[Project]:
         items = await self._query_by_pk(project_pk(user_id), sk_prefix="PROJECT#")
-        projects = sorted((_item_to_model(item) for item in items), key=lambda p: p.created_at)
+        projects = sorted((Project.model_validate(item) for item in items), key=lambda p: p.created_at)
         return projects[offset : offset + limit]
 
     async def get(self, user_id: str, project_id: str) -> Project | None:
         item = await self._get(project_pk(user_id), project_sk(project_id))
-        return _item_to_model(item) if item else None
+        return Project.model_validate(item) if item else None
 
     async def create(self, user_id: str, data: ProjectCreate) -> Project | None:
         items = await self._query_by_pk(project_pk(user_id), sk_prefix="PROJECT#")
@@ -40,7 +32,7 @@ class DynamoProjectRepository(BaseDynamoRepository):
 
         now = datetime.now(UTC)
         pid = generate_id()
-        item: dict[str, Any] = {
+        item: DynamoItem = {
             "PK": project_pk(user_id),
             "SK": project_sk(pid),
             "id": pid,
@@ -51,7 +43,7 @@ class DynamoProjectRepository(BaseDynamoRepository):
             "updatedAt": now.isoformat(),
         }
         await self._put(item)
-        return _item_to_model(item)
+        return Project.model_validate(item)
 
     async def update(self, user_id: str, project_id: str, data: ProjectUpdate) -> Project | None:
         values = data.model_dump(exclude_none=True)
@@ -59,7 +51,7 @@ class DynamoProjectRepository(BaseDynamoRepository):
             return await self.get(user_id, project_id)
 
         attrs = await self._update(project_pk(user_id), project_sk(project_id), values)
-        return _item_to_model(attrs) if attrs else None
+        return Project.model_validate(attrs) if attrs else None
 
     async def delete(self, user_id: str, project_id: str) -> bool:
         deleted = await self._delete(project_pk(user_id), project_sk(project_id))

--- a/src/openfactcheck/api/repositories/dynamodb/types.py
+++ b/src/openfactcheck/api/repositories/dynamodb/types.py
@@ -1,0 +1,7 @@
+"""Shared type aliases for DynamoDB repositories."""
+
+from typing import Any
+
+type DynamoItem = dict[str, Any]
+type AttrNames = dict[str, str]
+type AttrValues = dict[str, Any]

--- a/src/openfactcheck/api/repositories/dynamodb/workspaces.py
+++ b/src/openfactcheck/api/repositories/dynamodb/workspaces.py
@@ -1,60 +1,37 @@
-# pyright: reportMissingTypeStubs=false, reportUnknownMemberType=false, reportUnknownVariableType=false
 """DynamoDB implementation of the workspace repository."""
 
 import asyncio
 from datetime import UTC, datetime
-from typing import Any
 
-from openfactcheck.api.models import Workspace, WorkspaceCreate, WorkspaceRun, WorkspaceSettings, WorkspaceUpdate
-from openfactcheck.api.repositories.constants import MAX_WORKSPACES_PER_PROJECT, generate_id
+from openfactcheck.api.models import (
+    Workspace,
+    WorkspaceCreate,
+    WorkspaceRun,
+    WorkspaceUpdate,
+)
+from openfactcheck.api.repositories.constants import (
+    MAX_WORKSPACES_PER_PROJECT,
+    generate_id,
+)
 from openfactcheck.api.repositories.dynamodb.base import BaseDynamoRepository
 from openfactcheck.api.repositories.dynamodb.keys import workspace_pk, workspace_sk
-
-
-def _parse_run(raw: dict[str, Any] | None) -> WorkspaceRun | None:
-    if raw is None:
-        return None
-    return WorkspaceRun.model_validate(raw)
-
-
-def _item_to_model(item: dict[str, Any]) -> Workspace:
-    settings_raw = item.get("settings", {})
-    settings = (
-        WorkspaceSettings.model_validate(settings_raw)
-        if isinstance(settings_raw, dict)
-        else WorkspaceSettings.model_validate_json(settings_raw)
-    )
-
-    return Workspace(
-        id=item["id"],
-        user_id=item["userId"],
-        project_id=item["projectId"],
-        name=item["name"],
-        description=item.get("description", ""),
-        locked=item.get("locked", False),
-        sort_order=int(item.get("sortOrder", 0)),
-        settings=settings,
-        content=item.get("content"),
-        run=_parse_run(item.get("run")),
-        created_at=datetime.fromisoformat(item["createdAt"]),
-        updated_at=datetime.fromisoformat(item["updatedAt"]),
-    )
+from openfactcheck.api.repositories.dynamodb.types import DynamoItem
 
 
 class DynamoWorkspaceRepository(BaseDynamoRepository):
     """Workspace CRUD backed by DynamoDB single-table design."""
 
-    async def _list_items(self, user_id: str, project_id: str) -> list[dict[str, Any]]:
+    async def _list_items(self, user_id: str, project_id: str) -> list[DynamoItem]:
         return await self._query_by_pk(workspace_pk(user_id, project_id), sk_prefix="WORKSPACE#")
 
     async def list_by_project(self, user_id: str, project_id: str) -> list[Workspace]:
         items = await self._list_items(user_id, project_id)
-        workspaces = [_item_to_model(item) for item in items]
+        workspaces = [Workspace.model_validate(item) for item in items]
         return sorted(workspaces, key=lambda w: w.sort_order)
 
     async def get(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
         item = await self._get(workspace_pk(user_id, project_id), workspace_sk(workspace_id))
-        return _item_to_model(item) if item else None
+        return Workspace.model_validate(item) if item else None
 
     async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None:
         items = await self._list_items(user_id, project_id)
@@ -65,7 +42,7 @@ class DynamoWorkspaceRepository(BaseDynamoRepository):
 
         now = datetime.now(UTC)
         wid = generate_id()
-        item: dict[str, Any] = {
+        item: DynamoItem = {
             "PK": workspace_pk(user_id, project_id),
             "SK": workspace_sk(wid),
             "id": wid,
@@ -80,10 +57,10 @@ class DynamoWorkspaceRepository(BaseDynamoRepository):
             "updatedAt": now.isoformat(),
         }
         await self._put(item)
-        return _item_to_model(item)
+        return Workspace.model_validate(item)
 
     async def update(self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate) -> Workspace | None:
-        values: dict[str, Any] = {}
+        values: DynamoItem = {}
         if data.name is not None:
             values["name"] = data.name
         if data.description is not None:
@@ -99,7 +76,7 @@ class DynamoWorkspaceRepository(BaseDynamoRepository):
             return await self.get(user_id, project_id, workspace_id)
 
         attrs = await self._update(workspace_pk(user_id, project_id), workspace_sk(workspace_id), values)
-        return _item_to_model(attrs) if attrs else None
+        return Workspace.model_validate(attrs) if attrs else None
 
     async def delete(self, user_id: str, project_id: str, workspace_id: str) -> bool:
         return await self._delete(workspace_pk(user_id, project_id), workspace_sk(workspace_id))
@@ -117,7 +94,7 @@ class DynamoWorkspaceRepository(BaseDynamoRepository):
 
         now = datetime.now(UTC)
         new_id = generate_id()
-        item: dict[str, Any] = {
+        item: DynamoItem = {
             "PK": workspace_pk(user_id, project_id),
             "SK": workspace_sk(new_id),
             "id": new_id,
@@ -134,7 +111,7 @@ class DynamoWorkspaceRepository(BaseDynamoRepository):
         if source.content:
             item["content"] = source.content
         await self._put(item)
-        return _item_to_model(item)
+        return Workspace.model_validate(item)
 
     async def reorder(self, user_id: str, project_id: str, ordered_ids: list[str]) -> None:
         pk = workspace_pk(user_id, project_id)

--- a/src/openfactcheck/api/repositories/protocols.py
+++ b/src/openfactcheck/api/repositories/protocols.py
@@ -37,7 +37,11 @@ class WorkspaceRepository(Protocol):
     async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None: ...
 
     async def update(
-        self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate
+        self,
+        user_id: str,
+        project_id: str,
+        workspace_id: str,
+        data: WorkspaceUpdate,
     ) -> Workspace | None: ...
 
     async def delete(self, user_id: str, project_id: str, workspace_id: str) -> bool: ...

--- a/src/openfactcheck/api/repositories/sqlite/engine.py
+++ b/src/openfactcheck/api/repositories/sqlite/engine.py
@@ -1,9 +1,15 @@
 """SQLAlchemy async engine, session factory, and declarative base."""
 
+import sqlite3
 from pathlib import Path
 
 from sqlalchemy import event
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase
 
 
@@ -11,34 +17,39 @@ class Base(DeclarativeBase):
     """Declarative base for all ORM table models."""
 
 
-async def create_engine_and_tables(sqlite_path: str) -> AsyncEngine:
-    """Create an async SQLite engine and ensure all tables exist.
+def _resolve_url(sqlite_path: str) -> str:
+    """Resolve the SQLite path and ensure the parent directory exists."""
+    if sqlite_path == ":memory:":
+        return "sqlite+aiosqlite:///:memory:"
+    resolved = Path(sqlite_path).expanduser().resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return f"sqlite+aiosqlite:///{resolved}"
 
-    The parent directory for *sqlite_path* is created if it does not exist.
-    Pass ``":memory:"`` for an in-memory database (useful in tests).
+
+def create_engine(sqlite_path: str) -> AsyncEngine:
+    """Create an async SQLite engine with foreign key enforcement.
+
+    Pass ``":memory:"`` for an in-memory database. Note: in-memory databases
+    are not shared across connections and all data is lost when the engine
+    is disposed. Use only for tests.
     """
-    if sqlite_path != ":memory:":
-        resolved = Path(sqlite_path).expanduser().resolve()
-        resolved.parent.mkdir(parents=True, exist_ok=True)
-        url = f"sqlite+aiosqlite:///{resolved}"
-    else:
-        url = "sqlite+aiosqlite:///:memory:"
+    engine = create_async_engine(_resolve_url(sqlite_path))
 
-    engine = create_async_engine(url)
-
-    # Enable foreign key enforcement (required for CASCADE to work in SQLite)
     @event.listens_for(engine.sync_engine, "connect")
-    def _enable_foreign_keys(dbapi_conn: object, _connection_record: object) -> None:  # pyright: ignore[reportUnusedFunction]
-        cursor = dbapi_conn.cursor()  # type: ignore[union-attr]
-        cursor.execute("PRAGMA foreign_keys=ON")  # type: ignore[union-attr]
-        cursor.close()  # type: ignore[union-attr]
-
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    def _enable_foreign_keys(dbapi_conn: sqlite3.Connection, _connection_record: object) -> None:  # pyright: ignore[reportUnusedFunction] - registered via SQLAlchemy event listener.
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
     return engine
 
 
-def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+async def create_tables(engine: AsyncEngine) -> None:
+    """Create all tables defined on the declarative base."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     """Return a session factory bound to *engine*."""
     return async_sessionmaker(engine, expire_on_commit=False)

--- a/src/openfactcheck/api/repositories/sqlite/helpers.py
+++ b/src/openfactcheck/api/repositories/sqlite/helpers.py
@@ -1,13 +1,8 @@
 """Shared helpers for SQLite repository implementations."""
 
-from datetime import UTC, datetime
+from openfactcheck.api.repositories.sqlite.engine import Base
 
 
-def ensure_utc(dt: datetime) -> datetime:
-    """Attach UTC tzinfo to a naive datetime from SQLite."""
-    return dt.replace(tzinfo=UTC)
-
-
-def ensure_utc_optional(dt: datetime | None) -> datetime | None:
-    """Attach UTC tzinfo to an optional naive datetime from SQLite."""
-    return dt.replace(tzinfo=UTC) if dt else None
+def row_to_dict(row: Base) -> dict[str, object]:
+    """Extract mapped column values from an ORM row, excluding ORM internals."""
+    return {c.key: getattr(row, c.key) for c in row.__table__.columns}

--- a/src/openfactcheck/api/repositories/sqlite/projects.py
+++ b/src/openfactcheck/api/repositories/sqlite/projects.py
@@ -7,19 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openfactcheck.api.models import Project, ProjectCreate, ProjectUpdate
 from openfactcheck.api.repositories.constants import MAX_PROJECTS_PER_USER, generate_id
-from openfactcheck.api.repositories.sqlite.helpers import ensure_utc
+from openfactcheck.api.repositories.sqlite.helpers import row_to_dict
 from openfactcheck.api.repositories.sqlite.tables import ProjectRow
-
-
-def _row_to_model(row: ProjectRow) -> Project:
-    return Project(
-        id=row.id,
-        user_id=row.user_id,
-        name=row.name,
-        description=row.description,
-        created_at=ensure_utc(row.created_at),
-        updated_at=ensure_utc(row.updated_at),
-    )
 
 
 class SqliteProjectRepository:
@@ -35,22 +24,22 @@ class SqliteProjectRepository:
                 .where(ProjectRow.user_id == user_id)
                 .order_by(ProjectRow.created_at)
                 .limit(limit)
-                .offset(offset)
+                .offset(offset),
             )
-            return [_row_to_model(row) for row in result.scalars()]
+            return [Project.model_validate(row_to_dict(row)) for row in result.scalars()]
 
     async def get(self, user_id: str, project_id: str) -> Project | None:
         async with self._session_factory() as session:
             result = await session.execute(
-                select(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id)
+                select(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id),
             )
             row = result.scalar_one_or_none()
-            return _row_to_model(row) if row else None
+            return Project.model_validate(row_to_dict(row)) if row else None
 
     async def create(self, user_id: str, data: ProjectCreate) -> Project | None:
         async with self._session_factory() as session:
             count_result = await session.execute(
-                select(func.count()).select_from(ProjectRow).where(ProjectRow.user_id == user_id)
+                select(func.count()).select_from(ProjectRow).where(ProjectRow.user_id == user_id),
             )
             if count_result.scalar_one() >= MAX_PROJECTS_PER_USER:
                 return None
@@ -66,7 +55,7 @@ class SqliteProjectRepository:
             )
             session.add(row)
             await session.commit()
-            return _row_to_model(row)
+            return Project.model_validate(row_to_dict(row))
 
     async def update(self, user_id: str, project_id: str, data: ProjectUpdate) -> Project | None:
         values = data.model_dump(exclude_none=True)
@@ -77,10 +66,10 @@ class SqliteProjectRepository:
 
         async with self._session_factory() as session:
             cursor = await session.execute(
-                update(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id).values(**values)
+                update(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id).values(**values),
             )
             await session.commit()
-            if cursor.rowcount == 0:  # type: ignore[union-attr]
+            if cursor.rowcount == 0:
                 return None
 
         return await self.get(user_id, project_id)
@@ -88,7 +77,7 @@ class SqliteProjectRepository:
     async def delete(self, user_id: str, project_id: str) -> bool:
         async with self._session_factory() as session:
             cursor = await session.execute(
-                delete(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id)
+                delete(ProjectRow).where(ProjectRow.id == project_id, ProjectRow.user_id == user_id),
             )
             await session.commit()
-            return bool(cursor.rowcount)  # type: ignore[union-attr]
+            return bool(cursor.rowcount)

--- a/src/openfactcheck/api/repositories/sqlite/workspaces.py
+++ b/src/openfactcheck/api/repositories/sqlite/workspaces.py
@@ -6,27 +6,18 @@ from datetime import UTC, datetime
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from openfactcheck.api.models import Workspace, WorkspaceCreate, WorkspaceRun, WorkspaceSettings, WorkspaceUpdate
-from openfactcheck.api.repositories.constants import MAX_WORKSPACES_PER_PROJECT, generate_id
-from openfactcheck.api.repositories.sqlite.helpers import ensure_utc
+from openfactcheck.api.models import (
+    Workspace,
+    WorkspaceCreate,
+    WorkspaceRun,
+    WorkspaceUpdate,
+)
+from openfactcheck.api.repositories.constants import (
+    MAX_WORKSPACES_PER_PROJECT,
+    generate_id,
+)
+from openfactcheck.api.repositories.sqlite.helpers import row_to_dict
 from openfactcheck.api.repositories.sqlite.tables import WorkspaceRow
-
-
-def _row_to_model(row: WorkspaceRow) -> Workspace:
-    return Workspace(
-        id=row.id,
-        user_id=row.user_id,
-        project_id=row.project_id,
-        name=row.name,
-        description=row.description,
-        locked=row.locked,
-        sort_order=row.sort_order,
-        settings=WorkspaceSettings.model_validate_json(row.settings_json),
-        content=json.loads(row.content_json) if row.content_json and row.content_json != "{}" else None,
-        run=WorkspaceRun.model_validate_json(row.run_json) if row.run_json else None,
-        created_at=ensure_utc(row.created_at),
-        updated_at=ensure_utc(row.updated_at),
-    )
 
 
 class SqliteWorkspaceRepository:
@@ -39,7 +30,7 @@ class SqliteWorkspaceRepository:
         result = await session.execute(
             select(func.count())
             .select_from(WorkspaceRow)
-            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
+            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id),
         )
         return result.scalar_one()
 
@@ -47,7 +38,7 @@ class SqliteWorkspaceRepository:
         result = await session.execute(
             select(func.coalesce(func.max(WorkspaceRow.sort_order), 0))
             .select_from(WorkspaceRow)
-            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
+            .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id),
         )
         return result.scalar_one() + 1
 
@@ -55,10 +46,13 @@ class SqliteWorkspaceRepository:
         async with self._session_factory() as session:
             result = await session.execute(
                 select(WorkspaceRow)
-                .where(WorkspaceRow.user_id == user_id, WorkspaceRow.project_id == project_id)
-                .order_by(WorkspaceRow.sort_order)
+                .where(
+                    WorkspaceRow.user_id == user_id,
+                    WorkspaceRow.project_id == project_id,
+                )
+                .order_by(WorkspaceRow.sort_order),
             )
-            return [_row_to_model(row) for row in result.scalars()]
+            return [Workspace.model_validate(row_to_dict(row)) for row in result.scalars()]
 
     async def get(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
         async with self._session_factory() as session:
@@ -67,10 +61,10 @@ class SqliteWorkspaceRepository:
                     WorkspaceRow.id == workspace_id,
                     WorkspaceRow.user_id == user_id,
                     WorkspaceRow.project_id == project_id,
-                )
+                ),
             )
             row = result.scalar_one_or_none()
-            return _row_to_model(row) if row else None
+            return Workspace.model_validate(row_to_dict(row)) if row else None
 
     async def create(self, user_id: str, project_id: str, data: WorkspaceCreate) -> Workspace | None:
         async with self._session_factory() as session:
@@ -92,7 +86,7 @@ class SqliteWorkspaceRepository:
             )
             session.add(row)
             await session.commit()
-            return _row_to_model(row)
+            return Workspace.model_validate(row_to_dict(row))
 
     async def update(self, user_id: str, project_id: str, workspace_id: str, data: WorkspaceUpdate) -> Workspace | None:
         values: dict[str, object] = {}
@@ -120,10 +114,10 @@ class SqliteWorkspaceRepository:
                     WorkspaceRow.user_id == user_id,
                     WorkspaceRow.project_id == project_id,
                 )
-                .values(**values)
+                .values(**values),
             )
             await session.commit()
-            if cursor.rowcount == 0:  # type: ignore[union-attr]
+            if cursor.rowcount == 0:
                 return None
 
         return await self.get(user_id, project_id, workspace_id)
@@ -135,10 +129,10 @@ class SqliteWorkspaceRepository:
                     WorkspaceRow.id == workspace_id,
                     WorkspaceRow.user_id == user_id,
                     WorkspaceRow.project_id == project_id,
-                )
+                ),
             )
             await session.commit()
-            return bool(cursor.rowcount)  # type: ignore[union-attr]
+            return bool(cursor.rowcount)
 
     async def duplicate(self, user_id: str, project_id: str, workspace_id: str) -> Workspace | None:
         source = await self.get(user_id, project_id, workspace_id)
@@ -165,7 +159,7 @@ class SqliteWorkspaceRepository:
             )
             session.add(row)
             await session.commit()
-            return _row_to_model(row)
+            return Workspace.model_validate(row_to_dict(row))
 
     async def reorder(self, user_id: str, project_id: str, ordered_ids: list[str]) -> None:
         async with self._session_factory() as session:
@@ -177,7 +171,7 @@ class SqliteWorkspaceRepository:
                         WorkspaceRow.user_id == user_id,
                         WorkspaceRow.project_id == project_id,
                     )
-                    .values(sort_order=index, updated_at=datetime.now(UTC))
+                    .values(sort_order=index, updated_at=datetime.now(UTC)),
                 )
             await session.commit()
 
@@ -191,6 +185,6 @@ class SqliteWorkspaceRepository:
                     WorkspaceRow.user_id == user_id,
                     WorkspaceRow.project_id == project_id,
                 )
-                .values(run_json=run.model_dump_json(), updated_at=datetime.now(UTC))
+                .values(run_json=run.model_dump_json(), updated_at=datetime.now(UTC)),
             )
             await session.commit()

--- a/src/openfactcheck/api/routers/projects.py
+++ b/src/openfactcheck/api/routers/projects.py
@@ -8,7 +8,11 @@ from openfactcheck.api.dependencies import get_current_user, get_project_repo
 from openfactcheck.api.errors import NotFoundError, ProjectLimitError
 from openfactcheck.api.models import AuthUser, ProjectCreate, ProjectUpdate
 from openfactcheck.api.repositories.protocols import ProjectRepository
-from openfactcheck.api.schemas.projects import CreateProjectRequest, ProjectResponse, UpdateProjectRequest
+from openfactcheck.api.schemas.projects import (
+    CreateProjectRequest,
+    ProjectResponse,
+    UpdateProjectRequest,
+)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -36,7 +40,7 @@ async def create_project(
     """Create a new project."""
     project = await repo.create(user.sub, ProjectCreate(name=body.name, description=body.description))
     if project is None:
-        raise ProjectLimitError()
+        raise ProjectLimitError
     return ProjectResponse.from_model(project)
 
 
@@ -61,7 +65,11 @@ async def update_project(
     repo: Annotated[ProjectRepository, Depends(get_project_repo)],
 ) -> ProjectResponse:
     """Update a project."""
-    project = await repo.update(user.sub, project_id, ProjectUpdate(name=body.name, description=body.description))
+    project = await repo.update(
+        user.sub,
+        project_id,
+        ProjectUpdate(name=body.name, description=body.description),
+    )
     if project is None:
         raise NotFoundError(f"Project {project_id} not found")
     return ProjectResponse.from_model(project)

--- a/src/openfactcheck/api/routers/workspaces.py
+++ b/src/openfactcheck/api/routers/workspaces.py
@@ -5,13 +5,31 @@ import json
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, status
-from pydantic import BaseModel  # noqa: TC002 — used by RunRequest/RunResponse below
+from pydantic import BaseModel
 
 from openfactcheck.api.config import APIConfig
-from openfactcheck.api.dependencies import get_config, get_current_user, get_workspace_repo
-from openfactcheck.api.errors import AppError, ErrorCode, NotFoundError, WorkspaceLimitError
-from openfactcheck.api.models import AuthUser, RunStatus, WorkspaceCreate, WorkspaceRun, WorkspaceUpdate
-from openfactcheck.api.repositories.constants import MAX_CONTENT_BYTES, MAX_PIPELINE_BYTES
+from openfactcheck.api.dependencies import (
+    get_config,
+    get_current_user,
+    get_workspace_repo,
+)
+from openfactcheck.api.errors import (
+    AppError,
+    ErrorCode,
+    NotFoundError,
+    WorkspaceLimitError,
+)
+from openfactcheck.api.models import (
+    AuthUser,
+    WorkspaceCreate,
+    WorkspaceRun,
+    WorkspaceRunStatus,
+    WorkspaceUpdate,
+)
+from openfactcheck.api.repositories.constants import (
+    MAX_CONTENT_BYTES,
+    MAX_PIPELINE_BYTES,
+)
 from openfactcheck.api.repositories.protocols import WorkspaceRepository
 from openfactcheck.api.schemas.workspaces import (
     CreateWorkspaceRequest,
@@ -21,6 +39,8 @@ from openfactcheck.api.schemas.workspaces import (
 )
 
 router = APIRouter(prefix="/projects/{project_id}/workspaces", tags=["workspaces"])
+
+_background_tasks: set[asyncio.Task[None]] = set()
 
 ResourceId = Annotated[str, Path(max_length=20)]
 
@@ -44,9 +64,13 @@ async def create_workspace(
     repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
 ) -> WorkspaceResponse:
     """Create a new workspace in a project."""
-    ws = await repo.create(user.sub, project_id, WorkspaceCreate(name=body.name, description=body.description))
+    ws = await repo.create(
+        user.sub,
+        project_id,
+        WorkspaceCreate(name=body.name, description=body.description),
+    )
     if ws is None:
-        raise WorkspaceLimitError()
+        raise WorkspaceLimitError
     return WorkspaceResponse.from_model(ws)
 
 
@@ -74,7 +98,11 @@ async def update_workspace(
 ) -> WorkspaceResponse:
     """Update a workspace."""
     if body.content is not None and len(str(body.content)) > MAX_CONTENT_BYTES:
-        raise AppError("Workspace content exceeds size limit", ErrorCode.VALIDATION_ERROR, status=422)
+        raise AppError(
+            "Workspace content exceeds size limit",
+            ErrorCode.VALIDATION_ERROR,
+            status=422,
+        )
     ws = await repo.update(
         user.sub,
         project_id,
@@ -120,7 +148,7 @@ async def duplicate_workspace(
 
     ws = await repo.duplicate(user.sub, project_id, workspace_id)
     if ws is None:
-        raise WorkspaceLimitError()
+        raise WorkspaceLimitError
     return WorkspaceResponse.from_model(ws)
 
 
@@ -139,7 +167,11 @@ async def reorder_workspaces(
     if len(body.ordered_ids) != len(submitted_ids):
         raise AppError("ordered_ids contains duplicates", ErrorCode.VALIDATION_ERROR, status=422)
     if submitted_ids != current_ids:
-        raise AppError("ordered_ids must contain exactly all workspace IDs", ErrorCode.VALIDATION_ERROR, status=422)
+        raise AppError(
+            "ordered_ids must contain exactly all workspace IDs",
+            ErrorCode.VALIDATION_ERROR,
+            status=422,
+        )
 
     await repo.reorder(user.sub, project_id, body.ordered_ids)
 
@@ -171,11 +203,11 @@ async def _start_sfn(
     pipeline: dict[str, object],
 ) -> None:
     """Start a Step Functions execution for the pipeline."""
-    import boto3
+    import boto3  # noqa: PLC0415 - lazy import for optional cloud dependency.
 
     def _start() -> None:
-        sfn = boto3.client("stepfunctions")  # pyright: ignore[reportUnknownVariableType,reportUnknownMemberType]
-        sfn.start_execution(  # pyright: ignore[reportUnknownMemberType]
+        sfn = boto3.client("stepfunctions")
+        sfn.start_execution(
             stateMachineArn=state_machine_arn,
             input=json.dumps(
                 {
@@ -183,7 +215,7 @@ async def _start_sfn(
                     "project_id": project_id,
                     "workspace_id": workspace_id,
                     "pipeline": pipeline,
-                }
+                },
             ),
         )
 
@@ -198,23 +230,28 @@ async def _run_local(
     pipeline: dict[str, object],
 ) -> None:
     """Local mode: run pipeline in-process and update workspace run state."""
-    from datetime import UTC, datetime
+    from datetime import UTC, datetime  # noqa: PLC0415 - lazy import to avoid engine dependency at module level.
 
-    from openfactcheck.engine import execute_pipeline
+    from openfactcheck.engine import (  # noqa: PLC0415 - lazy import to avoid engine dependency at module level.
+        execute_pipeline,
+    )
 
     result = await execute_pipeline(pipeline)
     now = datetime.now(UTC)
     if result.success:
-        run = WorkspaceRun(status=RunStatus.COMPLETED, output=result.output or "", completed_at=now)
+        run = WorkspaceRun(status=WorkspaceRunStatus.COMPLETED, output=result.output or "", completed_at=now)
     else:
         run = WorkspaceRun(
-            status=RunStatus.FAILED, output=result.output or "", error=result.error or "", completed_at=now
+            status=WorkspaceRunStatus.FAILED,
+            output=result.output or "",
+            error=result.error or "",
+            completed_at=now,
         )
     await repo.set_run(user_id, project_id, workspace_id, run)
 
 
 @router.post("/{workspace_id}/run", status_code=status.HTTP_202_ACCEPTED)
-async def run_pipeline(
+async def run_pipeline(  # noqa: PLR0913 - FastAPI DI requires all params as function args.
     project_id: ResourceId,
     workspace_id: ResourceId,
     body: RunRequest,
@@ -233,15 +270,23 @@ async def run_pipeline(
 
     if config.mode == "cloud":
         try:
-            await _start_sfn(config.state_machine_arn, user.sub, project_id, workspace_id, body.pipeline)
+            await _start_sfn(
+                config.state_machine_arn,
+                user.sub,
+                project_id,
+                workspace_id,
+                body.pipeline,
+            )
         except Exception:
-            run = WorkspaceRun(status=RunStatus.FAILED, error="Failed to dispatch pipeline")
+            run = WorkspaceRun(status=WorkspaceRunStatus.FAILED, error="Failed to dispatch pipeline")
             await repo.set_run(user.sub, project_id, workspace_id, run)
             raise
     else:
-        run = WorkspaceRun(status=RunStatus.RUNNING)
+        run = WorkspaceRun(status=WorkspaceRunStatus.RUNNING)
         await repo.set_run(user.sub, project_id, workspace_id, run)
-        asyncio.create_task(_run_local(repo, user.sub, project_id, workspace_id, body.pipeline))
+        task = asyncio.create_task(_run_local(repo, user.sub, project_id, workspace_id, body.pipeline))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
 
     return RunResponse(status="running")
 

--- a/src/openfactcheck/api/schemas/projects.py
+++ b/src/openfactcheck/api/schemas/projects.py
@@ -8,6 +8,10 @@ from pydantic import BaseModel, Field
 
 from openfactcheck.api.models import Project
 
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
 
 class CreateProjectRequest(BaseModel):
     """Body for POST /api/v1/projects."""
@@ -21,6 +25,11 @@ class UpdateProjectRequest(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
     description: str | None = Field(default=None, max_length=10000)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
 
 
 class ProjectResponse(BaseModel):

--- a/src/openfactcheck/api/schemas/workspaces.py
+++ b/src/openfactcheck/api/schemas/workspaces.py
@@ -1,11 +1,18 @@
 """Workspace request/response schemas."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Annotated
 
 from pydantic import BaseModel, Field
 
 from openfactcheck.api.models import Workspace, WorkspaceSettings
+from openfactcheck.api.models.types import JSONObject
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
 
 
 class CreateWorkspaceRequest(BaseModel):
@@ -22,13 +29,18 @@ class UpdateWorkspaceRequest(BaseModel):
     description: str | None = Field(default=None, max_length=10000)
     locked: bool | None = None
     settings: WorkspaceSettings | None = None
-    content: dict[str, object] | None = None
+    content: JSONObject | None = None
 
 
 class ReorderWorkspacesRequest(BaseModel):
     """Body for PUT /api/v1/projects/{pid}/workspaces/reorder."""
 
     ordered_ids: list[Annotated[str, Field(max_length=20)]] = Field(min_length=1, max_length=5)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
 
 
 class WorkspaceResponse(BaseModel):
@@ -41,12 +53,12 @@ class WorkspaceResponse(BaseModel):
     locked: bool
     sort_order: int
     settings: WorkspaceSettings
-    content: dict[str, object] | None = None
+    content: JSONObject | None = None
     created_at: datetime
     updated_at: datetime
 
     @staticmethod
-    def from_model(ws: Workspace) -> "WorkspaceResponse":
+    def from_model(ws: Workspace) -> WorkspaceResponse:
         """Convert a domain Workspace to a response schema."""
         return WorkspaceResponse(
             id=ws.id,

--- a/src/openfactcheck/config.py
+++ b/src/openfactcheck/config.py
@@ -12,8 +12,14 @@ Resolution order (highest wins)::
 from pathlib import Path
 from typing import Literal
 
-from pydantic import AliasChoices, Field, SecretStr  # noqa: TC002
-from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+from pydantic import AliasChoices, Field, SecretStr
+from pydantic_settings import (
+    BaseSettings,
+    JsonConfigSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
 
 
 class OpenFactCheckConfig(BaseSettings):
@@ -66,11 +72,9 @@ class OpenFactCheckConfig(BaseSettings):
         init_settings: PydanticBaseSettingsSource,
         env_settings: PydanticBaseSettingsSource,
         dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,  # noqa: ARG003 - required by pydantic-settings override.
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         """Priority: constructor > env vars > .env > json/yaml config > defaults."""
-        from pydantic_settings import JsonConfigSettingsSource, YamlConfigSettingsSource
-
         return (
             init_settings,
             env_settings,

--- a/src/openfactcheck/contracts.py
+++ b/src/openfactcheck/contracts.py
@@ -22,7 +22,7 @@ class ClaimExtractor(Protocol):
     valid (e.g. the input contains no checkable claims).
     """
 
-    async def __call__(self, input: Input) -> list[Claim]: ...
+    async def __call__(self, text: Input) -> list[Claim]: ...
 
 
 @runtime_checkable

--- a/src/openfactcheck/engine/__init__.py
+++ b/src/openfactcheck/engine/__init__.py
@@ -1,8 +1,15 @@
 """Graph execution engine — interprets Blockly workspace JSON and executes block handlers."""
 
-import openfactcheck.engine.handlers as handlers  # noqa: F401 — auto-registers all block handlers
+from openfactcheck.engine import handlers
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.errors import EngineError, UnknownBlockError
 from openfactcheck.engine.executor import ExecutionResult, execute_pipeline
 
-__all__ = ["Block", "EngineError", "ExecutionResult", "UnknownBlockError", "execute_pipeline", "handlers"]
+__all__ = [
+    "Block",
+    "EngineError",
+    "ExecutionResult",
+    "UnknownBlockError",
+    "execute_pipeline",
+    "handlers",
+]

--- a/src/openfactcheck/engine/block.py
+++ b/src/openfactcheck/engine/block.py
@@ -1,4 +1,3 @@
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
 """Typed wrapper around a raw Blockly block dict.
 
 This is the JSON boundary layer for the engine. Raw ``dict[str, Any]`` from
@@ -36,7 +35,7 @@ class Block:
         id: Unique block instance ID assigned by Blockly.
     """
 
-    __slots__ = ("type", "id", "_fields", "_inputs", "_next_data")
+    __slots__ = ("_fields", "_inputs", "_next_data", "id", "type")
 
     def __init__(self, data: dict[str, Any]) -> None:
         self.type: str = str(data.get("type", ""))

--- a/src/openfactcheck/engine/context.py
+++ b/src/openfactcheck/engine/context.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from openfactcheck.engine.errors import UnknownBlockError
-from openfactcheck.engine.handler import HANDLERS  # noqa: TC001 — runtime import, not type-only
+from openfactcheck.engine.handler import HANDLERS
 
 MAX_OUTPUT_BYTES = 65_536
 
@@ -35,8 +35,8 @@ class ExecutionContext:
         variables: Shared variable storage for ``variables_set``/``variables_get`` blocks.
     """
 
-    output_lines: list[str] = field(default_factory=lambda: [])
-    variables: dict[str, Any] = field(default_factory=lambda: {})
+    output_lines: list[str] = field(default_factory=list)
+    variables: dict[str, Any] = field(default_factory=dict)
     _output_bytes: int = 0
     _truncated: bool = False
 
@@ -57,7 +57,7 @@ class ExecutionContext:
         self._output_bytes += line_bytes
         self.output_lines.append(line)
 
-    def execute_block(self, block: Block) -> Any:  # noqa: ANN401
+    def execute_block(self, block: Block) -> object:
         """Dispatch a block to its registered handler and return the result.
 
         Raises:

--- a/src/openfactcheck/engine/handlers/__init__.py
+++ b/src/openfactcheck/engine/handlers/__init__.py
@@ -1,10 +1,12 @@
 """Block handlers — import all handler modules to auto-register them."""
 
-import openfactcheck.engine.handlers.lists as lists  # noqa: F401
-import openfactcheck.engine.handlers.logic as logic  # noqa: F401
-import openfactcheck.engine.handlers.loops as loops  # noqa: F401
-import openfactcheck.engine.handlers.math as math  # noqa: F401
-import openfactcheck.engine.handlers.text as text  # noqa: F401
-import openfactcheck.engine.handlers.variables as variables  # noqa: F401
+from openfactcheck.engine.handlers import (
+    lists,
+    logic,
+    loops,
+    math,
+    text,
+    variables,
+)
 
 __all__ = ["lists", "logic", "loops", "math", "text", "variables"]

--- a/src/openfactcheck/engine/handlers/lists.py
+++ b/src/openfactcheck/engine/handlers/lists.py
@@ -1,5 +1,7 @@
 """List block handlers — ``lists_create_with``, ``lists_sort``, etc."""
 
+import random
+
 from openfactcheck.engine import resolve
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
@@ -127,14 +129,18 @@ def _list_index(block: Block, ctx: ExecutionContext, items: list[object]) -> int
     if where == "LAST":
         return len(items) - 1
     if where == "RANDOM":
-        import random
-
         return random.randrange(len(items)) if items else 0
     at = resolve.integer(block, ctx, "AT", default=1)
     return (at - 1) if where == "FROM_START" else (len(items) - at)
 
 
-def _list_index_range(block: Block, ctx: ExecutionContext, items: list[object], where_field: str, at_input: str) -> int:
+def _list_index_range(
+    block: Block,
+    ctx: ExecutionContext,
+    items: list[object],
+    where_field: str,
+    at_input: str,
+) -> int:
     """Resolve a sublist index."""
     where = block.get_field(where_field, default="FROM_START")
     if where == "FIRST":
@@ -147,7 +153,7 @@ def _list_index_range(block: Block, ctx: ExecutionContext, items: list[object], 
 
 def _sort_numeric(x: object) -> float:
     try:
-        return float(x)  # type: ignore[arg-type]
+        return float(x)  # pyright: ignore[reportArgumentType] - runtime try/except handles non-numeric values.
     except (TypeError, ValueError):
         return 0.0
 

--- a/src/openfactcheck/engine/handlers/logic.py
+++ b/src/openfactcheck/engine/handlers/logic.py
@@ -1,7 +1,5 @@
 """Logic block handlers — ``logic_boolean``, ``controls_if``, etc."""
 
-from typing import Any
-
 from openfactcheck.engine import resolve
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
@@ -9,15 +7,15 @@ from openfactcheck.engine.handler import handler
 
 
 @handler("logic_boolean")
-def logic_boolean(block: Block, ctx: ExecutionContext) -> bool:
+def logic_boolean(block: Block, _ctx: ExecutionContext) -> bool:
     """Return True or False from the BOOL field."""
     return block.get_field("BOOL", default="TRUE") == "TRUE"
 
 
 @handler("logic_null")
-def logic_null(block: Block, ctx: ExecutionContext) -> None:
+def logic_null(_block: Block, _ctx: ExecutionContext) -> None:
     """Return None."""
-    return None
+    return
 
 
 @handler("logic_negate")
@@ -37,13 +35,13 @@ def logic_compare(block: Block, ctx: ExecutionContext) -> bool:
     if op == "NEQ":
         return a != b
     if op == "LT":
-        return a < b  # type: ignore[operator]
+        return a < b
     if op == "LTE":
-        return a <= b  # type: ignore[operator]
+        return a <= b
     if op == "GT":
-        return a > b  # type: ignore[operator]
+        return a > b
     if op == "GTE":
-        return a >= b  # type: ignore[operator]
+        return a >= b
     return False
 
 
@@ -57,7 +55,7 @@ def logic_operation(block: Block, ctx: ExecutionContext) -> bool:
 
 
 @handler("logic_ternary")
-def logic_ternary(block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
+def logic_ternary(block: Block, ctx: ExecutionContext) -> object:
     """If IF is truthy, return THEN, else return ELSE."""
     if resolve.boolean(block, ctx, "IF"):
         return resolve.value(block, ctx, "THEN")

--- a/src/openfactcheck/engine/handlers/loops.py
+++ b/src/openfactcheck/engine/handlers/loops.py
@@ -9,11 +9,11 @@ MAX_ITERATIONS = 10_000
 """Safety limit to prevent infinite loops."""
 
 
-class BreakLoop(Exception):
+class BreakLoop(Exception):  # noqa: N818 - control flow signal, not an error.
     """Raised by controls_flow_statements to break out of a loop."""
 
 
-class ContinueLoop(Exception):
+class ContinueLoop(Exception):  # noqa: N818 - control flow signal, not an error.
     """Raised by controls_flow_statements to skip to the next iteration."""
 
 
@@ -87,7 +87,7 @@ def controls_for_each(block: Block, ctx: ExecutionContext) -> None:
 
 
 @handler("controls_flow_statements")
-def controls_flow_statements(block: Block, ctx: ExecutionContext) -> None:
+def controls_flow_statements(block: Block, _ctx: ExecutionContext) -> None:
     """Break or continue. FLOW field: BREAK or CONTINUE."""
     if block.get_field("FLOW", default="BREAK") == "BREAK":
         raise BreakLoop

--- a/src/openfactcheck/engine/handlers/math.py
+++ b/src/openfactcheck/engine/handlers/math.py
@@ -10,7 +10,7 @@ from openfactcheck.engine.handler import handler
 
 
 @handler("math_number")
-def math_number(block: Block, ctx: ExecutionContext) -> float:
+def math_number(block: Block, _ctx: ExecutionContext) -> float:
     """Return the numeric value from the NUM field."""
     return float(block.get_field("NUM", default="0"))
 
@@ -87,7 +87,7 @@ MATH_CONSTANTS: dict[str, float] = {
 
 
 @handler("math_constant")
-def math_constant(block: Block, ctx: ExecutionContext) -> float:
+def math_constant(block: Block, _ctx: ExecutionContext) -> float:
     """Return a named math constant."""
     return MATH_CONSTANTS.get(block.get_field("CONSTANT", default="PI"), 0.0)
 
@@ -140,7 +140,10 @@ def math_modulo(block: Block, ctx: ExecutionContext) -> float:
 @handler("math_constrain")
 def math_constrain(block: Block, ctx: ExecutionContext) -> float:
     """Clamp VALUE between LOW and HIGH."""
-    return max(resolve.num(block, ctx, "LOW"), min(resolve.num(block, ctx, "VALUE"), resolve.num(block, ctx, "HIGH")))
+    return max(
+        resolve.num(block, ctx, "LOW"),
+        min(resolve.num(block, ctx, "VALUE"), resolve.num(block, ctx, "HIGH")),
+    )
 
 
 @handler("math_random_int")
@@ -152,7 +155,7 @@ def math_random_int(block: Block, ctx: ExecutionContext) -> int:
 
 
 @handler("math_random_float")
-def math_random_float(block: Block, ctx: ExecutionContext) -> float:
+def math_random_float(_block: Block, _ctx: ExecutionContext) -> float:
     """Random float in [0, 1)."""
     return random.random()
 
@@ -162,7 +165,7 @@ def math_on_list(block: Block, ctx: ExecutionContext) -> float:
     """Aggregate operation on a list of numbers."""
     op = block.get_field("OP", default="SUM")
     raw = resolve.items(block, ctx, "LIST")
-    nums = [float(x) for x in raw if x is not None]  # type: ignore[arg-type]
+    nums = [float(x) for x in raw if x is not None]
     if not nums:
         return 0.0
     if op == "SUM":
@@ -190,9 +193,9 @@ def math_on_list(block: Block, ctx: ExecutionContext) -> float:
 
 
 def _is_prime(n: int) -> bool:
-    if n < 2:
+    if n < 2:  # noqa: PLR2004 - mathematical constant in primality test.
         return False
-    if n < 4:
+    if n < 4:  # noqa: PLR2004 - mathematical constant in primality test.
         return True
     if n % 2 == 0 or n % 3 == 0:
         return False

--- a/src/openfactcheck/engine/handlers/text.py
+++ b/src/openfactcheck/engine/handlers/text.py
@@ -1,5 +1,7 @@
 """Text block handlers — ``text``, ``text_print``, ``text_join``, etc."""
 
+import random
+
 from openfactcheck.engine import resolve
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
@@ -7,7 +9,7 @@ from openfactcheck.engine.handler import handler
 
 
 @handler("text")
-def text(block: Block, ctx: ExecutionContext) -> str:
+def text(block: Block, _ctx: ExecutionContext) -> str:
     """Return the string literal from the TEXT field."""
     return block.get_field("TEXT", default="")
 
@@ -67,8 +69,6 @@ def text_char_at(block: Block, ctx: ExecutionContext) -> str:
     if where == "LAST":
         return val[-1]
     if where == "RANDOM":
-        import random
-
         return random.choice(val)
     at = resolve.integer(block, ctx, "AT", default=1)
     idx = (at - 1) if where == "FROM_START" else (len(val) - at)

--- a/src/openfactcheck/engine/handlers/variables.py
+++ b/src/openfactcheck/engine/handlers/variables.py
@@ -1,7 +1,5 @@
 """Variable block handlers — ``variables_get``, ``variables_set``."""
 
-from typing import Any
-
 from openfactcheck.engine import resolve
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
@@ -9,7 +7,7 @@ from openfactcheck.engine.handler import handler
 
 
 @handler("variables_get")
-def variables_get(block: Block, ctx: ExecutionContext) -> Any:  # noqa: ANN401
+def variables_get(block: Block, ctx: ExecutionContext) -> object:
     """Return the value of the named variable."""
     return ctx.variables.get(block.get_field("VAR", default="item"), "")
 

--- a/src/openfactcheck/engine/lambda_handler.py
+++ b/src/openfactcheck/engine/lambda_handler.py
@@ -1,4 +1,3 @@
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false
 """Lambda handler — executes a pipeline and returns the result.
 
 Invoked by Step Functions. Receives pipeline JSON, returns execution output.
@@ -11,7 +10,7 @@ from typing import Any
 from openfactcheck.engine.executor import execute_pipeline
 
 
-def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ANN401, ARG001
+def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:  # noqa: ANN401 - AWS Lambda context type requires a heavy dependency.
     """AWS Lambda entry point — execute pipeline and return result."""
     pipeline: dict[str, Any] = event["pipeline"]
     result = asyncio.run(execute_pipeline(pipeline))

--- a/src/openfactcheck/engine/parser.py
+++ b/src/openfactcheck/engine/parser.py
@@ -1,4 +1,3 @@
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
 """Blockly workspace JSON parser — extracts top-level blocks from workspace state."""
 
 from typing import Any

--- a/src/openfactcheck/engine/resolve.py
+++ b/src/openfactcheck/engine/resolve.py
@@ -22,7 +22,7 @@ def num(block: Block, ctx: ExecutionContext, name: str, default: float = 0.0) ->
         return default
     result = ctx.execute_block(input_block)
     try:
-        return float(result)  # type: ignore[arg-type]
+        return float(result)
     except (TypeError, ValueError):
         return default
 
@@ -51,7 +51,7 @@ def integer(block: Block, ctx: ExecutionContext, name: str, default: int = 0) ->
         return default
     result = ctx.execute_block(input_block)
     try:
-        return int(float(result))  # type: ignore[arg-type]
+        return int(float(result))
     except (TypeError, ValueError):
         return default
 
@@ -72,7 +72,7 @@ def items(block: Block, ctx: ExecutionContext, name: str) -> list[object]:
         return []
     result = ctx.execute_block(input_block)
     if isinstance(result, list):
-        return cast(list[object], result)
+        return cast("list[object]", result)
     return []
 
 

--- a/taskfiles/dev.taskfile.yml
+++ b/taskfiles/dev.taskfile.yml
@@ -67,6 +67,7 @@ tasks:
     desc: Remove build artifacts and caches
     cmds:
       - rm -rf dist build .pytest_cache .ruff_cache src/*.egg-info
+      - find . -type d -name __pycache__ -exec rm -rf {} +
 
   default:
     desc: Show available dev tasks

--- a/tests/api/auth/test_cognito.py
+++ b/tests/api/auth/test_cognito.py
@@ -9,7 +9,8 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
 
-from openfactcheck.api.auth.cognito import DEV_USER, CognitoVerifier, DevVerifier
+from openfactcheck.api.auth.cognito import CognitoVerifier
+from openfactcheck.api.auth.dev import DEV_USER, DevVerifier
 from openfactcheck.api.errors import AuthError
 
 REGION = "us-east-1"

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -6,11 +6,11 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from openfactcheck.api.app import create_app
-from openfactcheck.api.auth.cognito import DEV_USER
+from openfactcheck.api.auth.dev import DEV_USER
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.dependencies import get_current_user, get_project_repo, get_workspace_repo
 from openfactcheck.api.models import AuthUser
-from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
+from openfactcheck.api.repositories.sqlite.engine import create_engine, create_session_factory, create_tables
 from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
 from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
 
@@ -20,8 +20,9 @@ TEST_USER = DEV_USER
 @pytest_asyncio.fixture(loop_scope="function")
 async def client() -> AsyncIterator[AsyncClient]:
     """Yield an httpx AsyncClient wired to a test app with in-memory SQLite and mock auth."""
-    engine = await create_engine_and_tables(":memory:")
-    sf = session_factory(engine)
+    engine = create_engine(":memory:")
+    await create_tables(engine)
+    sf = create_session_factory(engine)
     project_repo = SqliteProjectRepository(sf)
     workspace_repo = SqliteWorkspaceRepository(sf)
 

--- a/tests/api/repositories/conftest.py
+++ b/tests/api/repositories/conftest.py
@@ -5,13 +5,14 @@ from collections.abc import AsyncIterator
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from openfactcheck.api.repositories.sqlite.engine import create_engine_and_tables, session_factory
+from openfactcheck.api.repositories.sqlite.engine import create_engine, create_session_factory, create_tables
 
 
 @pytest_asyncio.fixture(loop_scope="function")
 async def db_session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
     """Yield a session factory backed by a fresh in-memory SQLite database."""
-    engine = await create_engine_and_tables(":memory:")
-    factory = session_factory(engine)
+    engine = create_engine(":memory:")
+    await create_tables(engine)
+    factory = create_session_factory(engine)
     yield factory
     await engine.dispose()

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -18,8 +18,8 @@ async def test_ClaimExtractor_accepts_conforming_implementation() -> None:
     """A class with matching async __call__ satisfies the Protocol and can be invoked."""
 
     class DummyExtractor:
-        async def __call__(self, input: Input) -> list[Claim]:
-            return [Claim(text=f"claim from {input.content}")]
+        async def __call__(self, text: Input) -> list[Claim]:
+            return [Claim(text=f"claim from {text.content}")]
 
     extractor: ClaimExtractor = DummyExtractor()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1079,6 +1079,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-litellm"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "litellm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/37/ccc1f284a42900ca5b267a50da8e50145e9f264b32ee955ce91aa360d188/langchain_litellm-0.6.4.tar.gz", hash = "sha256:663281db392b3de1f07f891d0f80f9d4b26c0f0d2abbf854ef9b186d99c309ee", size = 339457, upload-time = "2026-04-03T16:56:47.886Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e8/25c50bbad7a05106c7af65557e165d6cb6159c90854dae61de59debe735d/langchain_litellm-0.6.4-py3-none-any.whl", hash = "sha256:60f4e37be1a47dc88f94fac7085675ef8fa04bba92f48735792d82f492120744", size = 26360, upload-time = "2026-04-03T16:56:46.76Z" },
+]
+
+[[package]]
 name = "langgraph"
 version = "1.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1440,6 +1455,7 @@ name = "openfactcheck"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
+    { name = "langchain-litellm" },
     { name = "langgraph" },
     { name = "litellm" },
     { name = "pydantic" },
@@ -1470,6 +1486,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -1479,6 +1496,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'cloud'", specifier = ">=1.35" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.115" },
     { name = "langchain-core", specifier = ">=1.2" },
+    { name = "langchain-litellm", specifier = ">=0.6" },
     { name = "langgraph", specifier = ">=1.1" },
     { name = "litellm", specifier = ">=1.83" },
     { name = "mangum", marker = "extra == 'api'", specifier = ">=0.19" },
@@ -1501,6 +1519,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=0.26" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-mock", specifier = ">=3.14" },
     { name = "ruff", specifier = ">=0.15.8" },
 ]
 
@@ -1923,6 +1942,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Configure 42 ruff lint rules with per-file ignores for handlers and models
- Add pyright execution environments for dynamodb, sqlite, routers, engine
- Split auth into protocol/cognito/dev files
- Refactor dependencies to _State class, consolidate _init_repos
- Add Pydantic alias_generator (to_camel) and field validators on all models
- Replace _item_to_model/_row_to_model with model_validate across all repos
- Add WorkspaceRun state invariants with match-based validation
- Extract shared types (JSONObject, DynamoItem) and validators (normalize_datetime)
- Split create_engine_and_tables into create_engine + create_tables
- Fix RUF006 asyncio.create_task GC bug in workspace router
- Add section separators across all files
- Remove all stale suppressions, add targeted noqa/pyright ignores with reasons
- Clean up dead code (sqlite helpers, empty test dirs)