### PR TITLE
chore(deps): only open dependabot PRs for major and minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      # Only major and minor updates open PRs; skip routine patch bumps.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "uv"
     directory: "/"
@@ -18,3 +22,7 @@ updates:
       python:
         patterns:
           - "*"
+    ignore:
+      # Only major and minor updates open PRs; skip routine patch bumps.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Limits dependabot to **major and minor** version updates by ignoring routine `version-update:semver-patch` bumps for both the `github-actions` and `uv` ecosystems.

## Why

Patch-level version bumps generate frequent low-value PRs. Restricting to major/minor keeps the dependency-update queue meaningful.

## Note

Patch-level **security** updates are unaffected — they still open PRs, which is the desired behavior.

Once merged to the default branch, dependabot will also auto-close any open PR that now matches the ignore rule (the existing patch-level ones) on its next run.
