### PR TITLE
feat: add dummy components and components/types reference docs

### DIFF
--- a/docs/reference/components/dummy.md
+++ b/docs/reference/components/dummy.md
@@ -1,0 +1,3 @@
+# Dummy components
+
+::: openfactcheck.components.dummy

--- a/docs/reference/components/index.md
+++ b/docs/reference/components/index.md
@@ -1,0 +1,11 @@
+# Components
+
+::: openfactcheck.components
+    options:
+      members: false
+      show_root_heading: false
+
+## Pages
+
+- [Contracts](protocols.md) — the category protocols every component implements.
+- [Dummy](dummy.md) — placeholder components that run a pipeline with no external dependencies.

--- a/docs/reference/components/protocols.md
+++ b/docs/reference/components/protocols.md
@@ -1,0 +1,3 @@
+# Contracts
+
+::: openfactcheck.components.protocols

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,5 +2,11 @@
 
 Generated API reference for OpenFactCheck's public modules.
 
+- [REST API](rest/index.md) — the HTTP API, rendered from the live OpenAPI spec.
+- [Types](types.md) — the core fact-checking data vocabulary: claims, evidence, verdicts, results.
+- [Messages](messages/index.md) — chat message types shared across the layers.
 - [Chat](chat/index.md) — LLM client, provider configuration, and backend selection.
-- [API](api/index.md) — REST API infrastructure: authentication, schemas, and endpoints.
+- [Prompts](prompts/index.md) — prompt templates and the markdown codec.
+- [Graph](graph/index.md) — the typed orchestration layer for composing components.
+- [Components](components/index.md) — the category contracts and their implementations.
+- [API](api/index.md) — Python building blocks behind the REST API: auth, models, repositories.

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,0 +1,3 @@
+# Types
+
+::: openfactcheck.types

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
   - Reference:
       - reference/index.md
       - REST API: reference/rest/index.md
+      - Types: reference/types.md
       - Messages: reference/messages/index.md
       - Chat:
           - reference/chat/index.md
@@ -149,6 +150,10 @@ nav:
           - Errors: reference/graph/errors.md
           - Persistence: reference/graph/persistence.md
           - Mermaid: reference/graph/mermaid.md
+      - Components:
+          - reference/components/index.md
+          - Contracts: reference/components/protocols.md
+          - Dummy: reference/components/dummy.md
       - API:
           - reference/api/index.md
           - Auth:

--- a/src/openfactcheck/components/dummy/__init__.py
+++ b/src/openfactcheck/components/dummy/__init__.py
@@ -1,0 +1,20 @@
+"""Deterministic dummy components.
+
+A complete set of placeholder components: each satisfies a category contract but
+performs no real work. Wiring all four runs a pipeline end to end with no
+external dependencies, which makes them handy as placeholders and as test
+fixtures.
+"""
+
+from openfactcheck.components.dummy.aggregator import DummyAggregator
+from openfactcheck.components.dummy.claim_processor import DummyClaimProcessor
+from openfactcheck.components.dummy.retriever import DummyRetriever
+from openfactcheck.components.dummy.verifier import DummyVerifier
+
+# Dummy components
+__all__ = [
+    "DummyAggregator",
+    "DummyClaimProcessor",
+    "DummyRetriever",
+    "DummyVerifier",
+]

--- a/src/openfactcheck/components/dummy/aggregator.py
+++ b/src/openfactcheck/components/dummy/aggregator.py
@@ -1,0 +1,24 @@
+"""Dummy aggregator."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import OverallVerdict, Verdict
+
+
+@dataclass(frozen=True, slots=True)
+class DummyAggregator:
+    """Aggregator that reaches no overall judgment.
+
+    Returns a fixed inconclusive judgment, ignoring the per-claim verdicts.
+    """
+
+    async def __call__(self, verdicts: list[Verdict]) -> OverallVerdict:
+        """Return a fixed inconclusive judgment.
+
+        Args:
+            verdicts: Per-claim verdicts; ignored.
+
+        Returns:
+            An overall judgment labelled ``not_enough_evidence`` with zero score.
+        """
+        return OverallVerdict(label="not_enough_evidence", score=0.0)

--- a/src/openfactcheck/components/dummy/claim_processor.py
+++ b/src/openfactcheck/components/dummy/claim_processor.py
@@ -1,0 +1,28 @@
+"""Dummy claim processor."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import Claim, Input
+
+
+@dataclass(frozen=True, slots=True)
+class DummyClaimProcessor:
+    """Claim processor that performs no extraction.
+
+    Wraps the whole input as a single claim, or yields nothing when the input is
+    blank.
+    """
+
+    async def __call__(self, text: Input) -> list[Claim]:
+        """Wrap ``text`` as a single claim.
+
+        Args:
+            text: Input to turn into claims.
+
+        Returns:
+            One claim holding the full input content, or an empty list when the
+            content is blank.
+        """
+        if not text.content.strip():
+            return []
+        return [Claim(text=text.content)]

--- a/src/openfactcheck/components/dummy/retriever.py
+++ b/src/openfactcheck/components/dummy/retriever.py
@@ -1,0 +1,25 @@
+"""Dummy retriever."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import Claim, Evidence
+
+
+@dataclass(frozen=True, slots=True)
+class DummyRetriever:
+    """Retriever that fetches no evidence.
+
+    Returns an empty evidence set for any claim, which turns the pipeline into
+    closed-book verification.
+    """
+
+    async def __call__(self, claim: Claim) -> Evidence:
+        """Return empty evidence for ``claim``.
+
+        Args:
+            claim: Claim to gather evidence for.
+
+        Returns:
+            Evidence attached to ``claim`` with no sources.
+        """
+        return Evidence(claim=claim, sources=[])

--- a/src/openfactcheck/components/dummy/verifier.py
+++ b/src/openfactcheck/components/dummy/verifier.py
@@ -1,0 +1,30 @@
+"""Dummy verifier."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import Claim, Evidence, Verdict
+
+
+@dataclass(frozen=True, slots=True)
+class DummyVerifier:
+    """Verifier that reaches no conclusion.
+
+    Returns a fixed inconclusive verdict for any claim, ignoring the evidence.
+    """
+
+    async def __call__(self, claim: Claim, evidence: Evidence) -> Verdict:
+        """Return a fixed inconclusive verdict for ``claim``.
+
+        Args:
+            claim: Claim under evaluation.
+            evidence: Sources bearing on the claim; ignored.
+
+        Returns:
+            A verdict labelled ``not_enough_evidence`` with zero confidence.
+        """
+        return Verdict(
+            claim=claim,
+            label="not_enough_evidence",
+            confidence=0.0,
+            reasoning="No verification performed.",
+        )

--- a/src/openfactcheck/components/protocols.py
+++ b/src/openfactcheck/components/protocols.py
@@ -2,7 +2,7 @@
 
 Each component category is a ``Protocol`` defining the signature any
 implementation must match. Implementations live in sibling subpackages
-(``null``, ``default``, and paper ports such as ``factool``) and are
+(``dummy``, ``default``, and paper ports such as ``factool``) and are
 interchangeable with any other implementation of the same category.
 """
 

--- a/tests/components/dummy/__init__.py
+++ b/tests/components/dummy/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the dummy components."""

--- a/tests/components/dummy/test_aggregator.py
+++ b/tests/components/dummy/test_aggregator.py
@@ -1,0 +1,32 @@
+"""Tests for DummyAggregator."""
+
+import pytest
+
+from openfactcheck.components import Aggregator
+from openfactcheck.components.dummy import DummyAggregator
+from openfactcheck.types import Claim, Verdict
+
+
+def test_DummyAggregator_satisfies_protocol() -> None:
+    assert isinstance(DummyAggregator(), Aggregator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyAggregator_returns_inconclusive_judgment() -> None:
+    aggregator = DummyAggregator()
+    verdict = Verdict(claim=Claim(text="c"), label="supported", confidence=1.0, reasoning="")
+
+    overall = await aggregator([verdict])
+
+    assert overall.label == "not_enough_evidence"
+    assert overall.score == 0.0
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyAggregator_handles_empty_verdicts() -> None:
+    aggregator = DummyAggregator()
+
+    overall = await aggregator([])
+
+    assert overall.label == "not_enough_evidence"
+    assert overall.score == 0.0

--- a/tests/components/dummy/test_claim_processor.py
+++ b/tests/components/dummy/test_claim_processor.py
@@ -1,0 +1,29 @@
+"""Tests for DummyClaimProcessor."""
+
+import pytest
+
+from openfactcheck.components import ClaimProcessor
+from openfactcheck.components.dummy import DummyClaimProcessor
+from openfactcheck.types import Claim, Input
+
+
+def test_DummyClaimProcessor_satisfies_protocol() -> None:
+    assert isinstance(DummyClaimProcessor(), ClaimProcessor)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyClaimProcessor_wraps_input_as_single_claim() -> None:
+    processor = DummyClaimProcessor()
+
+    result = await processor(Input(content="The sky is blue."))
+
+    assert result == [Claim(text="The sky is blue.")]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyClaimProcessor_blank_input_yields_no_claims() -> None:
+    processor = DummyClaimProcessor()
+
+    result = await processor(Input(content="   "))
+
+    assert result == []

--- a/tests/components/dummy/test_retriever.py
+++ b/tests/components/dummy/test_retriever.py
@@ -1,0 +1,22 @@
+"""Tests for DummyRetriever."""
+
+import pytest
+
+from openfactcheck.components import Retriever
+from openfactcheck.components.dummy import DummyRetriever
+from openfactcheck.types import Claim
+
+
+def test_DummyRetriever_satisfies_protocol() -> None:
+    assert isinstance(DummyRetriever(), Retriever)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyRetriever_returns_no_sources() -> None:
+    retriever = DummyRetriever()
+    claim = Claim(text="water is wet")
+
+    evidence = await retriever(claim)
+
+    assert evidence.claim == claim
+    assert evidence.sources == []

--- a/tests/components/dummy/test_verifier.py
+++ b/tests/components/dummy/test_verifier.py
@@ -1,0 +1,24 @@
+"""Tests for DummyVerifier."""
+
+import pytest
+
+from openfactcheck.components import Verifier
+from openfactcheck.components.dummy import DummyVerifier
+from openfactcheck.types import Claim, Evidence
+
+
+def test_DummyVerifier_satisfies_protocol() -> None:
+    assert isinstance(DummyVerifier(), Verifier)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyVerifier_returns_inconclusive_verdict() -> None:
+    verifier = DummyVerifier()
+    claim = Claim(text="the earth is round")
+    evidence = Evidence(claim=claim, sources=[])
+
+    verdict = await verifier(claim, evidence)
+
+    assert verdict.claim == claim
+    assert verdict.label == "not_enough_evidence"
+    assert verdict.confidence == 0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,12 @@
 
 import asyncio
 
+from openfactcheck.components.dummy import (
+    DummyAggregator,
+    DummyClaimProcessor,
+    DummyRetriever,
+    DummyVerifier,
+)
 from openfactcheck.pipeline import Components, PipelineState, build_pipeline
 from openfactcheck.types import Claim, Evidence, Input, OverallVerdict, Source, Verdict
 
@@ -90,3 +96,22 @@ def test_build_pipeline_state_records_input() -> None:
     build_pipeline().run(Input(content="The sky is blue."), state=state, deps=components)
 
     assert state.input == Input(content="The sky is blue.")
+
+
+def test_build_pipeline_with_dummy_components() -> None:
+    components = Components(
+        processor=DummyClaimProcessor(),
+        retriever=DummyRetriever(),
+        verifier=DummyVerifier(),
+        aggregator=DummyAggregator(),
+    )
+
+    result = build_pipeline().run(Input(content="The sky is blue."), state=PipelineState(), deps=components)
+
+    assert result.input.content == "The sky is blue."
+    assert result.claims == [Claim(text="The sky is blue.")]
+    assert len(result.evidence) == 1
+    assert result.evidence[0].sources == []
+    assert [verdict.label for verdict in result.verdicts] == ["not_enough_evidence"]
+    assert result.overall_label == "not_enough_evidence"
+    assert result.overall_score == 0.0


### PR DESCRIPTION
## Why

The contracts foundation (#64) shipped with no component implementations. This adds the first family — `dummy` — a complete set of deterministic placeholder components, plus the reference docs that were missing for the whole components layer and the core types vocabulary.

## What

**Dummy components** (`components/dummy/`) — each a frozen, dependency-free dataclass satisfying its contract:
- `DummyClaimProcessor` — wraps the whole input as one claim (empty input -> no claims)
- `DummyRetriever` — empty evidence (closed-book)
- `DummyVerifier` — fixed `not_enough_evidence`, confidence 0
- `DummyAggregator` — fixed `not_enough_evidence`, score 0

Named `dummy` rather than `null` because only the retriever is a true null-object; the processor produces a claim and the verifier/aggregator return fixed placeholder values.

**Tests** — per-component unit tests (Protocol conformance + behavior) under `tests/components/dummy/`, plus `test_build_pipeline_with_dummy_components` wiring all four through `build_pipeline()` end to end.

**Docs** — reference pages for the components layer (Contracts + Dummy) and for the core `types` vocabulary, slotted into the nav; the Reference landing now lists every layer (it previously listed only Chat + API). Fixes the `components/protocols.py` module docstring to point at the `dummy` sibling package.

## Verification

- `uv run pyright src` — 0 errors
- `task dev:test` — 546 passed
- `mkdocs build --strict` — clean (all component + type symbols render)
- `task dev:lint` — format, ruff, typecheck all pass

## Follow-up

- `components/default/` (real LLM components), then the facade and a `pipeline/` package of premade wirings.
- Component discovery registry tracked in #65 (deferred until the catalog warrants it).