### PR TITLE
feat: structured output for the chat layer

### DIFF
--- a/deployments/repositories/aws_ecr.tf
+++ b/deployments/repositories/aws_ecr.tf
@@ -16,6 +16,31 @@ resource "aws_ecr_repository" "openfactcheck_api" {
   }
 }
 
+# Allow the Lambda service to pull images from this repo (fixes ImageAccessDenied).
+resource "aws_ecr_repository_policy" "openfactcheck_api" {
+  repository = aws_ecr_repository.openfactcheck_api.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "LambdaECRImageRetrievalPolicy"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer"
+        ]
+        Condition = {
+          StringLike = {
+            "aws:sourceArn" = "arn:aws:lambda:${var.aws_region}:${var.aws_account}:function:openfactcheck-*"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_ecr_lifecycle_policy" "openfactcheck_api" {
   repository = aws_ecr_repository.openfactcheck_api.name
 
@@ -53,6 +78,31 @@ resource "aws_ecr_repository" "openfactcheck_engine" {
   tags = {
     Name = "OpenFactCheck - ECR - Engine - ${terraform.workspace} - ${var.aws_region}"
   }
+}
+
+# Allow the Lambda service to pull images from this repo (fixes ImageAccessDenied).
+resource "aws_ecr_repository_policy" "openfactcheck_engine" {
+  repository = aws_ecr_repository.openfactcheck_engine.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "LambdaECRImageRetrievalPolicy"
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action = [
+          "ecr:BatchGetImage",
+          "ecr:GetDownloadUrlForLayer"
+        ]
+        Condition = {
+          StringLike = {
+            "aws:sourceArn" = "arn:aws:lambda:${var.aws_region}:${var.aws_account}:function:openfactcheck-*"
+          }
+        }
+      }
+    ]
+  })
 }
 
 resource "aws_ecr_lifecycle_policy" "openfactcheck_engine" {

--- a/docs/reference/chat/errors.md
+++ b/docs/reference/chat/errors.md
@@ -38,3 +38,8 @@
     options:
       show_root_heading: true
       heading_level: 3
+
+::: openfactcheck.chat.errors.StructuredOutputError
+    options:
+      show_root_heading: true
+      heading_level: 3

--- a/src/openfactcheck/chat/__init__.py
+++ b/src/openfactcheck/chat/__init__.py
@@ -48,6 +48,7 @@ from openfactcheck.chat.errors import (
     ProviderError,
     ProviderNotFoundError,
     RateLimitError,
+    StructuredOutputError,
     UnsupportedFeatureError,
 )
 from openfactcheck.chat.messages import (
@@ -59,7 +60,7 @@ from openfactcheck.chat.messages import (
     UserMessage,
 )
 from openfactcheck.chat.providers.base import BaseProvider, ProviderCapabilities
-from openfactcheck.chat.requests import ChatRequest
+from openfactcheck.chat.requests import ChatRequest, ResponseFormat
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, StreamEvent, TextDelta, Usage
 
 # Client
@@ -92,6 +93,7 @@ __all__ += [
     "ChatRequest",
     "ChatResponse",
     "FinishReason",
+    "ResponseFormat",
     "StreamEnd",
     "StreamEvent",
     "TextDelta",
@@ -105,6 +107,7 @@ __all__ += [
     "ProviderError",
     "ProviderNotFoundError",
     "RateLimitError",
+    "StructuredOutputError",
     "UnsupportedFeatureError",
 ]
 

--- a/src/openfactcheck/chat/backends/anthropic/backend.py
+++ b/src/openfactcheck/chat/backends/anthropic/backend.py
@@ -24,7 +24,7 @@ from openfactcheck.chat.backends.anthropic.normalize import (
     to_chat_response,
     to_stream_end,
 )
-from openfactcheck.chat.backends.anthropic.params import Kwargs, config_to_kwargs
+from openfactcheck.chat.backends.anthropic.params import Kwargs, config_to_kwargs, response_format_kwargs
 from openfactcheck.chat.responses import TextDelta
 
 if TYPE_CHECKING:
@@ -61,6 +61,8 @@ class AnthropicBackend:
         system, messages = to_anthropic_messages(request.messages)
         if system is not None:
             kwargs["system"] = system
+        if request.response_format is not None:
+            kwargs.update(response_format_kwargs(request.response_format))
         return kwargs, messages
 
     def completion(self, request: ChatRequest) -> ChatResponse:

--- a/src/openfactcheck/chat/backends/anthropic/normalize.py
+++ b/src/openfactcheck/chat/backends/anthropic/normalize.py
@@ -6,6 +6,7 @@ only places in this package that touch ``anthropic`` SDK types directly.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, TypedDict
 
 from openfactcheck.chat.errors import (
@@ -62,14 +63,23 @@ def to_chat_response(
     model: str,
     provider: ProviderName,
 ) -> ChatResponse:
-    """Convert an Anthropic ``Message`` to our ChatResponse."""
+    """Convert an Anthropic ``Message`` to our ChatResponse.
+
+    For a forced-tool structured-output reply, the tool input is JSON-encoded
+    into the message content so callers see the same JSON-string contract as
+    other backends.
+    """
+    tool_inputs = [block.input for block in response.content if block.type == "tool_use"]
     text_parts = [block.text for block in response.content if block.type == "text"]
-    if not text_parts:
+    if tool_inputs:
+        content = json.dumps(tool_inputs[0])
+    elif text_parts:
+        content = "".join(text_parts)
+    else:
         raise UnsupportedFeatureError(
-            "Anthropic response contained no text blocks (only thinking/tool_use). "
+            "Anthropic response contained no text or tool_use blocks (only thinking). "
             "Non-text content is not yet supported."
         )
-    content = "".join(text_parts)
 
     usage = Usage(
         input_tokens=response.usage.input_tokens,

--- a/src/openfactcheck/chat/backends/anthropic/params.py
+++ b/src/openfactcheck/chat/backends/anthropic/params.py
@@ -13,6 +13,7 @@ from openfactcheck.chat.errors import ProviderError, UnsupportedFeatureError
 
 if TYPE_CHECKING:
     from openfactcheck.chat.config import ModelConfig
+    from openfactcheck.chat.requests import ResponseFormat
 
 type Kwargs = dict[str, Any]
 """Keyword arguments for ``anthropic.messages.create``.
@@ -52,3 +53,16 @@ def config_to_kwargs(config: ModelConfig) -> Kwargs:
     if config.thinking and config.thinking_budget_tokens is not None:
         params["thinking"] = {"type": "enabled", "budget_tokens": config.thinking_budget_tokens}
     return params
+
+
+def response_format_kwargs(response_format: ResponseFormat) -> Kwargs:
+    """Build forced tool-use kwargs for Anthropic structured output.
+
+    Anthropic has no ``response_format`` parameter, so a single tool whose
+    ``input_schema`` is the requested schema is declared and forced via
+    ``tool_choice``. The model's tool input is then the structured result.
+    """
+    return {
+        "tools": [{"name": response_format.name, "input_schema": response_format.json_schema}],
+        "tool_choice": {"type": "tool", "name": response_format.name},
+    }

--- a/src/openfactcheck/chat/backends/openai/backend.py
+++ b/src/openfactcheck/chat/backends/openai/backend.py
@@ -24,7 +24,7 @@ from openfactcheck.chat.backends.openai.normalize import (
     to_openai_messages,
     to_stream_end,
 )
-from openfactcheck.chat.backends.openai.params import Kwargs, config_to_kwargs
+from openfactcheck.chat.backends.openai.params import Kwargs, config_to_kwargs, response_format_kwargs
 from openfactcheck.chat.responses import TextDelta
 
 if TYPE_CHECKING:
@@ -81,6 +81,8 @@ class OpenAIBackend:
     def _prepare(self, request: ChatRequest) -> tuple[Kwargs, list[OpenAIMessage]]:
         """Build SDK kwargs and convert messages for ``request``."""
         kwargs = config_to_kwargs(request.config)
+        if request.response_format is not None:
+            kwargs.update(response_format_kwargs(request.response_format))
         messages = to_openai_messages(request.messages)
         return kwargs, messages
 

--- a/src/openfactcheck/chat/backends/openai/params.py
+++ b/src/openfactcheck/chat/backends/openai/params.py
@@ -6,13 +6,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, cast
 
 from openfactcheck.chat.config import OpenAICompatibleConfig
 from openfactcheck.chat.errors import UnsupportedFeatureError
 
 if TYPE_CHECKING:
     from openfactcheck.chat.config import ModelConfig
+    from openfactcheck.chat.requests import ResponseFormat
 
 type Kwargs = dict[str, Any]
 """Keyword arguments for ``openai.chat.completions.create``.
@@ -52,3 +54,88 @@ def config_to_kwargs(config: ModelConfig) -> Kwargs:
     _set_optional(params, "presence_penalty", config.presence_penalty)
     _set_optional(params, "reasoning_effort", config.reasoning_effort)
     return params
+
+
+def response_format_kwargs(response_format: ResponseFormat) -> Kwargs:
+    """Build the ``response_format`` kwarg for OpenAI structured output.
+
+    Wraps the schema as a ``json_schema`` response format. When the request
+    asks for strict enforcement, the schema is tightened with
+    [`to_strict_schema`][openfactcheck.chat.backends.openai.params.to_strict_schema]
+    so it satisfies OpenAI's strict-mode requirements.
+    """
+    schema = to_strict_schema(response_format.json_schema) if response_format.strict else response_format.json_schema
+    return {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": response_format.name,
+                "schema": schema,
+                "strict": response_format.strict,
+            },
+        }
+    }
+
+
+_UNSUPPORTED_KEYWORDS = frozenset(
+    {
+        # Numbers and integers.
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        # Strings.
+        "minLength",
+        "maxLength",
+        "pattern",
+        "format",
+        # Arrays.
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        # Objects.
+        "minProperties",
+        "maxProperties",
+        "patternProperties",
+        "propertyNames",
+    }
+)
+"""Validation keywords outside the strict structured-output subset.
+
+Strict mode does not support these (some providers reject them outright, for
+example Anthropic on numeric ranges). They are dropped from the wire schema;
+the constraints still hold because the reply is validated against the original
+model, with reprompts on failure.
+"""
+
+
+def to_strict_schema(schema: dict[str, object]) -> dict[str, object]:
+    """Return a deep copy of a JSON Schema tightened for strict structured output.
+
+    Strict mode requires every object to set ``additionalProperties: false`` and
+    to list all of its properties as ``required``. This walks the schema
+    (including ``$defs`` and nested objects), applies both, and drops validation
+    keywords outside the supported subset (numeric ranges, string patterns, and
+    so on). The input is left untouched.
+    """
+    result = deepcopy(schema)
+    _tighten(result)
+    return result
+
+
+def _tighten(node: object) -> None:
+    """Recursively enforce strict-object rules on a JSON Schema node, in place."""
+    if isinstance(node, dict):
+        obj = cast("dict[str, object]", node)
+        for keyword in _UNSUPPORTED_KEYWORDS & obj.keys():
+            del obj[keyword]
+        props = obj.get("properties")
+        if obj.get("type") == "object" and isinstance(props, dict):
+            obj["additionalProperties"] = False
+            obj["required"] = list(cast("dict[str, object]", props).keys())
+        for value in obj.values():
+            _tighten(value)
+    elif isinstance(node, list):
+        for item in cast("list[object]", node):
+            _tighten(item)

--- a/src/openfactcheck/chat/client.py
+++ b/src/openfactcheck/chat/client.py
@@ -29,10 +29,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel, ValidationError
+
 from openfactcheck.chat.backends import _default_backend  # pyright: ignore[reportPrivateUsage] - internal API.
 from openfactcheck.chat.config import RuntimeConfig
+from openfactcheck.chat.errors import StructuredOutputError, UnsupportedFeatureError
+from openfactcheck.chat.messages import UserMessage
 from openfactcheck.chat.providers import get_provider
-from openfactcheck.chat.requests import ChatRequest
+from openfactcheck.chat.requests import ChatRequest, ResponseFormat
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -90,8 +94,18 @@ class ChatClient:
         self._provider.validate_config(config)
         self._backend: ChatBackend = backend if backend is not None else _default_backend(config.provider)
 
-    def _build_request(self, messages: list[Message]) -> ChatRequest:
-        return ChatRequest(messages=messages, config=self._config, runtime=self._runtime)
+    def _build_request(self, messages: list[Message], response_format: ResponseFormat | None = None) -> ChatRequest:
+        return ChatRequest(
+            messages=messages,
+            config=self._config,
+            runtime=self._runtime,
+            response_format=response_format,
+        )
+
+    def _require_structured_output(self) -> None:
+        """Raise if the configured provider does not support structured output."""
+        if not self._provider.capabilities.structured_output:
+            raise UnsupportedFeatureError(f"provider '{self._config.provider}' does not support structured output.")
 
     def completion(self, messages: list[Message]) -> ChatResponse:
         """Send messages and return a complete response.
@@ -139,3 +153,100 @@ class ChatClient:
         """
         async for event in self._backend.astream(self._build_request(messages)):
             yield event
+
+    def completion_as[T: BaseModel](self, messages: list[Message], response_model: type[T]) -> T:
+        """Send messages and return a validated instance of ``response_model``.
+
+        Asks the model to reply with JSON matching ``response_model`` and
+        validates the reply into an instance. On a validation failure, the
+        error is sent back to the model and the call retried up to
+        [`max_parse_retries`][RuntimeConfig.max_parse_retries] times before
+        raising.
+
+        Args:
+            messages: The conversation to send.
+            response_model: The Pydantic model the reply must conform to.
+
+        Returns:
+            A validated instance of ``response_model``.
+
+        Raises:
+            UnsupportedFeatureError: The provider does not support structured
+                output.
+            StructuredOutputError: The reply still failed validation after the
+                allowed retries.
+        """
+        self._require_structured_output()
+        response_format = ResponseFormat(
+            name=response_model.__name__,
+            json_schema=response_model.model_json_schema(),
+        )
+        conversation = list(messages)
+        retries_left = self._runtime.max_parse_retries
+        while True:
+            response = self._backend.completion(self._build_request(conversation, response_format))
+            raw = response.message.content
+            try:
+                return response_model.model_validate_json(raw)
+            except ValidationError as exc:
+                if retries_left <= 0:
+                    raise StructuredOutputError(
+                        f"reply did not match {response_model.__name__} after retries.",
+                        raw=raw,
+                        validation_error=exc,
+                    ) from exc
+                retries_left -= 1
+                reprompt = UserMessage(
+                    content=(
+                        "Your previous reply did not match the required schema. "
+                        f"Fix these errors and return only valid JSON:\n{exc}"
+                    ),
+                )
+                conversation = [*conversation, response.message, reprompt]
+
+    async def acompletion_as[T: BaseModel](self, messages: list[Message], response_model: type[T]) -> T:
+        """Send messages and await a validated instance of ``response_model``.
+
+        Async peer of [`completion_as`][ChatClient.completion_as]; same
+        validation and retry behavior.
+
+        Args:
+            messages: The conversation to send.
+            response_model: The Pydantic model the reply must conform to.
+
+        Returns:
+            A validated instance of ``response_model``.
+
+        Raises:
+            UnsupportedFeatureError: The provider does not support structured
+                output.
+            StructuredOutputError: The reply still failed validation after the
+                allowed retries.
+        """
+        self._require_structured_output()
+        response_format = ResponseFormat(
+            name=response_model.__name__,
+            json_schema=response_model.model_json_schema(),
+        )
+        conversation = list(messages)
+        retries_left = self._runtime.max_parse_retries
+        while True:
+            response = await self._backend.acompletion(self._build_request(conversation, response_format))
+            raw = response.message.content
+            try:
+                return response_model.model_validate_json(raw)
+            except ValidationError as exc:
+                if retries_left <= 0:
+                    raise StructuredOutputError(
+                        f"reply did not match {response_model.__name__} after retries.",
+                        raw=raw,
+                        validation_error=exc,
+                    ) from exc
+                retries_left -= 1
+                reprompt = UserMessage(
+                    content=(
+                        "Your previous reply did not match the required schema. "
+                        f"Fix these errors and return only valid JSON:\n{exc}"
+                    ),
+                )
+                conversation = [*conversation, response.message, reprompt]

--- a/src/openfactcheck/chat/config.py
+++ b/src/openfactcheck/chat/config.py
@@ -234,3 +234,14 @@ class RuntimeConfig(BaseModel):
 
     Set to ``0`` to disable. Must be non-negative.
     """
+
+    max_parse_retries: int = Field(default=0, ge=0)
+    """Reprompts allowed when a structured-output reply fails validation.
+
+    Applies only to [`ChatClient.completion_as`][ChatClient.completion_as] and
+    its async peer. ``0`` raises on the first validation failure; a positive
+    value re-sends the validation error to the model up to that many times
+    before raising. Distinct from
+    [`max_retries`][RuntimeConfig.max_retries], which retries transport
+    failures. Must be non-negative.
+    """

--- a/src/openfactcheck/chat/errors.py
+++ b/src/openfactcheck/chat/errors.py
@@ -33,6 +33,13 @@ Example:
     ```
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import ValidationError
+
 
 class ChatModelError(Exception):
     """Base exception for every chat layer error.
@@ -47,10 +54,8 @@ class ProviderNotFoundError(ChatModelError):
 
     Raised when [`ChatClient`][ChatClient] is constructed with a
     [`ModelConfig`][ModelConfig] whose provider has no registered
-    [`BaseProvider`][BaseProvider], or when a backend's optional SDK
-    dependency is missing from the environment (install with
-    ``pip install 'openfactcheck[openai]'``, ``openfactcheck[anthropic]``,
-    and so on).
+    [`BaseProvider`][BaseProvider], or when a backend's provider SDK cannot
+    be imported.
     """
 
 
@@ -88,3 +93,19 @@ class UnsupportedFeatureError(ChatModelError):
     behavior the provider can't satisfy, for example tool calls on a model
     that doesn't support them.
     """
+
+
+class StructuredOutputError(ChatModelError):
+    """A structured-output reply could not be validated against the requested model.
+
+    Raised by [`ChatClient.completion_as`][ChatClient.completion_as] and its
+    async peer after the reply fails validation and any configured reprompts
+    are exhausted. The raw reply text and the underlying validation error are
+    attached for inspection.
+    """
+
+    def __init__(self, message: str, *, raw: str, validation_error: ValidationError) -> None:
+        """Record the raw reply text and the validation error that rejected it."""
+        self.raw = raw
+        self.validation_error = validation_error
+        super().__init__(message)

--- a/src/openfactcheck/chat/requests.py
+++ b/src/openfactcheck/chat/requests.py
@@ -28,6 +28,27 @@ from openfactcheck.chat.config import ModelConfig, RuntimeConfig
 from openfactcheck.chat.messages import Message
 
 
+class ResponseFormat(BaseModel):
+    """Schema a structured-output reply must conform to.
+
+    Built from a Pydantic model by
+    [`ChatClient.completion_as`][ChatClient.completion_as] and carried on the
+    request so a backend can enforce it with the provider's native mechanism.
+    The reply's content is then the JSON matching this schema.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
+    name: str
+    """Schema name, used as the json_schema name or the forced tool name."""
+
+    json_schema: dict[str, object]
+    """The JSON Schema the reply must satisfy, from the model's ``model_json_schema()``."""
+
+    strict: bool = True
+    """Whether to request strict schema enforcement where the provider supports it."""
+
+
 class ChatRequest(BaseModel):
     """A complete request for a single chat completion or stream.
 
@@ -52,4 +73,11 @@ class ChatRequest(BaseModel):
     """Execution-level settings such as timeout and retries.
 
     Defaults to an empty [`RuntimeConfig`][RuntimeConfig].
+    """
+
+    response_format: ResponseFormat | None = None
+    """Optional structured-output schema.
+
+    When set, the backend asks the model to return JSON matching the schema,
+    and the reply's content is that JSON string. Unset for plain text replies.
     """

--- a/tests/chat/backends/anthropic/test_normalize.py
+++ b/tests/chat/backends/anthropic/test_normalize.py
@@ -105,15 +105,28 @@ def test_to_chat_response_concatenates_text_blocks() -> None:
     assert result.message.content == "Part one. Part two."
 
 
-def test_to_chat_response_rejects_no_text_blocks() -> None:
-    """A response with only non-text blocks raises UnsupportedFeatureError."""
+def test_to_chat_response_tool_use_becomes_json() -> None:
+    """A forced-tool reply JSON-encodes the tool input into the message content."""
     response = SimpleNamespace(
-        content=[SimpleNamespace(type="tool_use", id="tu_1")],
+        content=[SimpleNamespace(type="tool_use", id="tu_1", name="Person", input={"name": "Ada", "age": 36})],
         usage=SimpleNamespace(input_tokens=10, output_tokens=3),
         stop_reason="tool_use",
     )
 
-    with pytest.raises(UnsupportedFeatureError, match="no text blocks"):
+    result = to_chat_response(response, model="claude-sonnet-4-6", provider="anthropic")
+
+    assert result.message.content == '{"name": "Ada", "age": 36}'
+
+
+def test_to_chat_response_rejects_blocks_without_text_or_tool_use() -> None:
+    """A response with neither text nor tool_use blocks raises UnsupportedFeatureError."""
+    response = SimpleNamespace(
+        content=[SimpleNamespace(type="thinking", thinking="...")],
+        usage=SimpleNamespace(input_tokens=10, output_tokens=3),
+        stop_reason="end_turn",
+    )
+
+    with pytest.raises(UnsupportedFeatureError, match="no text or tool_use blocks"):
         to_chat_response(response, model="claude-sonnet-4-6", provider="anthropic")
 
 

--- a/tests/chat/backends/anthropic/test_params.py
+++ b/tests/chat/backends/anthropic/test_params.py
@@ -2,9 +2,10 @@
 
 import pytest
 
-from openfactcheck.chat.backends.anthropic.params import config_to_kwargs
+from openfactcheck.chat.backends.anthropic.params import config_to_kwargs, response_format_kwargs
 from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig
 from openfactcheck.chat.errors import ProviderError, UnsupportedFeatureError
+from openfactcheck.chat.requests import ResponseFormat
 
 
 def test_config_to_kwargs_minimal() -> None:
@@ -52,3 +53,14 @@ def test_config_to_kwargs_rejects_openai() -> None:
 
     with pytest.raises(UnsupportedFeatureError, match="does not support provider 'openai'"):
         config_to_kwargs(config)
+
+
+def test_response_format_kwargs_uses_forced_tool() -> None:
+    """Structured output becomes a single forced tool whose input_schema is the model schema."""
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+    response_format = ResponseFormat(name="Person", json_schema=schema)
+
+    kwargs = response_format_kwargs(response_format)
+
+    assert kwargs["tools"] == [{"name": "Person", "input_schema": schema}]
+    assert kwargs["tool_choice"] == {"type": "tool", "name": "Person"}

--- a/tests/chat/backends/openai/test_params.py
+++ b/tests/chat/backends/openai/test_params.py
@@ -2,9 +2,10 @@
 
 import pytest
 
-from openfactcheck.chat.backends.openai.params import config_to_kwargs
+from openfactcheck.chat.backends.openai.params import config_to_kwargs, response_format_kwargs, to_strict_schema
 from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig
 from openfactcheck.chat.errors import UnsupportedFeatureError
+from openfactcheck.chat.requests import ResponseFormat
 
 
 def test_config_to_kwargs_minimal() -> None:
@@ -47,3 +48,84 @@ def test_config_to_kwargs_rejects_anthropic() -> None:
 
     with pytest.raises(UnsupportedFeatureError, match="does not support provider 'anthropic'"):
         config_to_kwargs(config)
+
+
+def test_to_strict_schema_tightens_objects() -> None:
+    """Strict transform sets additionalProperties=false and requires every property, including in $defs."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "pet": {"$ref": "#/$defs/Pet"},
+        },
+        "required": ["name"],
+        "$defs": {
+            "Pet": {
+                "type": "object",
+                "properties": {"species": {"type": "string"}},
+            }
+        },
+    }
+
+    strict = to_strict_schema(schema)
+
+    assert strict["additionalProperties"] is False
+    assert sorted(strict["required"]) == ["name", "pet"]
+    pet = strict["$defs"]["Pet"]
+    assert pet["additionalProperties"] is False
+    assert pet["required"] == ["species"]
+    # Original is untouched.
+    assert "additionalProperties" not in schema
+
+
+def test_to_strict_schema_drops_unsupported_keywords() -> None:
+    """Constraint keywords outside the strict subset are stripped from the wire schema."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "score": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "name": {"type": "string", "maxLength": 50, "pattern": "^x"},
+            "tags": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+        },
+    }
+
+    strict = to_strict_schema(schema)
+
+    assert "minimum" not in strict["properties"]["score"]
+    assert "maximum" not in strict["properties"]["score"]
+    assert "maxLength" not in strict["properties"]["name"]
+    assert "pattern" not in strict["properties"]["name"]
+    assert "minItems" not in strict["properties"]["tags"]
+    # The underlying type information is preserved.
+    assert strict["properties"]["score"]["type"] == "number"
+
+
+def test_response_format_kwargs_strict() -> None:
+    """A strict ResponseFormat becomes a json_schema response_format with a tightened schema."""
+    response_format = ResponseFormat(
+        name="Person",
+        json_schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        strict=True,
+    )
+
+    kwargs = response_format_kwargs(response_format)
+
+    block = kwargs["response_format"]
+    assert block["type"] == "json_schema"
+    assert block["json_schema"]["name"] == "Person"
+    assert block["json_schema"]["strict"] is True
+    assert block["json_schema"]["schema"]["additionalProperties"] is False
+
+
+def test_response_format_kwargs_non_strict_skips_transform() -> None:
+    """A non-strict ResponseFormat passes the schema through unchanged."""
+    response_format = ResponseFormat(
+        name="Person",
+        json_schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        strict=False,
+    )
+
+    kwargs = response_format_kwargs(response_format)
+
+    schema = kwargs["response_format"]["json_schema"]["schema"]
+    assert "additionalProperties" not in schema

--- a/tests/chat/test_client.py
+++ b/tests/chat/test_client.py
@@ -1,14 +1,42 @@
 """Tests for ChatClient with mocked backend."""
 
+from types import SimpleNamespace
+
 import pytest
+from pydantic import BaseModel
 
 from openfactcheck.chat.backends.anthropic import AnthropicBackend
 from openfactcheck.chat.backends.openai import OpenAIBackend
 from openfactcheck.chat.client import ChatClient
 from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig, RuntimeConfig
+from openfactcheck.chat.errors import StructuredOutputError, UnsupportedFeatureError
 from openfactcheck.chat.messages import AssistantMessage, UserMessage
 from openfactcheck.chat.requests import ChatRequest
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, TextDelta, Usage
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class ScriptedBackend:
+    """Backend test double that returns a scripted sequence of reply contents."""
+
+    def __init__(self, contents: list[str]) -> None:
+        self._contents = contents
+        self.requests: list[ChatRequest] = []
+
+    def _next(self, request: ChatRequest) -> ChatResponse:
+        content = self._contents[len(self.requests)]
+        self.requests.append(request)
+        return ChatResponse(message=AssistantMessage(content=content), model="gpt-4o", provider="openai")
+
+    def completion(self, request: ChatRequest) -> ChatResponse:
+        return self._next(request)
+
+    async def acompletion(self, request: ChatRequest) -> ChatResponse:
+        return self._next(request)
 
 
 class FakeBackend:
@@ -152,3 +180,62 @@ def test_ChatClient_default_backend_anthropic_uses_direct_sdk() -> None:
     client = ChatClient(config=config)
 
     assert isinstance(client._backend, AnthropicBackend)
+
+
+def test_ChatClient_completion_as_returns_model(openai_config: OpenAIConfig) -> None:
+    """completion_as validates the reply into the requested model and sets a response_format."""
+    backend = ScriptedBackend(['{"name": "Ada", "age": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    person = client.completion_as([UserMessage(content="Make a person")], _Person)
+
+    assert person == _Person(name="Ada", age=36)
+    assert backend.requests[0].response_format is not None
+    assert backend.requests[0].response_format.name == "_Person"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_acompletion_as_returns_model(openai_config: OpenAIConfig) -> None:
+    """acompletion_as validates the reply into the requested model."""
+    backend = ScriptedBackend(['{"name": "Ada", "age": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    person = await client.acompletion_as([UserMessage(content="Make a person")], _Person)
+
+    assert person == _Person(name="Ada", age=36)
+
+
+def test_ChatClient_completion_as_raises_on_invalid(openai_config: OpenAIConfig) -> None:
+    """With max_parse_retries=0, an invalid reply raises StructuredOutputError without retrying."""
+    backend = ScriptedBackend(['{"name": "Ada"}'])
+    client = ChatClient(config=openai_config, runtime=RuntimeConfig(max_parse_retries=0), backend=backend)  # type: ignore[arg-type]
+
+    with pytest.raises(StructuredOutputError) as excinfo:
+        client.completion_as([UserMessage(content="Make a person")], _Person)
+
+    assert len(backend.requests) == 1
+    assert excinfo.value.raw == '{"name": "Ada"}'
+
+
+def test_ChatClient_completion_as_retries_then_succeeds(openai_config: OpenAIConfig) -> None:
+    """A validation failure is reprompted, and the retried reply is returned."""
+    backend = ScriptedBackend(['{"name": "Ada"}', '{"name": "Ada", "age": 36}'])
+    client = ChatClient(config=openai_config, runtime=RuntimeConfig(max_parse_retries=2), backend=backend)  # type: ignore[arg-type]
+
+    person = client.completion_as([UserMessage(content="Make a person")], _Person)
+
+    assert person == _Person(name="Ada", age=36)
+    assert len(backend.requests) == 2
+    # The retry carries the original turn plus the failed reply and a reprompt.
+    assert len(backend.requests[1].messages) == 3
+    assert isinstance(backend.requests[1].messages[-1], UserMessage)
+
+
+def test_ChatClient_completion_as_unsupported_raises(openai_config: OpenAIConfig, mocker) -> None:  # noqa: ANN001 - pytest-mock fixture.
+    """completion_as raises when the provider does not support structured output."""
+    backend = ScriptedBackend(['{"name": "Ada", "age": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+    mocker.patch.object(client._provider, "capabilities", SimpleNamespace(structured_output=False))
+
+    with pytest.raises(UnsupportedFeatureError):
+        client.completion_as([UserMessage(content="Make a person")], _Person)

--- a/tests/chat/test_errors.py
+++ b/tests/chat/test_errors.py
@@ -1,6 +1,7 @@
 """Tests for LLM error hierarchy."""
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from openfactcheck.chat.errors import (
     AuthenticationError,
@@ -8,6 +9,7 @@ from openfactcheck.chat.errors import (
     ProviderError,
     ProviderNotFoundError,
     RateLimitError,
+    StructuredOutputError,
     UnsupportedFeatureError,
 )
 
@@ -30,3 +32,19 @@ def test_error_inherits_from_base(error_cls: type[ChatModelError]) -> None:
     assert isinstance(err, ChatModelError)
     assert isinstance(err, Exception)
     assert str(err) == "test message"
+
+
+def test_StructuredOutputError_carries_raw_and_validation_error() -> None:
+    """StructuredOutputError is a ChatModelError and exposes the raw reply and validation error."""
+
+    class _Model(BaseModel):
+        count: int
+
+    try:
+        _Model.model_validate_json("{}")
+    except ValidationError as exc:
+        err = StructuredOutputError("did not match", raw="{}", validation_error=exc)
+
+    assert isinstance(err, ChatModelError)
+    assert err.raw == "{}"
+    assert isinstance(err.validation_error, ValidationError)


### PR DESCRIPTION
## Summary

Adds typed structured output to the chat layer so components get validated Pydantic objects instead of hand-parsing text. Lights up the `structured_output` provider capability that was already declared but unimplemented.

- **API:** `ChatClient.completion_as(messages, response_model) -> T` and async `acompletion_as`, returning the Pydantic instance directly (PEP 695 generics).
- **Uniform contract:** every backend returns a `ChatResponse` whose `message.content` is the JSON string; validation happens once in the client. `ChatRequest` carries an optional `ResponseFormat` (name + json_schema + strict); backends never see the Pydantic class.
- **OpenAI / OpenRouter:** native `json_schema` `response_format`. `to_strict_schema` sets `additionalProperties:false` + all-required over nested `$defs`, and strips validation keywords outside the strict subset (numeric ranges, string patterns, etc.) so schemas are portable — constraints still hold client-side via Pydantic.
- **Anthropic:** forced single tool-use; `normalize.py` JSON-encodes the tool input into content.
- **Validation failure is the caller's choice:** new `RuntimeConfig.max_parse_retries` (default `0` raises `StructuredOutputError`; `N>0` reprompts with the error). Guarded by the `structured_output` capability.
- Prompt-and-parse fallback for non-native providers is deferred to #30.

## Verification

- `task dev:test`: 463 passed (11 new).
- `task dev:lint`: ruff 0, pyright 0, format clean.
- `mkdocs build --strict`: clean.
- Live: 36/36 across 6 frontier OpenRouter models (gpt-5.5, claude-opus-4.8, gemini-3.5-flash, grok-4.3, deepseek-v3.2, llama-4-maverick) x 6 schema shapes, plus a bounded-concurrency async burst. The keyword-stripping fix was found by this stress test (Anthropic 400s on numeric ranges).