### PR TITLE
refactor: reshape result contract and lay the components foundation

### DIFF
--- a/src/openfactcheck/components/__init__.py
+++ b/src/openfactcheck/components/__init__.py
@@ -1,0 +1,25 @@
+"""Public API for the components layer.
+
+A component is a callable implementing one of the category contracts:
+``ClaimProcessor``, ``Retriever``, ``Verifier``, and ``Aggregator`` (plus the
+optional ``QueryGenerator``). Any implementation of a contract is
+interchangeable with any other. Import the contracts from
+``openfactcheck.components``; concrete implementations live in subpackages.
+"""
+
+from openfactcheck.components.protocols import (
+    Aggregator,
+    ClaimProcessor,
+    QueryGenerator,
+    Retriever,
+    Verifier,
+)
+
+# Component category contracts
+__all__ = [
+    "Aggregator",
+    "ClaimProcessor",
+    "QueryGenerator",
+    "Retriever",
+    "Verifier",
+]

--- a/src/openfactcheck/components/protocols.py
+++ b/src/openfactcheck/components/protocols.py
@@ -1,32 +1,32 @@
 """Component category contracts for the fact-checking pipeline.
 
 Each component category is a ``Protocol`` defining the signature any
-implementation must match. Paper-specific components (Factool, RARR, and
-so on) live in separate modules under ``openfactcheck.components`` and
-are interchangeable with any other implementation of the same category.
+implementation must match. Implementations live in sibling subpackages
+(``null``, ``default``, and paper ports such as ``factool``) and are
+interchangeable with any other implementation of the same category.
 """
 
 from typing import Protocol, runtime_checkable
 
-from openfactcheck.types import Claim, Evidence, FactCheckResult, Input, Query, Verdict
+from openfactcheck.types import Claim, Evidence, Input, OverallVerdict, Query, Verdict
 
 
 @runtime_checkable
-class ClaimExtractor(Protocol):
-    """Extract atomic factual claims from input text.
+class ClaimProcessor(Protocol):
+    """Turn input text into atomic factual claims.
 
     One input may yield zero or more claims. Returning an empty list is
     valid (for example, when the input contains no checkable claims).
     """
 
     async def __call__(self, text: Input) -> list[Claim]:
-        """Extract claims from ``text``.
+        """Produce atomic claims from ``text``.
 
         Args:
-            text: Raw input text to scan for claims.
+            text: Input text to process into claims.
 
         Returns:
-            Atomic factual claims found in ``text``; empty when there are
+            Atomic factual claims drawn from ``text``; empty when there are
             no checkable claims.
         """
         ...
@@ -95,21 +95,21 @@ class Verifier(Protocol):
 
 @runtime_checkable
 class Aggregator(Protocol):
-    """Combine per-claim verdicts into the pipeline's overall result.
+    """Combine per-claim verdicts into one overall judgment.
 
-    Implementations set ``overall_label`` and ``overall_score`` on the
-    result. Strategy is implementation-defined (majority vote, weighted
-    average, worst-case, and so on).
+    Strategy is implementation-defined (majority vote, weighted average,
+    worst-case, and so on). The pipeline assembles the full result around
+    the returned judgment.
     """
 
-    async def __call__(self, verdicts: list[Verdict]) -> FactCheckResult:
-        """Aggregate per-claim verdicts.
+    async def __call__(self, verdicts: list[Verdict]) -> OverallVerdict:
+        """Aggregate per-claim verdicts into one overall judgment.
 
         Args:
-            verdicts: Per-claim verdicts produced earlier in the pipeline.
+            verdicts: Per-claim verdicts produced earlier in the pipeline;
+                may be empty when the input yielded no claims.
 
         Returns:
-            Overall fact-check result with an aggregate label and score
-            populated from ``verdicts``.
+            The overall judgment, with a strategy-defined label and score.
         """
         ...

--- a/src/openfactcheck/pipeline.py
+++ b/src/openfactcheck/pipeline.py
@@ -1,31 +1,33 @@
 """The default fact-check pipeline, composed on the graph layer.
 
 [`build_pipeline`][build_pipeline] wires the component contracts into a runnable
-[`Graph`][openfactcheck.graph.Graph]: it extracts claims from the input, fans
+[`Graph`][openfactcheck.graph.Graph]: it processes the input into claims, fans
 out over them to retrieve evidence and verify each claim in parallel, collects
-the per-claim verdicts, and aggregates them into a result. The components are
-supplied per run as [`Components`][Components] dependencies, so any
-implementation of a contract can be swapped in without touching the wiring.
+the per-claim reports, and assembles them with an overall judgment into a
+result. The components are supplied per run as [`Components`][Components]
+dependencies, and the original input rides on
+[`PipelineState`][PipelineState], so any implementation of a contract can be
+swapped in without touching the wiring.
 
 ```python
 graph = build_pipeline()
-result = graph.run(Input(content="..."), state=None, deps=components)
+result = graph.run(Input(content="..."), state=PipelineState(), deps=components)
 ```
 """
 
 from dataclasses import dataclass
 
-from openfactcheck.contracts import Aggregator, ClaimExtractor, Retriever, Verifier
+from openfactcheck.components.protocols import Aggregator, ClaimProcessor, Retriever, Verifier
 from openfactcheck.graph import Graph, GraphBuilder, StepContext
-from openfactcheck.types import Claim, Evidence, FactCheckResult, Input, Verdict
+from openfactcheck.types import Claim, ClaimReport, Evidence, FactCheckResult, Input
 
 
 @dataclass(frozen=True, slots=True)
 class Components:
     """The fact-check components a pipeline run draws on, injected as dependencies."""
 
-    extractor: ClaimExtractor
-    """Extracts atomic claims from the input."""
+    processor: ClaimProcessor
+    """Produces atomic claims from the input."""
 
     retriever: Retriever
     """Fetches evidence for one claim."""
@@ -34,47 +36,80 @@ class Components:
     """Judges one claim against its evidence."""
 
     aggregator: Aggregator
-    """Combines the per-claim verdicts into the overall result."""
+    """Combines the per-claim verdicts into the overall judgment."""
 
 
-def build_pipeline() -> Graph[Input, FactCheckResult, None, Components]:
+@dataclass
+class PipelineState:
+    """Run-scoped state for a fact-check run.
+
+    Carries the original input from the entry step to the assembly step. The
+    entry step runs once before any fan-out, so recording the input here is
+    free of races.
+    """
+
+    input: Input | None = None
+    """The run's original input, recorded by the entry step for assembly."""
+
+
+def build_pipeline() -> Graph[Input, FactCheckResult, PipelineState, Components]:
     """Build the default fact-check graph.
 
-    The returned graph extracts claims, fans out to retrieve and verify each
-    claim concurrently, collects the verdicts, and aggregates them. Supply the
-    components as ``deps`` when running it.
+    The returned graph records the input, processes it into claims, fans out to
+    retrieve and verify each claim concurrently, collects the per-claim reports,
+    and assembles them with an overall judgment into a result. Supply the
+    components as ``deps`` and a fresh [`PipelineState`][PipelineState] as
+    ``state`` when running it.
 
     Returns:
         A built [`Graph`][openfactcheck.graph.Graph] taking an
         [`Input`][openfactcheck.types.Input] and returning a
         [`FactCheckResult`][openfactcheck.types.FactCheckResult].
     """
-    g = GraphBuilder(deps_type=Components, input_type=Input, output_type=FactCheckResult)
+    g = GraphBuilder(
+        deps_type=Components,
+        input_type=Input,
+        output_type=FactCheckResult,
+        state_type=PipelineState,
+    )
 
     @g.step_node
-    async def extract(ctx: StepContext[Input, None, Components]) -> list[Claim]:
-        return await ctx.deps.extractor(ctx.inputs)
+    async def process(ctx: StepContext[Input, PipelineState, Components]) -> list[Claim]:
+        ctx.state.input = ctx.inputs
+        return await ctx.deps.processor(ctx.inputs)
 
     @g.step_node
-    async def retrieve(ctx: StepContext[Claim, None, Components]) -> Evidence:
+    async def retrieve(ctx: StepContext[Claim, PipelineState, Components]) -> Evidence:
         return await ctx.deps.retriever(ctx.inputs)
 
     @g.step_node
-    async def verify(ctx: StepContext[Evidence, None, Components]) -> Verdict:
-        return await ctx.deps.verifier(ctx.inputs.claim, ctx.inputs)
+    async def verify(ctx: StepContext[Evidence, PipelineState, Components]) -> ClaimReport:
+        verdict = await ctx.deps.verifier(ctx.inputs.claim, ctx.inputs)
+        return ClaimReport(claim=ctx.inputs.claim, evidence=ctx.inputs, verdict=verdict)
 
-    verdicts = g.collect_node(Verdict, node_id="verdicts")
+    reports = g.collect_node(ClaimReport, node_id="reports")
 
     @g.step_node
-    async def aggregate(ctx: StepContext[list[Verdict], None, Components]) -> FactCheckResult:
-        return await ctx.deps.aggregator(ctx.inputs)
+    async def assemble(ctx: StepContext[list[ClaimReport], PipelineState, Components]) -> FactCheckResult:
+        overall = await ctx.deps.aggregator([report.verdict for report in ctx.inputs])
+        recorded = ctx.state.input
+        if recorded is None:  # pragma: no cover - the process step records the input first.
+            raise RuntimeError("pipeline input was not recorded before assembly")
+        return FactCheckResult(
+            input=recorded,
+            claims=[report.claim for report in ctx.inputs],
+            evidence=[report.evidence for report in ctx.inputs],
+            verdicts=[report.verdict for report in ctx.inputs],
+            overall_label=overall.label,
+            overall_score=overall.score,
+        )
 
     g.add(
-        g.edge_from(g.start_node).to(extract),
-        g.edge_from(extract).map().to(retrieve),
+        g.edge_from(g.start_node).to(process),
+        g.edge_from(process).map().to(retrieve),
         g.edge_from(retrieve).to(verify),
-        g.edge_from(verify).to(verdicts),
-        g.edge_from(verdicts).to(aggregate),
-        g.edge_from(aggregate).to(g.end_node),
+        g.edge_from(verify).to(reports),
+        g.edge_from(reports).to(assemble),
+        g.edge_from(assemble).to(g.end_node),
     )
     return g.build()

--- a/src/openfactcheck/types.py
+++ b/src/openfactcheck/types.py
@@ -2,68 +2,147 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class Input(BaseModel):
     """Content to be fact-checked."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     content: str
+    """The text to be fact-checked."""
 
 
 class Claim(BaseModel):
     """A single factual claim extracted from the input."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     text: str
+    """The factual statement being checked."""
 
 
 class Query(BaseModel):
     """Search queries generated for verifying a claim."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     claim: Claim
+    """The claim the queries seek evidence for."""
+
     questions: list[str]
+    """Search questions derived from the claim."""
 
 
 class SourceMetadata(BaseModel):
     """Base metadata for a source. Subclass for specific source types."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
 
 
 class WebMetadata(SourceMetadata):
     """Metadata for a web source."""
 
     url: str
+    """Address of the web page."""
+
     title: str
+    """Title of the web page."""
 
 
 class Source(BaseModel):
     """A piece of evidence from any source type."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     content: str
+    """The source's textual content."""
+
     metadata: SourceMetadata = SourceMetadata()
+    """Structured metadata describing where the source came from."""
 
 
 class Evidence(BaseModel):
     """Evidence collected for a single claim."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     claim: Claim
+    """The claim this evidence bears on."""
+
     sources: list[Source]
+    """Sources gathered for the claim; empty when nothing was found."""
 
 
 class Verdict(BaseModel):
     """Verification result for a single claim."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     claim: Claim
+    """The claim being judged."""
+
     label: Literal["supported", "refuted", "not_enough_evidence"]
+    """Whether the evidence supports, refutes, or is insufficient for the claim."""
+
     confidence: float
+    """How strongly the evidence backs the assigned label."""
+
     reasoning: str
+    """Explanation for the assigned label."""
+
+
+class OverallVerdict(BaseModel):
+    """Aggregate judgment over a run's per-claim verdicts."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
+    label: str
+    """Overall outcome label for the run, named by the aggregation strategy."""
+
+    score: float
+    """Overall confidence or agreement score for the run."""
+
+
+class ClaimReport(BaseModel):
+    """A single claim paired with its evidence and verdict.
+
+    Keeps the per-claim artifacts produced across the pipeline aligned, so the
+    overall result can be assembled from a list of reports in claim order.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
+    claim: Claim
+    """The claim this report concerns."""
+
+    evidence: Evidence
+    """Evidence gathered for the claim."""
+
+    verdict: Verdict
+    """Verdict reached for the claim against its evidence."""
 
 
 class FactCheckResult(BaseModel):
     """Complete result of a fact-checking pipeline run."""
 
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
     input: Input
+    """The original input that was checked."""
+
     claims: list[Claim]
+    """Claims extracted from the input."""
+
     evidence: list[Evidence]
+    """Evidence gathered for each claim."""
+
     verdicts: list[Verdict]
+    """Per-claim verdicts."""
+
     overall_label: str
+    """Aggregate outcome label for the whole input."""
+
     overall_score: float
+    """Aggregate confidence or agreement score for the whole input."""

--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the components layer."""

--- a/tests/components/test_protocols.py
+++ b/tests/components/test_protocols.py
@@ -2,29 +2,30 @@
 
 import pytest
 
-from openfactcheck.contracts import Aggregator, ClaimExtractor, QueryGenerator, Retriever, Verifier
+from openfactcheck.components import Aggregator, ClaimProcessor, QueryGenerator, Retriever, Verifier
 from openfactcheck.types import (
     Claim,
     Evidence,
-    FactCheckResult,
     Input,
+    OverallVerdict,
     Query,
     Source,
     Verdict,
 )
 
+
 @pytest.mark.asyncio(loop_scope="function")
-async def test_ClaimExtractor_accepts_conforming_implementation() -> None:
+async def test_ClaimProcessor_accepts_conforming_implementation() -> None:
     """A class with matching async __call__ satisfies the Protocol and can be invoked."""
 
-    class DummyExtractor:
+    class DummyProcessor:
         async def __call__(self, text: Input) -> list[Claim]:
             return [Claim(text=f"claim from {text.content}")]
 
-    extractor: ClaimExtractor = DummyExtractor()
+    processor: ClaimProcessor = DummyProcessor()
 
-    assert isinstance(extractor, ClaimExtractor)
-    result = await extractor(Input(content="sample"))
+    assert isinstance(processor, ClaimProcessor)
+    result = await processor(Input(content="sample"))
     assert result == [Claim(text="claim from sample")]
 
 
@@ -83,15 +84,9 @@ async def test_Aggregator_accepts_conforming_implementation() -> None:
     """A class with matching async __call__ satisfies the Aggregator Protocol."""
 
     class DummyAggregator:
-        async def __call__(self, verdicts: list[Verdict]) -> FactCheckResult:
-            return FactCheckResult(
-                input=Input(content=""),
-                claims=[v.claim for v in verdicts],
-                evidence=[],
-                verdicts=verdicts,
-                overall_label="supported",
-                overall_score=1.0,
-            )
+        async def __call__(self, verdicts: list[Verdict]) -> OverallVerdict:
+            label = "supported" if verdicts else "not_enough_evidence"
+            return OverallVerdict(label=label, score=1.0)
 
     aggregator: Aggregator = DummyAggregator()
 
@@ -99,14 +94,14 @@ async def test_Aggregator_accepts_conforming_implementation() -> None:
     claim = Claim(text="c")
     verdict = Verdict(claim=claim, label="supported", confidence=1.0, reasoning="")
     result = await aggregator([verdict])
-    assert result.overall_label == "supported"
-    assert result.verdicts == [verdict]
+    assert result.label == "supported"
+    assert result.score == 1.0
 
 
 @pytest.mark.parametrize(
     "protocol",
-    [ClaimExtractor, QueryGenerator, Retriever, Verifier, Aggregator],
-    ids=["ClaimExtractor", "QueryGenerator", "Retriever", "Verifier", "Aggregator"],
+    [ClaimProcessor, QueryGenerator, Retriever, Verifier, Aggregator],
+    ids=["ClaimProcessor", "QueryGenerator", "Retriever", "Verifier", "Aggregator"],
 )
 def test_contracts_reject_class_without_call(protocol: type) -> None:
     """A class without __call__ does not satisfy any component Protocol."""

--- a/tests/graph/test_boundary.py
+++ b/tests/graph/test_boundary.py
@@ -11,7 +11,7 @@ GRAPH_ROOT = Path(__file__).resolve().parent.parent.parent / "src" / "openfactch
 # the fact-checking domain. Pipelines that use the graph live outside this package.
 FORBIDDEN_PREFIXES = (
     "openfactcheck.types",
-    "openfactcheck.contracts",
+    "openfactcheck.components",
     "openfactcheck.chat",
     "openfactcheck.prompts",
 )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,18 +1,13 @@
 """Tests for the default fact-check pipeline wired on the graph layer."""
 
-from openfactcheck.pipeline import Components, build_pipeline
-from openfactcheck.types import (
-    Claim,
-    Evidence,
-    FactCheckResult,
-    Input,
-    Source,
-    Verdict,
-)
+import asyncio
+
+from openfactcheck.pipeline import Components, PipelineState, build_pipeline
+from openfactcheck.types import Claim, Evidence, Input, OverallVerdict, Source, Verdict
 
 
-async def _extract(text: Input) -> list[Claim]:
-    return [Claim(text=sentence) for sentence in text.content.split(".") if sentence.strip()]
+async def _process(text: Input) -> list[Claim]:
+    return [Claim(text=sentence.strip()) for sentence in text.content.split(".") if sentence.strip()]
 
 
 async def _retrieve(claim: Claim) -> Evidence:
@@ -24,26 +19,74 @@ async def _verify(claim: Claim, evidence: Evidence) -> Verdict:
     return Verdict(claim=claim, label=label, confidence=0.9, reasoning="stub")
 
 
-async def _aggregate(verdicts: list[Verdict]) -> FactCheckResult:
+async def _aggregate(verdicts: list[Verdict]) -> OverallVerdict:
+    if not verdicts:
+        return OverallVerdict(label="not_enough_evidence", score=0.0)
     supported = sum(1 for verdict in verdicts if verdict.label == "supported")
-    score = supported / len(verdicts) if verdicts else 0.0
-    return FactCheckResult(
-        input=Input(content=""),
-        claims=[verdict.claim for verdict in verdicts],
-        evidence=[],
-        verdicts=verdicts,
-        overall_label="supported" if score >= 0.5 else "refuted",  # noqa: PLR2004 - simple stub threshold.
-        overall_score=score,
-    )
+    score = supported / len(verdicts)
+    label = "supported" if score >= 0.5 else "refuted"  # noqa: PLR2004 - simple stub threshold.
+    return OverallVerdict(label=label, score=score)
 
 
 def test_build_pipeline_runs_end_to_end() -> None:
-    graph = build_pipeline()
-    components = Components(extractor=_extract, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
 
-    result = graph.run(Input(content="The sky is blue. Water is wet."), state=None, deps=components)
+    result = build_pipeline().run(
+        Input(content="The sky is blue. Water is wet."), state=PipelineState(), deps=components
+    )
 
-    assert [claim.text.strip() for claim in result.claims] == ["The sky is blue", "Water is wet"]
+    assert [claim.text for claim in result.claims] == ["The sky is blue", "Water is wet"]
     assert all(verdict.label == "supported" for verdict in result.verdicts)
     assert result.overall_label == "supported"
     assert result.overall_score == 1.0
+    # The result carries the real input and per-claim evidence, aligned by claim.
+    assert result.input.content == "The sky is blue. Water is wet."
+    assert len(result.evidence) == len(result.claims)
+    assert [evidence.claim for evidence in result.evidence] == result.claims
+
+
+def test_build_pipeline_preserves_claim_order() -> None:
+    delays = {"a": 0.03, "b": 0.0, "c": 0.0}
+
+    async def slow_retrieve(claim: Claim) -> Evidence:
+        await asyncio.sleep(delays.get(claim.text, 0.0))
+        return Evidence(claim=claim, sources=[Source(content=f"e:{claim.text}")])
+
+    components = Components(processor=_process, retriever=slow_retrieve, verifier=_verify, aggregator=_aggregate)
+
+    result = build_pipeline().run(Input(content="a. b. c."), state=PipelineState(), deps=components)
+
+    # Source order survives nondeterministic branch completion.
+    assert [claim.text for claim in result.claims] == ["a", "b", "c"]
+    assert [verdict.claim.text for verdict in result.verdicts] == ["a", "b", "c"]
+    assert [evidence.claim.text for evidence in result.evidence] == ["a", "b", "c"]
+
+
+def test_build_pipeline_zero_claims() -> None:
+    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+
+    result = build_pipeline().run(Input(content="   "), state=PipelineState(), deps=components)
+
+    assert result.claims == []
+    assert result.evidence == []
+    assert result.verdicts == []
+    assert result.input.content == "   "
+    assert result.overall_label == "not_enough_evidence"
+
+
+def test_build_pipeline_duplicate_claims() -> None:
+    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+
+    result = build_pipeline().run(Input(content="dup. dup."), state=PipelineState(), deps=components)
+
+    assert [claim.text for claim in result.claims] == ["dup", "dup"]
+    assert len(result.verdicts) == 2
+
+
+def test_build_pipeline_state_records_input() -> None:
+    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    state = PipelineState()
+
+    build_pipeline().run(Input(content="The sky is blue."), state=state, deps=components)
+
+    assert state.input == Input(content="The sky is blue.")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,10 +1,15 @@
 """Tests for core data types."""
 
+import pytest
+from pydantic import ValidationError
+
 from openfactcheck.types import (
     Claim,
+    ClaimReport,
     Evidence,
     FactCheckResult,
     Input,
+    OverallVerdict,
     Query,
     Source,
     Verdict,
@@ -121,3 +126,28 @@ def test_serialization_round_trip() -> None:
     restored = FactCheckResult.model_validate(data)
     assert restored.verdicts[0].label == "supported"
     assert restored.evidence[0].sources[0].content == "Scientific consensus"
+
+
+def test_overall_verdict() -> None:
+    overall = OverallVerdict(label="supported", score=0.8)
+    assert overall.label == "supported"
+    assert overall.score == 0.8
+
+
+def test_claim_report() -> None:
+    claim = Claim(text="The earth is round")
+    evidence = Evidence(claim=claim, sources=[Source(content="NASA")])
+    verdict = Verdict(claim=claim, label="supported", confidence=0.9, reasoning="confirmed")
+
+    report = ClaimReport(claim=claim, evidence=evidence, verdict=verdict)
+
+    assert report.claim == claim
+    assert report.evidence == evidence
+    assert report.verdict.label == "supported"
+
+
+def test_frozen_model_rejects_mutation() -> None:
+    claim = Claim(text="The earth is round")
+
+    with pytest.raises(ValidationError):
+        claim.text = "mutated"


### PR DESCRIPTION
## Why

The component layer (v1's "solvers") is the next feature, but the result contract was broken: `Aggregator.__call__(verdicts) -> FactCheckResult` while `FactCheckResult` requires `input`, `claims`, and `evidence` the aggregator never receives. No aggregator could be written honestly. This lays the foundation so the pipeline produces a complete, honest result, and moves the contracts to their permanent home beside the (future) implementations. No component implementations yet — those land next.

## What

- **Aggregator reshaped** to `async __call__(verdicts) -> OverallVerdict` (new `{label, score}` type). The **pipeline** now assembles the full `FactCheckResult`: `verify` returns a `ClaimReport` (claim + evidence + verdict), `collect_node` returns them in claim order, and an `assemble` step builds the result from the reports plus the original input carried on a new `PipelineState`. The result now carries the real input and per-claim evidence, aligned by claim.
- **`ClaimExtractor` → `ClaimProcessor`** across the Protocol, `Components.processor`, the pipeline `process` step, and tests — aligning code with `PHILOSOPHY.md`, which already names the category `ClaimProcessor`.
- **`contracts.py` → `components/protocols.py`** (git-tracked rename), beside the future `null`/`default`/paper-port implementations, matching the repo pattern of co-locating protocols with implementations and the `protocols.py` naming rule. Re-exported from `openfactcheck.components`. `types.py` stays top-level (shared vocabulary + public output type).
- **`types.py` frozen retrofit**: all models now `frozen=True, extra="forbid", use_attribute_docstrings=True` with a docstring on every field; added `OverallVerdict` and `ClaimReport`.
- **Graph boundary guard** updated to forbid `openfactcheck.components` (the contracts' new home).

## Verification

- `uv run pyright src` — 0 errors (the `.map()` typing chain holds)
- `task dev:test` — 535 passed (new end-to-end honesty, claim-order, zero-claims, duplicate-claims, and state cases)
- `mkdocs build --strict` — clean
- `task dev:lint` — format, ruff, typecheck all pass

## Follow-up

The four `components/null/` no-op components, then `components/default/` and the `pipeline/` package of premade wirings.