### PR TITLE
refactor: extract messages into a standalone package

### DIFF
--- a/docs/reference/chat/index.md
+++ b/docs/reference/chat/index.md
@@ -8,7 +8,6 @@
 ## Pages
 
 - [`ChatClient` class](client.md) — the facade callers use to send messages and receive completions or streams.
-- [Messages](messages.md) — system, user, assistant, and tool messages that flow through the client.
 - [Requests](requests.md) — the bundled payload a backend receives (messages + config + runtime).
 - [Responses](responses.md) — complete responses, streaming events, and usage data.
 - [Config](config.md) — provider-specific configuration and runtime settings.

--- a/docs/reference/messages/index.md
+++ b/docs/reference/messages/index.md
@@ -1,42 +1,42 @@
 # Messages
 
-::: openfactcheck.chat.messages
+::: openfactcheck.messages
     options:
       members: false
       show_root_heading: false
 
 ## Core message types
 
-::: openfactcheck.chat.messages.SystemMessage
+::: openfactcheck.messages.SystemMessage
     options:
       show_root_heading: true
       heading_level: 3
 
-::: openfactcheck.chat.messages.UserMessage
+::: openfactcheck.messages.UserMessage
     options:
       show_root_heading: true
       heading_level: 3
 
-::: openfactcheck.chat.messages.AssistantMessage
+::: openfactcheck.messages.AssistantMessage
     options:
       show_root_heading: true
       heading_level: 3
 
-::: openfactcheck.chat.messages.ToolMessage
+::: openfactcheck.messages.ToolMessage
     options:
       show_root_heading: true
       heading_level: 3
 
 ## Tool calls
 
-::: openfactcheck.chat.messages.ToolCall
+::: openfactcheck.messages.ToolCall
     options:
       show_root_heading: true
       heading_level: 3
 
 ## Union type
 
-::: openfactcheck.chat.messages.Message
+::: openfactcheck.messages.Message
     options:
       show_root_heading: true
       heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,10 +106,10 @@ nav:
   - Reference:
       - reference/index.md
       - REST API: reference/rest/index.md
+      - Messages: reference/messages/index.md
       - Chat:
           - reference/chat/index.md
           - reference/chat/client.md
-          - Messages: reference/chat/messages.md
           - Requests: reference/chat/requests.md
           - Responses: reference/chat/responses.md
           - Config: reference/chat/config.md

--- a/src/openfactcheck/chat/__init__.py
+++ b/src/openfactcheck/chat/__init__.py
@@ -2,21 +2,18 @@
 
 Build a [`ChatClient`][ChatClient] with a provider-specific configuration
 (for example [`OpenAIConfig`][OpenAIConfig]), send it a list of
-[`Message`][Message] values, and receive a [`ChatResponse`][ChatResponse] or
+[`Message`][openfactcheck.messages.Message] values, and receive a [`ChatResponse`][ChatResponse] or
 a stream of [`StreamEvent`][StreamEvent] values. Failures raise
 [`ChatModelError`][ChatModelError] subclasses.
 
-Import everything from ``openfactcheck.chat`` directly; submodule paths are
-not part of the public API.
+Import the chat API from ``openfactcheck.chat`` directly; submodule paths are
+not part of the public API. Message types live in the ``openfactcheck.messages``
+package.
 
 Example:
     ```python
-    from openfactcheck.chat import (
-        ChatClient,
-        OpenAIConfig,
-        SystemMessage,
-        UserMessage,
-    )
+    from openfactcheck.chat import ChatClient, OpenAIConfig
+    from openfactcheck.messages import SystemMessage, UserMessage
 
     client = ChatClient(config=OpenAIConfig(model="gpt-4o"))
     response = client.completion(
@@ -51,14 +48,6 @@ from openfactcheck.chat.errors import (
     StructuredOutputError,
     UnsupportedFeatureError,
 )
-from openfactcheck.chat.messages import (
-    AssistantMessage,
-    Message,
-    SystemMessage,
-    ToolCall,
-    ToolMessage,
-    UserMessage,
-)
 from openfactcheck.chat.providers.base import BaseProvider, ProviderCapabilities
 from openfactcheck.chat.requests import ChatRequest, ResponseFormat
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, StreamEvent, TextDelta, Usage
@@ -76,16 +65,6 @@ __all__ += [
     "OpenRouterConfig",
     "ProviderName",
     "RuntimeConfig",
-]
-
-# Messages
-__all__ += [
-    "AssistantMessage",
-    "Message",
-    "SystemMessage",
-    "ToolCall",
-    "ToolMessage",
-    "UserMessage",
 ]
 
 # Requests and responses

--- a/src/openfactcheck/chat/backends/anthropic/normalize.py
+++ b/src/openfactcheck/chat/backends/anthropic/normalize.py
@@ -15,15 +15,15 @@ from openfactcheck.chat.errors import (
     RateLimitError,
     UnsupportedFeatureError,
 )
-from openfactcheck.chat.messages import AssistantMessage, SystemMessage, UserMessage
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, Usage
+from openfactcheck.messages import AssistantMessage, SystemMessage, UserMessage
 
 if TYPE_CHECKING:
     from anthropic.types import Message as AnthropicMessage
 
     from openfactcheck.chat.config import ProviderName
     from openfactcheck.chat.errors import ChatModelError
-    from openfactcheck.chat.messages import Message
+    from openfactcheck.messages import Message
 
 
 class AnthropicInputMessage(TypedDict):

--- a/src/openfactcheck/chat/backends/openai/normalize.py
+++ b/src/openfactcheck/chat/backends/openai/normalize.py
@@ -13,15 +13,15 @@ from openfactcheck.chat.errors import (
     ProviderError,
     RateLimitError,
 )
-from openfactcheck.chat.messages import AssistantMessage, SystemMessage, ToolCall, UserMessage
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, Usage
+from openfactcheck.messages import AssistantMessage, SystemMessage, ToolCall, UserMessage
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
     from openfactcheck.chat.config import ProviderName
     from openfactcheck.chat.errors import ChatModelError
-    from openfactcheck.chat.messages import Message
+    from openfactcheck.messages import Message
 
 
 class OpenAIMessage(TypedDict, total=False):

--- a/src/openfactcheck/chat/client.py
+++ b/src/openfactcheck/chat/client.py
@@ -17,7 +17,8 @@ All four raise [`ChatModelError`][ChatModelError] subclasses on failure.
 
 Example:
     ```python
-    from openfactcheck.chat import ChatClient, OpenAIConfig, UserMessage
+    from openfactcheck.chat import ChatClient, OpenAIConfig
+    from openfactcheck.messages import UserMessage
 
     client = ChatClient(config=OpenAIConfig(model="gpt-4o"))
     response = client.completion([UserMessage(content="Hello")])
@@ -34,17 +35,17 @@ from pydantic import BaseModel, ValidationError
 from openfactcheck.chat.backends import default_backend
 from openfactcheck.chat.config import RuntimeConfig
 from openfactcheck.chat.errors import StructuredOutputError, UnsupportedFeatureError
-from openfactcheck.chat.messages import UserMessage
 from openfactcheck.chat.providers import get_provider
 from openfactcheck.chat.requests import ChatRequest, ResponseFormat
+from openfactcheck.messages import UserMessage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
     from openfactcheck.chat.backends.base import ChatBackend
     from openfactcheck.chat.config import ModelConfig
-    from openfactcheck.chat.messages import Message
     from openfactcheck.chat.responses import ChatResponse, StreamEvent
+    from openfactcheck.messages import Message
 
 
 class ChatClient:

--- a/src/openfactcheck/chat/config.py
+++ b/src/openfactcheck/chat/config.py
@@ -11,7 +11,8 @@ branch on ``config.provider``.
 
 Example:
     ```python
-    from openfactcheck.chat import ChatClient, OpenAIConfig, UserMessage
+    from openfactcheck.chat import ChatClient, OpenAIConfig
+    from openfactcheck.messages import UserMessage
 
     client = ChatClient(config=OpenAIConfig(model="gpt-4o", temperature=0.2))
     response = client.completion([UserMessage(content="Hello")])

--- a/src/openfactcheck/chat/errors.py
+++ b/src/openfactcheck/chat/errors.py
@@ -17,8 +17,8 @@ Example:
         ChatModelError,
         OpenAIConfig,
         RateLimitError,
-        UserMessage,
     )
+    from openfactcheck.messages import UserMessage
 
     client = ChatClient(config=OpenAIConfig(model="gpt-4o"))
 

--- a/src/openfactcheck/chat/requests.py
+++ b/src/openfactcheck/chat/requests.py
@@ -11,8 +11,8 @@ Example:
         ChatRequest,
         OpenAIConfig,
         RuntimeConfig,
-        UserMessage,
     )
+    from openfactcheck.messages import UserMessage
 
     request = ChatRequest(
         messages=[UserMessage(content="Hello")],
@@ -25,7 +25,7 @@ Example:
 from pydantic import BaseModel, ConfigDict, Field
 
 from openfactcheck.chat.config import ModelConfig, RuntimeConfig
-from openfactcheck.chat.messages import Message
+from openfactcheck.messages import Message
 
 
 class ResponseFormat(BaseModel):

--- a/src/openfactcheck/chat/responses.py
+++ b/src/openfactcheck/chat/responses.py
@@ -16,8 +16,8 @@ Example:
         OpenAIConfig,
         StreamEnd,
         TextDelta,
-        UserMessage,
     )
+    from openfactcheck.messages import UserMessage
 
     client = ChatClient(config=OpenAIConfig(model="gpt-4o"))
 
@@ -42,7 +42,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Discriminator
 
 from openfactcheck.chat.config import ProviderName
-from openfactcheck.chat.messages import AssistantMessage
+from openfactcheck.messages import AssistantMessage
 
 
 class Usage(BaseModel):

--- a/src/openfactcheck/messages/__init__.py
+++ b/src/openfactcheck/messages/__init__.py
@@ -1,14 +1,13 @@
 """Message types for the chat layer.
 
 Build a conversation as a list of messages, each carrying a ``role`` that
-identifies the sender, and pass it to
-[`ChatClient`][ChatClient] to get a completion or
+identifies the sender, and pass it to a chat client to get a completion or
 stream. Backend implementations convert messages to and from the underlying
 provider format at the boundary.
 
 Example:
     ```python
-    from openfactcheck.chat import (
+    from openfactcheck.messages import (
         AssistantMessage,
         SystemMessage,
         ToolCall,
@@ -152,7 +151,6 @@ Message = Annotated[
 ]
 """Union of every message type that can appear in a conversation.
 
-Callers build a ``list[Message]`` and pass it to
-[`ChatClient`][ChatClient]; branch on ``role`` to
-distinguish the concrete type.
+Callers build a ``list[Message]`` and pass it to a chat client; branch on
+``role`` to distinguish the concrete type.
 """

--- a/src/openfactcheck/prompts/codecs/markdown/emit.py
+++ b/src/openfactcheck/prompts/codecs/markdown/emit.py
@@ -9,7 +9,7 @@ import yaml
 from openfactcheck.prompts.codecs.markdown._constants import ROLE_H1
 
 if TYPE_CHECKING:
-    from openfactcheck.chat.messages import Message
+    from openfactcheck.messages import Message
     from openfactcheck.prompts.template import PromptTemplate
     from openfactcheck.prompts.variables import Role
 

--- a/src/openfactcheck/prompts/prompt.py
+++ b/src/openfactcheck/prompts/prompt.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from openfactcheck.chat.messages import Message
+    from openfactcheck.messages import Message
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/openfactcheck/prompts/template.py
+++ b/src/openfactcheck/prompts/template.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
-from openfactcheck.chat.messages import AssistantMessage, SystemMessage, UserMessage
+from openfactcheck.messages import AssistantMessage, SystemMessage, UserMessage
 from openfactcheck.prompts._substitution import find_placeholders, substitute
 from openfactcheck.prompts.errors import (
     PromptNotFoundError,
@@ -45,7 +45,7 @@ from openfactcheck.prompts.variables import VariableSpec
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from openfactcheck.chat.messages import Message
+    from openfactcheck.messages import Message
     from openfactcheck.prompts.variables import Role
 
 

--- a/src/openfactcheck/prompts/variables.py
+++ b/src/openfactcheck/prompts/variables.py
@@ -24,7 +24,7 @@ Role = Literal["system", "user", "assistant"]
 
 These are the roles a template authors directly, and the roles the
 ``(role, text)`` tuple shorthand accepts. The chat layer's
-[`Message`][openfactcheck.chat.messages.Message] union covers additional roles
+[`Message`][openfactcheck.messages.Message] union covers additional roles
 (such as tool results) that belong to a conversation rather than a template.
 """
 

--- a/tests/chat/backends/anthropic/test_backend.py
+++ b/tests/chat/backends/anthropic/test_backend.py
@@ -7,7 +7,7 @@ import pytest
 from openfactcheck.chat.backends.anthropic import AnthropicBackend
 from openfactcheck.chat.config import AnthropicConfig, RuntimeConfig
 from openfactcheck.chat.errors import AuthenticationError
-from openfactcheck.chat.messages import SystemMessage, UserMessage
+from openfactcheck.messages import SystemMessage, UserMessage
 from openfactcheck.chat.requests import ChatRequest
 from openfactcheck.chat.responses import FinishReason, StreamEnd, TextDelta
 

--- a/tests/chat/backends/anthropic/test_normalize.py
+++ b/tests/chat/backends/anthropic/test_normalize.py
@@ -15,7 +15,7 @@ from openfactcheck.chat.errors import (
     RateLimitError,
     UnsupportedFeatureError,
 )
-from openfactcheck.chat.messages import AssistantMessage, SystemMessage, ToolMessage, UserMessage
+from openfactcheck.messages import AssistantMessage, SystemMessage, ToolMessage, UserMessage
 from openfactcheck.chat.responses import FinishReason
 
 

--- a/tests/chat/backends/openai/test_backend.py
+++ b/tests/chat/backends/openai/test_backend.py
@@ -7,7 +7,7 @@ import pytest
 from openfactcheck.chat.backends.openai import OpenAIBackend
 from openfactcheck.chat.config import OpenAIConfig, RuntimeConfig
 from openfactcheck.chat.errors import AuthenticationError
-from openfactcheck.chat.messages import UserMessage
+from openfactcheck.messages import UserMessage
 from openfactcheck.chat.requests import ChatRequest
 from openfactcheck.chat.responses import FinishReason, StreamEnd, TextDelta
 

--- a/tests/chat/backends/openai/test_normalize.py
+++ b/tests/chat/backends/openai/test_normalize.py
@@ -12,7 +12,7 @@ from openfactcheck.chat.errors import (
     ProviderError,
     RateLimitError,
 )
-from openfactcheck.chat.messages import AssistantMessage, SystemMessage, ToolMessage, UserMessage
+from openfactcheck.messages import AssistantMessage, SystemMessage, ToolMessage, UserMessage
 from openfactcheck.chat.responses import FinishReason
 
 

--- a/tests/chat/backends/openrouter/test_backend.py
+++ b/tests/chat/backends/openrouter/test_backend.py
@@ -13,7 +13,7 @@ from openfactcheck.chat.backends.openrouter import OpenRouterBackend
 from openfactcheck.chat.backends.openrouter.backend import OPENROUTER_BASE_URL
 from openfactcheck.chat.config import OpenRouterConfig, RuntimeConfig
 from openfactcheck.chat.errors import AuthenticationError
-from openfactcheck.chat.messages import UserMessage
+from openfactcheck.messages import UserMessage
 from openfactcheck.chat.requests import ChatRequest
 
 

--- a/tests/chat/test_client.py
+++ b/tests/chat/test_client.py
@@ -10,7 +10,7 @@ from openfactcheck.chat.backends.openai import OpenAIBackend
 from openfactcheck.chat.client import ChatClient
 from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig, RuntimeConfig
 from openfactcheck.chat.errors import StructuredOutputError, UnsupportedFeatureError
-from openfactcheck.chat.messages import AssistantMessage, UserMessage
+from openfactcheck.messages import AssistantMessage, UserMessage
 from openfactcheck.chat.requests import ChatRequest
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, TextDelta, Usage
 

--- a/tests/chat/test_requests.py
+++ b/tests/chat/test_requests.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from openfactcheck.chat.config import OpenAIConfig, RuntimeConfig
-from openfactcheck.chat.messages import UserMessage
+from openfactcheck.messages import UserMessage
 from openfactcheck.chat.requests import ChatRequest
 
 

--- a/tests/chat/test_responses.py
+++ b/tests/chat/test_responses.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from openfactcheck.chat.messages import AssistantMessage
+from openfactcheck.messages import AssistantMessage
 from openfactcheck.chat.responses import ChatResponse, FinishReason, StreamEnd, StreamEvent, TextDelta, Usage
 
 

--- a/tests/prompts/test_chat_bridge.py
+++ b/tests/prompts/test_chat_bridge.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from openfactcheck.chat import AssistantMessage, ChatClient, OpenAIConfig
+from openfactcheck.chat import ChatClient, OpenAIConfig
 from openfactcheck.chat.responses import ChatResponse
+from openfactcheck.messages import AssistantMessage
 from openfactcheck.prompts import PromptTemplate
 
 if TYPE_CHECKING:

--- a/tests/prompts/test_prompt.py
+++ b/tests/prompts/test_prompt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from openfactcheck.chat import SystemMessage, UserMessage
+from openfactcheck.messages import SystemMessage, UserMessage
 from openfactcheck.prompts import Prompt
 
 

--- a/tests/prompts/test_template.py
+++ b/tests/prompts/test_template.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from openfactcheck.chat import SystemMessage, UserMessage
+from openfactcheck.messages import SystemMessage, UserMessage
 from openfactcheck.prompts import (
     Prompt,
     PromptTemplate,

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from openfactcheck.chat.messages import (
+from openfactcheck.messages import (
     AssistantMessage,
     SystemMessage,
     ToolCall,


### PR DESCRIPTION
Extracts the chat message types into a standalone `openfactcheck.messages` package so `chat/` and `prompts/` become independent peers.

## Why

`prompts/` depended on `chat/` for one thing only: the `Message` types it renders into (`prompts → chat.messages`). Moving those types into a shared foundation removes that edge.

## Dependency graph

Before: `prompts → chat.messages`.

After:
```
messages/          (zero internal deps — standalone foundation)
   ↑      ↑
chat/    prompts/   each imports only openfactcheck.messages; neither imports the other
```

## What changed

- Moved `chat/messages.py` → `messages/__init__.py` (history preserved), with the test (`tests/test_messages.py`) and docs page (`docs/reference/messages/index.md`, its own dir) alongside.
- Rewrote every `openfactcheck.chat.messages` import to `openfactcheck.messages` across src, tests, and docs.
- `chat/__init__.py` no longer re-exports the message types.
- Updated docstring examples and the docs nav (top-level `Messages` section).

## Breaking change

The public import path is now `openfactcheck.messages`:

```python
from openfactcheck.messages import UserMessage   # was: from openfactcheck.chat import UserMessage
```

## Verification

`pyright src` clean · full suite (528) passes · `ruff` + `mkdocs build --strict` clean · import-graph check confirms `prompts` no longer imports `chat`.
