### PR TITLE
chore(deps): scope dependabot groups to minor and major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       github-actions:
         patterns:
           - "*"
+        # Keep patch bumps out of the group so they can't ride along on a minor/major PR.
+        update-types:
+          - "minor"
+          - "major"
     ignore:
       # Only major and minor updates open PRs; skip routine patch bumps.
       - dependency-name: "*"
@@ -22,6 +26,10 @@ updates:
       python:
         patterns:
           - "*"
+        # Keep patch bumps out of the group so they can't ride along on a minor/major PR.
+        update-types:
+          - "minor"
+          - "major"
     ignore:
       # Only major and minor updates open PRs; skip routine patch bumps.
       - dependency-name: "*"


### PR DESCRIPTION
## Why this matters

PR #61 ("bump the python group ... with 7 updates") shipped five patch bumps despite the `ignore: version-update:semver-patch` rule added in #60. The semver-patch ignore only governs whether a dependency opens a PR *on its own*. Once a group PR is already opening because another member has a legitimate minor/major bump (here fastapi 0.136→0.137 and pytest 9.0→9.1), dependabot resolves the whole group to latest and rewrites every member's lower bound, sweeping patch-only deps along. That ride-along is not gated by the per-dependency ignore.

## What this changes

Adds `update-types: [minor, major]` to both groups (`github-actions`, `python`). Patch bumps are no longer group members, so they can't ride along; the existing `ignore` block then suppresses them as ungrouped updates. Net effect: only minor and major bumps open PRs.

Note the two fields use different vocabularies on purpose: `groups.update-types` takes bare `minor`/`major`, while `ignore.update-types` takes `version-update:semver-patch`.

## After merge

Comment `@dependabot recreate` on #61 to regenerate it under the new config (drops the five patch bumps, keeps fastapi + pytest).