### PR TITLE
feat: port Factool knowledge-QA pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ htmlcov/
 *.md
 !README.md
 !docs/**/*.md
+!src/openfactcheck/**/prompts/*.md
 
 # TF files
 *.tfstate

--- a/docs/reference/components/factool.md
+++ b/docs/reference/components/factool.md
@@ -1,0 +1,3 @@
+# Factool components
+
+::: openfactcheck.components.factool

--- a/docs/reference/components/index.md
+++ b/docs/reference/components/index.md
@@ -8,4 +8,6 @@
 ## Pages
 
 - [Contracts](protocols.md) — the category protocols every component implements.
+- [Provenance](provenance.md) — shared metadata describing where a ported component comes from.
 - [Dummy](dummy.md) — placeholder components that run a pipeline with no external dependencies.
+- [Factool](factool.md) — a port of the Factool knowledge-QA factuality pipeline.

--- a/docs/reference/components/provenance.md
+++ b/docs/reference/components/provenance.md
@@ -1,0 +1,3 @@
+# Provenance
+
+::: openfactcheck.components.provenance

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,4 +9,5 @@ Generated API reference for OpenFactCheck's public modules.
 - [Prompts](prompts/index.md) — prompt templates and the markdown codec.
 - [Graph](graph/index.md) — the typed orchestration layer for composing components.
 - [Components](components/index.md) — the category contracts and their implementations.
+- [Integrations](integrations/index.md) — typed clients for external services such as web search.
 - [API](api/index.md) — Python building blocks behind the REST API: auth, models, repositories.

--- a/docs/reference/integrations/index.md
+++ b/docs/reference/integrations/index.md
@@ -1,0 +1,7 @@
+# Integrations
+
+Typed clients for external services that components depend on. Integrations are
+domain-agnostic: they return service-shaped data, and a component maps that into
+the fact-checking types. They implement no category contract.
+
+- [Serper](serper.md): typed async client for the Serper.dev Google Search API, covering search and webpage scraping.

--- a/docs/reference/integrations/serper.md
+++ b/docs/reference/integrations/serper.md
@@ -1,0 +1,3 @@
+# Serper
+
+::: openfactcheck.integrations.serper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,7 +153,12 @@ nav:
       - Components:
           - reference/components/index.md
           - Contracts: reference/components/protocols.md
+          - Provenance: reference/components/provenance.md
           - Dummy: reference/components/dummy.md
+          - Factool: reference/components/factool.md
+      - Integrations:
+          - reference/integrations/index.md
+          - Serper: reference/integrations/serper.md
       - API:
           - reference/api/index.md
           - Auth:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ pattern = "(?P<version>.+)"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openfactcheck"]
-artifacts = ["src/openfactcheck/prompts/_builtin/*.md"]
+artifacts = ["src/openfactcheck/**/prompts/*.md"]
 
 ###############################################################################
 # Testing
@@ -221,6 +221,9 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 ]
 "src/openfactcheck/graph/**" = [
     "UP046",  ## PEP-696 type-param defaults need typing_extensions + Generic[] on 3.12; native syntax is 3.13+.
+]
+"src/openfactcheck/integrations/**" = [
+    "PLR0913",  ## service clients take many keyword-only config knobs.
 ]
 "tests/**" = [
     "D",    ## test names already describe intent; no need for docstrings.

--- a/src/openfactcheck/components/__init__.py
+++ b/src/openfactcheck/components/__init__.py
@@ -14,6 +14,7 @@ from openfactcheck.components.protocols import (
     Retriever,
     Verifier,
 )
+from openfactcheck.components.provenance import Provenance
 
 # Component category contracts
 __all__ = [
@@ -22,4 +23,9 @@ __all__ = [
     "QueryGenerator",
     "Retriever",
     "Verifier",
+]
+
+# Shared metadata
+__all__ += [
+    "Provenance",
 ]

--- a/src/openfactcheck/components/dummy/__init__.py
+++ b/src/openfactcheck/components/dummy/__init__.py
@@ -1,13 +1,14 @@
 """Deterministic dummy components.
 
 A complete set of placeholder components: each satisfies a category contract but
-performs no real work. Wiring all four runs a pipeline end to end with no
+performs no real work. Wiring them all runs a pipeline end to end with no
 external dependencies, which makes them handy as placeholders and as test
 fixtures.
 """
 
 from openfactcheck.components.dummy.aggregator import DummyAggregator
 from openfactcheck.components.dummy.claim_processor import DummyClaimProcessor
+from openfactcheck.components.dummy.query_generator import DummyQueryGenerator
 from openfactcheck.components.dummy.retriever import DummyRetriever
 from openfactcheck.components.dummy.verifier import DummyVerifier
 
@@ -15,6 +16,7 @@ from openfactcheck.components.dummy.verifier import DummyVerifier
 __all__ = [
     "DummyAggregator",
     "DummyClaimProcessor",
+    "DummyQueryGenerator",
     "DummyRetriever",
     "DummyVerifier",
 ]

--- a/src/openfactcheck/components/dummy/query_generator.py
+++ b/src/openfactcheck/components/dummy/query_generator.py
@@ -1,0 +1,25 @@
+"""Dummy query generator."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import Claim, Query
+
+
+@dataclass(frozen=True, slots=True)
+class DummyQueryGenerator:
+    """Query generator that produces no search questions.
+
+    Wraps the claim in a query with an empty question list, so a paired
+    retriever has nothing to search for.
+    """
+
+    async def __call__(self, claim: Claim) -> Query:
+        """Return a query carrying ``claim`` with no questions.
+
+        Args:
+            claim: Claim to generate queries for.
+
+        Returns:
+            A query holding ``claim`` and an empty question list.
+        """
+        return Query(claim=claim, questions=[])

--- a/src/openfactcheck/components/dummy/retriever.py
+++ b/src/openfactcheck/components/dummy/retriever.py
@@ -2,24 +2,24 @@
 
 from dataclasses import dataclass
 
-from openfactcheck.types import Claim, Evidence
+from openfactcheck.types import Evidence, Query
 
 
 @dataclass(frozen=True, slots=True)
 class DummyRetriever:
     """Retriever that fetches no evidence.
 
-    Returns an empty evidence set for any claim, which turns the pipeline into
+    Returns an empty evidence set for any query, which turns the pipeline into
     closed-book verification.
     """
 
-    async def __call__(self, claim: Claim) -> Evidence:
-        """Return empty evidence for ``claim``.
+    async def __call__(self, query: Query) -> Evidence:
+        """Return empty evidence for ``query``.
 
         Args:
-            claim: Claim to gather evidence for.
+            query: The claim and its search questions; ignored.
 
         Returns:
-            Evidence attached to ``claim`` with no sources.
+            Evidence attached to the query's claim with no sources.
         """
-        return Evidence(claim=claim, sources=[])
+        return Evidence(claim=query.claim, sources=[])

--- a/src/openfactcheck/components/factool/__init__.py
+++ b/src/openfactcheck/components/factool/__init__.py
@@ -1,0 +1,62 @@
+"""Factool knowledge-QA components.
+
+A port of the knowledge-based QA factuality pipeline from FacTool (Chern et al.,
+2023). The components mirror the paper's stages: extract atomic claims, generate
+skeptical search queries, retrieve web evidence, verify each claim against that
+evidence, and aggregate to a response-level judgment.
+
+The LLM components run on an injected chat client;
+[`PROVENANCE`][openfactcheck.components.factool.PROVENANCE] records the
+recommended default model along with the source paper, repository, pinned
+commit, and license. Import from ``openfactcheck.components.factool``.
+"""
+
+from openfactcheck.components.factool.aggregator import FactoolAggregator
+from openfactcheck.components.factool.claim_processor import FactoolClaimProcessor
+from openfactcheck.components.factool.query_generator import FactoolQueryGenerator
+from openfactcheck.components.factool.retriever import FactoolRetriever
+from openfactcheck.components.factool.verifier import FactoolVerifier
+from openfactcheck.components.provenance import Provenance
+
+_CITATION = """\
+@article{chern2023factoolfactualitydetectiongenerative,
+    title={FacTool: Factuality Detection in Generative AI -- A Tool Augmented
+           Framework for Multi-Task and Multi-Domain Scenarios},
+    author={I-Chun Chern and Steffi Chern and Shiqi Chen and Weizhe Yuan and
+            Kehua Feng and Chunting Zhou and Junxian He and Graham Neubig and
+            Pengfei Liu},
+    year={2023},
+    eprint={2307.13528},
+    archivePrefix={arXiv},
+    primaryClass={cs.CL},
+    url={https://arxiv.org/abs/2307.13528},
+}"""
+
+PROVENANCE = Provenance(
+    paper_title=(
+        "FacTool: Factuality Detection in Generative AI - "
+        "A Tool Augmented Framework for Multi-Task and Multi-Domain Scenarios"
+    ),
+    paper_url="https://arxiv.org/abs/2307.13528",
+    citation=_CITATION,
+    repository_url="https://github.com/GAIR-NLP/factool",
+    repository_commit="3f3914bc090b644be044b7e0005113c135d8b20f",
+    license="Apache-2.0",
+    default_model="gpt-4o-mini",
+    paper_models=("gpt-3.5-turbo-0301", "gpt-4-0314"),
+)
+"""Provenance for the Factool knowledge-QA components."""
+
+# Components
+__all__ = [
+    "FactoolAggregator",
+    "FactoolClaimProcessor",
+    "FactoolQueryGenerator",
+    "FactoolRetriever",
+    "FactoolVerifier",
+]
+
+# Provenance
+__all__ += [
+    "PROVENANCE",
+]

--- a/src/openfactcheck/components/factool/aggregator.py
+++ b/src/openfactcheck/components/factool/aggregator.py
@@ -1,0 +1,31 @@
+"""Factool aggregator."""
+
+from dataclasses import dataclass
+
+from openfactcheck.types import OverallVerdict, Verdict
+
+
+@dataclass(frozen=True, slots=True)
+class FactoolAggregator:
+    """Combine per-claim verdicts with Factool's response-level rule.
+
+    A response is factual only when every claim is supported; a single
+    unsupported claim makes the whole response non-factual. The score reports
+    the fraction of supported claims.
+    """
+
+    async def __call__(self, verdicts: list[Verdict]) -> OverallVerdict:
+        """Aggregate per-claim verdicts into one overall judgment.
+
+        Args:
+            verdicts: Per-claim verdicts; may be empty.
+
+        Returns:
+            An overall judgment labelled ``factual`` or ``non_factual``, or
+            ``not_enough_evidence`` when there are no verdicts.
+        """
+        if not verdicts:
+            return OverallVerdict(label="not_enough_evidence", score=0.0)
+        supported = sum(1 for verdict in verdicts if verdict.label == "supported")
+        label = "factual" if supported == len(verdicts) else "non_factual"
+        return OverallVerdict(label=label, score=supported / len(verdicts))

--- a/src/openfactcheck/components/factool/claim_processor.py
+++ b/src/openfactcheck/components/factool/claim_processor.py
@@ -1,0 +1,48 @@
+"""Factool claim processor."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.prompts import PromptTemplate
+from openfactcheck.types import Claim, Input
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class _ClaimExtraction(BaseModel):
+    """Structured output: the claims extracted from a piece of text."""
+
+    claims: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class FactoolClaimProcessor:
+    """Extract atomic factual claims, following Factool's knowledge-QA method.
+
+    Prompts the model to break the input into short, self-contained claims with
+    their coreferences resolved.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(
+        default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "claim_processor.md")
+    )
+    """The claim-extraction prompt. Defaults to Factool's; override to customise."""
+
+    async def __call__(self, text: Input) -> list[Claim]:
+        """Extract atomic claims from ``text``.
+
+        Args:
+            text: Input text to process into claims.
+
+        Returns:
+            The extracted claims; empty when the model finds none.
+        """
+        messages = self.prompt.to_messages(input=text.content)
+        extraction = await self.client.acompletion_as(messages, _ClaimExtraction)
+        return [Claim(text=claim) for claim in extraction.claims]

--- a/src/openfactcheck/components/factool/prompts/claim_processor.md
+++ b/src/openfactcheck/components/factool/prompts/claim_processor.md
@@ -1,0 +1,56 @@
+---
+name: claim_processor
+description: Extract atomic, self-contained factual claims from a piece of text.
+variables:
+  input:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a brilliant assistant.
+
+</system>
+
+<user>
+
+# User Prompt
+
+You are given a piece of text that includes knowledge claims. A claim is a statement that asserts something as true or false, which can be verified by humans. Your task is to accurately identify and extract **every claim** stated in the provided text. Then, resolve any coreference (pronouns or other referring expressions) in the claim for clarity. Each claim should be **concise (less than 15 words)** and **self-contained**.
+
+## Examples
+
+**Text:**
+
+> Tomas Berdych defeated Gael Monfis 6-1, 6-4 on Saturday. The sixth-seed reaches Monte Carlo Masters final for the first time. Berdych will face either Rafael Nadal or Novak Djokovic in the final.
+
+**Claims:**
+
+- Tomas Berdych defeated Gael Monfis 6-1, 6-4
+- Tomas Berdych defeated Gael Monfis 6-1, 6-4 on Saturday
+- Tomas Berdych reaches Monte Carlo Masters final
+- Tomas Berdych is the sixth-seed
+- Tomas Berdych reaches Monte Carlo Masters final for the first time
+- Berdych will face either Rafael Nadal or Novak Djokovic
+- Berdych will face either Rafael Nadal or Novak Djokovic in the final
+
+**Text:**
+
+> Tinder only displays the last 34 photos - but users can easily see more. Firm also said it had improved its mutual friends feature.
+
+**Claims:**
+
+- Tinder only displays the last photos
+- Tinder only displays the last 34 photos
+- Tinder users can easily see more photos
+- Tinder said it had improved its feature
+- Tinder said it had improved its mutual friends feature
+
+## Text to process
+
+{{input}}
+
+</user>

--- a/src/openfactcheck/components/factool/prompts/query_generator.md
+++ b/src/openfactcheck/components/factool/prompts/query_generator.md
@@ -1,0 +1,51 @@
+---
+name: query_generator
+description: Generate skeptical search engine queries that help verify a claim.
+variables:
+  input:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a query generator that generates effective and concise search engine queries to verify a given claim.
+
+</system>
+
+<user>
+
+# User Prompt
+
+You are a query generator designed to help users verify a given claim using search engines. Your task is to generate **two** effective and skeptical search engine queries. These queries help a user critically evaluate the factuality of the provided claim using a search engine.
+
+## Examples
+
+**Claim:** The CEO of twitter is Bill Gates.
+
+**Queries:**
+
+- Who is the CEO of twitter?
+- CEO Twitter
+
+**Claim:** Michael Phelps is the most decorated Olympian of all time.
+
+**Queries:**
+
+- Who is the most decorated Olympian of all time?
+- Michael Phelps
+
+**Claim:** ChatGPT is created by Google.
+
+**Queries:**
+
+- Who created ChatGPT?
+- ChatGPT
+
+## Claim to verify
+
+{{input}}
+
+</user>

--- a/src/openfactcheck/components/factool/prompts/verifier.md
+++ b/src/openfactcheck/components/factool/prompts/verifier.md
@@ -1,0 +1,39 @@
+---
+name: verifier
+description: Judge whether a claim is factual against retrieved evidence, and correct it if not.
+variables:
+  claim:
+    type: string
+    required: true
+  evidence:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a brilliant assistant.
+
+</system>
+
+<user>
+
+# User Prompt
+
+You are given a piece of text. Your task is to identify whether there are any **factual errors** within the text.
+
+When you judge the factuality of the given text, you may reference the provided evidence if needed. The evidence may be helpful, and some evidence may contradict each other, so you must be careful when using it to judge the factuality of the given text.
+
+Provide your **reasoning** for whether the text is factual or not. Be careful: when you decide something is non-factual, you must point to evidence that supports your decision. Then decide whether the text is factual: **true** if it is factual, **false** otherwise. If there is a factual error, describe the **error** and provide a corrected version of the text; if the text is factual, leave the error and correction empty.
+
+## Text
+
+{{claim}}
+
+## Evidence
+
+{{evidence}}
+
+</user>

--- a/src/openfactcheck/components/factool/query_generator.py
+++ b/src/openfactcheck/components/factool/query_generator.py
@@ -1,0 +1,48 @@
+"""Factool query generator."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.prompts import PromptTemplate
+from openfactcheck.types import Claim, Query
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class _GeneratedQueries(BaseModel):
+    """Structured output: the search queries generated for a claim."""
+
+    queries: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class FactoolQueryGenerator:
+    """Generate skeptical search queries for a claim, following Factool's method.
+
+    Prompts the model for concise search-engine queries aimed at verifying the
+    claim.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(
+        default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "query_generator.md")
+    )
+    """The query-generation prompt. Defaults to Factool's; override to customise."""
+
+    async def __call__(self, claim: Claim) -> Query:
+        """Generate search queries for ``claim``.
+
+        Args:
+            claim: Claim to generate queries for.
+
+        Returns:
+            The claim paired with the generated search questions.
+        """
+        messages = self.prompt.to_messages(input=claim.text)
+        generated = await self.client.acompletion_as(messages, _GeneratedQueries)
+        return Query(claim=claim, questions=generated.queries)

--- a/src/openfactcheck/components/factool/retriever.py
+++ b/src/openfactcheck/components/factool/retriever.py
@@ -1,0 +1,55 @@
+"""Factool retriever, backed by Serper web search."""
+
+from dataclasses import dataclass
+
+from openfactcheck.integrations.serper import SearchParams, SearchResponse, SerperClient
+from openfactcheck.types import Evidence, Query, Source, SourceMetadata, WebMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class FactoolRetriever:
+    """Retrieve evidence for a claim's queries via Serper web search.
+
+    Searches every query attached to the claim and collects the answer box,
+    knowledge graph, and organic snippets into one evidence set.
+    """
+
+    serper: SerperClient
+    """The Serper client used for web search."""
+
+    num_results: int = 10
+    """Number of organic results to request for each query."""
+
+    async def __call__(self, query: Query) -> Evidence:
+        """Fetch evidence for ``query``.
+
+        Args:
+            query: The claim and the search questions to run.
+
+        Returns:
+            Evidence for the claim, with one source per retrieved snippet; an
+            empty source list when the query carries no questions.
+        """
+        if not query.questions:
+            return Evidence(claim=query.claim, sources=[])
+        params = [SearchParams(q=question, num=self.num_results) for question in query.questions]
+        responses = await self.serper.search_batch(params)
+        sources = [source for response in responses for source in self._sources(response)]
+        return Evidence(claim=query.claim, sources=sources)
+
+    def _sources(self, response: SearchResponse) -> list[Source]:
+        """Collect the snippets from one search response into evidence sources."""
+        sources: list[Source] = []
+        if (box := response.answer_box) is not None and (content := box.answer or box.snippet):
+            sources.append(self._source(content, box.link, box.title))
+        if (graph := response.knowledge_graph) is not None and graph.description:
+            sources.append(self._source(graph.description, graph.website, graph.title))
+        sources.extend(
+            self._source(result.snippet, result.link, result.title) for result in response.organic if result.snippet
+        )
+        return sources
+
+    def _source(self, content: str, url: str | None, title: str | None) -> Source:
+        """Build a source, attaching web metadata when a URL is present."""
+        metadata: SourceMetadata = WebMetadata(url=url, title=title) if url else SourceMetadata()
+        return Source(content=content, metadata=metadata)

--- a/src/openfactcheck/components/factool/verifier.py
+++ b/src/openfactcheck/components/factool/verifier.py
@@ -1,0 +1,71 @@
+"""Factool verifier."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.prompts import PromptTemplate
+from openfactcheck.types import Claim, Evidence, Verdict
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class _Verification(BaseModel):
+    """Structured output: Factool's per-claim verification result."""
+
+    reasoning: str
+    factuality: bool
+    error: str | None = None
+    correction: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FactoolVerifier:
+    """Judge a claim against its evidence, following Factool's method.
+
+    Factool reports factuality as a boolean and, when the claim is wrong, the
+    error and a correction. The boolean maps to ``supported`` or ``refuted``;
+    Factool emits no confidence, so the verdict leaves it unset.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "verifier.md"))
+    """The verification prompt. Defaults to Factool's; override to customise."""
+
+    async def __call__(self, claim: Claim, evidence: Evidence) -> Verdict:
+        """Verify ``claim`` against ``evidence``.
+
+        Args:
+            claim: Claim under evaluation.
+            evidence: Sources bearing on the claim's truthfulness.
+
+        Returns:
+            A verdict labelled ``supported`` or ``refuted``, with the error and
+            correction filled when the claim is judged non-factual.
+        """
+        messages = self.prompt.to_messages(claim=claim.text, evidence=self._format_evidence(evidence))
+        result = await self.client.acompletion_as(messages, _Verification)
+        return Verdict(
+            claim=claim,
+            label="supported" if result.factuality else "refuted",
+            confidence=None,
+            reasoning=result.reasoning,
+            error=self._clean(result.error),
+            correction=self._clean(result.correction),
+        )
+
+    @staticmethod
+    def _format_evidence(evidence: Evidence) -> str:
+        """Render the evidence as a list of snippet contents, as Factool does."""
+        return str([source.content for source in evidence.sources])
+
+    @staticmethod
+    def _clean(value: str | None) -> str | None:
+        """Treat the literal string ``None`` or a blank string as no value."""
+        if value is None or value.strip() in {"", "None"}:
+            return None
+        return value

--- a/src/openfactcheck/components/protocols.py
+++ b/src/openfactcheck/components/protocols.py
@@ -36,9 +36,9 @@ class ClaimProcessor(Protocol):
 class QueryGenerator(Protocol):
     """Generate search queries for a claim.
 
-    Optional category. Some pipelines separate query generation from
-    retrieval; others bundle both inside a ``Retriever``. The default
-    library pipeline bundles them.
+    Produces the search questions a [`Retriever`][Retriever] runs to gather
+    evidence. One claim yields one [`Query`][openfactcheck.types.Query] holding
+    any number of questions.
     """
 
     async def __call__(self, claim: Claim) -> Query:
@@ -55,21 +55,23 @@ class QueryGenerator(Protocol):
 
 @runtime_checkable
 class Retriever(Protocol):
-    """Fetch evidence for a single claim.
+    """Fetch evidence for a claim's queries.
 
-    Evidence is a set of sources bearing on the claim's truthfulness:
-    web pages, documents, vector-store results. A retriever that finds
-    nothing should return ``Evidence(claim=claim, sources=[])``.
+    A [`Query`][openfactcheck.types.Query] carries both the claim and the
+    search questions generated for it. Evidence is a set of sources bearing on
+    the claim's truthfulness: web pages, documents, vector-store results. A
+    retriever that finds nothing should return
+    ``Evidence(claim=query.claim, sources=[])``.
     """
 
-    async def __call__(self, claim: Claim) -> Evidence:
-        """Fetch evidence for ``claim``.
+    async def __call__(self, query: Query) -> Evidence:
+        """Fetch evidence for ``query``.
 
         Args:
-            claim: Claim to gather evidence for.
+            query: The claim paired with the search questions to run.
 
         Returns:
-            Evidence attached to ``claim``; may contain an empty
+            Evidence attached to the query's claim; may contain an empty
             ``sources`` list when nothing was found.
         """
         ...

--- a/src/openfactcheck/components/provenance.py
+++ b/src/openfactcheck/components/provenance.py
@@ -1,0 +1,38 @@
+"""Provenance metadata shared across ported components.
+
+A paper port records where its components come from and what they are based on.
+The concrete value lives in the port's own package; this module defines the
+shared shape so every port reports the same fields, which a registry or docs
+guide can surface uniformly.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Provenance:
+    """Where a ported component comes from and what it is based on."""
+
+    paper_title: str
+    """Title of the source paper."""
+
+    paper_url: str
+    """URL of the source paper."""
+
+    citation: str
+    """BibTeX entry for the source paper, so users can cite the original work."""
+
+    repository_url: str
+    """URL of the authors' reference implementation."""
+
+    repository_commit: str
+    """Commit of the reference implementation this port was read against."""
+
+    license: str
+    """License of the reference implementation."""
+
+    default_model: str
+    """Recommended default model for the components, close to the paper's setup."""
+
+    paper_models: tuple[str, ...]
+    """Exact model snapshots reported in the paper's experiments."""

--- a/src/openfactcheck/integrations/__init__.py
+++ b/src/openfactcheck/integrations/__init__.py
@@ -1,0 +1,10 @@
+"""Typed clients for external services that components depend on.
+
+An integration wraps a third-party service (web search, scrapers, and similar)
+behind a small typed client. Integrations are not components: they implement no
+category contract and hold no fact-checking domain types. A component depends on
+an integration and maps its service-shaped results into the domain types.
+
+Each service lives in its own subpackage, for example
+[`serper`][openfactcheck.integrations.serper].
+"""

--- a/src/openfactcheck/integrations/serper/__init__.py
+++ b/src/openfactcheck/integrations/serper/__init__.py
@@ -1,0 +1,69 @@
+"""Typed async client for the Serper.dev Google Search API.
+
+Build a [`SerperClient`][SerperClient], then call
+[`search`][SerperClient.search] or [`scrape`][SerperClient.scrape]; results
+come back as typed models. Import from ``openfactcheck.integrations.serper``.
+
+Example:
+    ```python
+    from openfactcheck.integrations.serper import SerperClient
+
+    client = SerperClient()
+    result = await client.search("who founded openai")
+    print(result.organic[0].link)
+    ```
+"""
+
+from openfactcheck.integrations.serper.client import (
+    DEFAULT_SCRAPE_BASE_URL,
+    DEFAULT_SEARCH_BASE_URL,
+    DEFAULT_TIMEOUT,
+    SerperClient,
+)
+from openfactcheck.integrations.serper.errors import SerperConfigError, SerperError, SerperRequestError
+from openfactcheck.integrations.serper.params import SearchParams, SerperTimeRange
+from openfactcheck.integrations.serper.responses import (
+    AnswerBox,
+    KnowledgeGraph,
+    OrganicResult,
+    PeopleAlsoAsk,
+    RelatedSearch,
+    ScrapeResponse,
+    SearchParameters,
+    SearchResponse,
+    Sitelink,
+)
+
+# Client
+__all__ = [
+    "SerperClient",
+]
+
+# Configuration
+__all__ += [
+    "DEFAULT_SCRAPE_BASE_URL",
+    "DEFAULT_SEARCH_BASE_URL",
+    "DEFAULT_TIMEOUT",
+    "SearchParams",
+    "SerperTimeRange",
+]
+
+# Responses
+__all__ += [
+    "AnswerBox",
+    "KnowledgeGraph",
+    "OrganicResult",
+    "PeopleAlsoAsk",
+    "RelatedSearch",
+    "ScrapeResponse",
+    "SearchParameters",
+    "SearchResponse",
+    "Sitelink",
+]
+
+# Errors
+__all__ += [
+    "SerperConfigError",
+    "SerperError",
+    "SerperRequestError",
+]

--- a/src/openfactcheck/integrations/serper/client.py
+++ b/src/openfactcheck/integrations/serper/client.py
@@ -1,0 +1,143 @@
+"""Async client for the Serper.dev API."""
+
+import os
+from collections.abc import Sequence
+from typing import cast
+
+import httpx
+
+from openfactcheck.integrations.serper.errors import SerperConfigError, SerperRequestError
+from openfactcheck.integrations.serper.params import SearchParams
+from openfactcheck.integrations.serper.responses import ScrapeResponse, SearchResponse
+
+DEFAULT_SEARCH_BASE_URL = "https://google.serper.dev"
+"""Default base URL for the Serper search endpoints."""
+
+DEFAULT_SCRAPE_BASE_URL = "https://scrape.serper.dev"
+"""Default base URL for the Serper webpage scrape endpoint."""
+
+DEFAULT_TIMEOUT = 30.0
+"""Default per-request timeout in seconds."""
+
+
+class SerperClient:
+    """Async client for the Serper.dev Google Search API.
+
+    Exposes the search and webpage-scrape endpoints as typed methods. The API
+    key is read from the ``api_key`` argument or the ``SERPER_API_KEY``
+    environment variable. New endpoints are cheap to add: route them through
+    the shared request path.
+
+    Example:
+        ```python
+        client = SerperClient()
+        result = await client.search("who founded openai")
+        for organic in result.organic:
+            print(organic.title, organic.link)
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        base_url: str = DEFAULT_SEARCH_BASE_URL,
+        scrape_base_url: str = DEFAULT_SCRAPE_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT,
+        gl: str | None = None,
+        hl: str | None = None,
+    ) -> None:
+        """Build a Serper client.
+
+        Args:
+            api_key: Serper API key. Falls back to the ``SERPER_API_KEY``
+                environment variable when omitted.
+            base_url: Base URL for the search endpoints.
+            scrape_base_url: Base URL for the webpage scrape endpoint.
+            timeout: Per-request timeout in seconds.
+            gl: Default country code applied to bare-string searches.
+            hl: Default language code applied to bare-string searches.
+
+        Raises:
+            SerperConfigError: No API key was given or found in the environment.
+        """
+        key = api_key if api_key is not None else os.environ.get("SERPER_API_KEY")
+        if not key:
+            raise SerperConfigError("no Serper API key; pass api_key= or set the SERPER_API_KEY environment variable.")
+        self._api_key = key
+        self._base_url = base_url.rstrip("/")
+        self._scrape_base_url = scrape_base_url.rstrip("/")
+        self._timeout = timeout
+        self._gl = gl
+        self._hl = hl
+
+    async def search(self, query: str | SearchParams) -> SearchResponse:
+        """Run a single web search.
+
+        Args:
+            query: A query string (using the client's default ``gl`` and
+                ``hl``) or a fully specified [`SearchParams`][SearchParams].
+
+        Returns:
+            The parsed search response.
+
+        Raises:
+            SerperRequestError: The request failed or returned an error status.
+        """
+        data = await self._post(f"{self._base_url}/search", self._params_for(query).to_payload())
+        return SearchResponse.model_validate(data)
+
+    async def search_batch(self, queries: Sequence[str | SearchParams]) -> list[SearchResponse]:
+        """Run several web searches in a single request.
+
+        Args:
+            queries: Query strings or [`SearchParams`][SearchParams] to search
+                for together.
+
+        Returns:
+            One response per query, in the order given.
+
+        Raises:
+            SerperRequestError: The request failed, returned an error status, or
+                did not return a list.
+        """
+        payload = [self._params_for(query).to_payload() for query in queries]
+        data = await self._post(f"{self._base_url}/search", payload)
+        if not isinstance(data, list):
+            raise SerperRequestError("expected a list response for a batch search.")
+        return [SearchResponse.model_validate(item) for item in cast("list[object]", data)]
+
+    async def scrape(self, url: str, *, include_markdown: bool = False) -> ScrapeResponse:
+        """Extract the contents of a web page.
+
+        Args:
+            url: The page to scrape.
+            include_markdown: Whether to also return the page as Markdown.
+
+        Returns:
+            The page's extracted text, metadata, and optional Markdown.
+
+        Raises:
+            SerperRequestError: The request failed or returned an error status.
+        """
+        data = await self._post(self._scrape_base_url, {"url": url, "includeMarkdown": include_markdown})
+        return ScrapeResponse.model_validate(data)
+
+    def _params_for(self, query: str | SearchParams) -> SearchParams:
+        """Coerce a query string or params into a [`SearchParams`][SearchParams]."""
+        if isinstance(query, SearchParams):
+            return query
+        return SearchParams(q=query, gl=self._gl, hl=self._hl)
+
+    async def _post(self, url: str, payload: object) -> object:
+        """Send a POST request to ``url`` and return the decoded JSON body."""
+        headers = {"X-API-KEY": self._api_key, "Content-Type": "application/json"}
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                response = await client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise SerperRequestError(f"Serper request to {url} returned status {exc.response.status_code}.") from exc
+        except httpx.HTTPError as exc:
+            raise SerperRequestError(f"Serper request to {url} failed: {exc}.") from exc

--- a/src/openfactcheck/integrations/serper/errors.py
+++ b/src/openfactcheck/integrations/serper/errors.py
@@ -1,0 +1,13 @@
+"""Error hierarchy for the Serper.dev integration."""
+
+
+class SerperError(Exception):
+    """Base error for every Serper.dev integration failure."""
+
+
+class SerperConfigError(SerperError):
+    """The client is missing required configuration, such as the API key."""
+
+
+class SerperRequestError(SerperError):
+    """A request to the Serper.dev API failed or returned an error status."""

--- a/src/openfactcheck/integrations/serper/params.py
+++ b/src/openfactcheck/integrations/serper/params.py
@@ -1,0 +1,50 @@
+"""Request parameters for Serper.dev search."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+type SerperTimeRange = Literal["qdr:h", "qdr:d", "qdr:w", "qdr:m", "qdr:y"]
+"""Recency window for results: past hour, day, week, month, or year."""
+
+
+class SearchParams(BaseModel):
+    """Parameters for a Serper.dev search request.
+
+    Only ``q`` is required. Unset fields are dropped from the request body so
+    the service applies its own defaults.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
+    q: str
+    """The search query."""
+
+    gl: str | None = None
+    """Country code for results, such as ``us``."""
+
+    hl: str | None = None
+    """Language code for results, such as ``en``."""
+
+    location: str | None = None
+    """Location to search from, such as ``SoHo, New York, United States``."""
+
+    num: int | None = None
+    """Number of results to return."""
+
+    page: int | None = None
+    """Result page number, starting at 1."""
+
+    tbs: SerperTimeRange | None = None
+    """Restrict results to a recent time window."""
+
+    autocorrect: bool | None = None
+    """Whether the service may autocorrect the query spelling."""
+
+    def to_payload(self) -> dict[str, object]:
+        """Render the request body, omitting unset fields.
+
+        Returns:
+            A JSON-serialisable mapping of the parameters that were set.
+        """
+        return self.model_dump(exclude_none=True)

--- a/src/openfactcheck/integrations/serper/responses.py
+++ b/src/openfactcheck/integrations/serper/responses.py
@@ -1,0 +1,201 @@
+"""Typed responses from the Serper.dev API.
+
+Field names are snake_case and aliased to Serper's camelCase JSON keys. Every
+model tolerates unmodeled fields (``extra="allow"``), so new keys the service
+adds are preserved on the instance rather than rejected.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+_RESPONSE_CONFIG = ConfigDict(
+    alias_generator=to_camel,
+    populate_by_name=True,
+    extra="allow",
+    frozen=True,
+    use_attribute_docstrings=True,
+)
+"""Shared response config: snake_case fields aliased to camelCase, tolerant of unmodeled keys."""
+
+
+class SearchParameters(BaseModel):
+    """The search parameters echoed back by the service."""
+
+    model_config = _RESPONSE_CONFIG
+
+    q: str
+    """The query that was searched."""
+
+    type: str | None = None
+    """The search type, such as ``search``."""
+
+    gl: str | None = None
+    """Country code applied to the search."""
+
+    hl: str | None = None
+    """Language code applied to the search."""
+
+    location: str | None = None
+    """Location applied to the search."""
+
+    num: int | None = None
+    """Number of results requested."""
+
+    page: int | None = None
+    """Result page number."""
+
+    autocorrect: bool | None = None
+    """Whether the query spelling was autocorrected."""
+
+
+class Sitelink(BaseModel):
+    """A secondary link shown beneath an organic result."""
+
+    model_config = _RESPONSE_CONFIG
+
+    title: str
+    """The sitelink's display title."""
+
+    link: str
+    """The sitelink's URL."""
+
+
+class OrganicResult(BaseModel):
+    """A single organic (non-paid) search result."""
+
+    model_config = _RESPONSE_CONFIG
+
+    title: str
+    """The result's title."""
+
+    link: str
+    """The result's URL."""
+
+    snippet: str | None = None
+    """A short extract from the page."""
+
+    position: int | None = None
+    """The result's rank on the page, starting at 1."""
+
+    date: str | None = None
+    """The page's date, when the service reports one."""
+
+    sitelinks: list[Sitelink] = Field(default_factory=list[Sitelink])
+    """Secondary links shown beneath the result."""
+
+    attributes: dict[str, str] = Field(default_factory=dict[str, str])
+    """Extra key-value details shown with the result."""
+
+
+class KnowledgeGraph(BaseModel):
+    """The structured entity panel shown alongside results."""
+
+    model_config = _RESPONSE_CONFIG
+
+    title: str | None = None
+    """The entity's name."""
+
+    type: str | None = None
+    """The entity's category, such as ``Company``."""
+
+    website: str | None = None
+    """The entity's official website."""
+
+    description: str | None = None
+    """A short description of the entity."""
+
+    attributes: dict[str, str] = Field(default_factory=dict[str, str])
+    """Key facts about the entity, such as its founder or founding date."""
+
+
+class AnswerBox(BaseModel):
+    """A direct answer or featured snippet for the query."""
+
+    model_config = _RESPONSE_CONFIG
+
+    answer: str | None = None
+    """The direct answer, when the service extracts one."""
+
+    snippet: str | None = None
+    """The featured snippet text."""
+
+    snippet_highlighted: list[str] | None = None
+    """Highlighted phrases within the snippet."""
+
+    title: str | None = None
+    """Title of the source page."""
+
+    link: str | None = None
+    """URL of the source page."""
+
+
+class PeopleAlsoAsk(BaseModel):
+    """A related question shown in the "People also ask" panel."""
+
+    model_config = _RESPONSE_CONFIG
+
+    question: str
+    """The related question."""
+
+    snippet: str | None = None
+    """A short answer extract."""
+
+    title: str | None = None
+    """Title of the source page."""
+
+    link: str | None = None
+    """URL of the source page."""
+
+
+class RelatedSearch(BaseModel):
+    """A related query suggestion."""
+
+    model_config = _RESPONSE_CONFIG
+
+    query: str
+    """The suggested query."""
+
+
+class SearchResponse(BaseModel):
+    """A response from the Serper.dev ``/search`` endpoint."""
+
+    model_config = _RESPONSE_CONFIG
+
+    search_parameters: SearchParameters | None = None
+    """The search parameters echoed by the service."""
+
+    organic: list[OrganicResult] = Field(default_factory=list[OrganicResult])
+    """The organic search results, in rank order."""
+
+    knowledge_graph: KnowledgeGraph | None = None
+    """The entity panel, when one is shown for the query."""
+
+    answer_box: AnswerBox | None = None
+    """The direct answer or featured snippet, when present."""
+
+    people_also_ask: list[PeopleAlsoAsk] = Field(default_factory=list[PeopleAlsoAsk])
+    """Related questions shown for the query."""
+
+    related_searches: list[RelatedSearch] = Field(default_factory=list[RelatedSearch])
+    """Related query suggestions."""
+
+
+class ScrapeResponse(BaseModel):
+    """A response from the Serper.dev webpage scrape endpoint."""
+
+    model_config = _RESPONSE_CONFIG
+
+    text: str | None = None
+    """The page's extracted plain text."""
+
+    markdown: str | None = None
+    """The page rendered as Markdown, when requested."""
+
+    metadata: dict[str, str] = Field(default_factory=dict[str, str])
+    """Metadata extracted from the page head."""
+
+    jsonld: dict[str, object] | None = None
+    """JSON-LD structured data found on the page, when present."""
+
+    credits: int | None = None
+    """API credits the scrape consumed."""

--- a/src/openfactcheck/pipeline.py
+++ b/src/openfactcheck/pipeline.py
@@ -2,10 +2,10 @@
 
 [`build_pipeline`][build_pipeline] wires the component contracts into a runnable
 [`Graph`][openfactcheck.graph.Graph]: it processes the input into claims, fans
-out over them to retrieve evidence and verify each claim in parallel, collects
-the per-claim reports, and assembles them with an overall judgment into a
-result. The components are supplied per run as [`Components`][Components]
-dependencies, and the original input rides on
+out over them to generate queries, retrieve evidence, and verify each claim in
+parallel, collects the per-claim reports, and assembles them with an overall
+judgment into a result. The components are supplied per run as
+[`Components`][Components] dependencies, and the original input rides on
 [`PipelineState`][PipelineState], so any implementation of a contract can be
 swapped in without touching the wiring.
 
@@ -17,9 +17,9 @@ result = graph.run(Input(content="..."), state=PipelineState(), deps=components)
 
 from dataclasses import dataclass
 
-from openfactcheck.components.protocols import Aggregator, ClaimProcessor, Retriever, Verifier
+from openfactcheck.components.protocols import Aggregator, ClaimProcessor, QueryGenerator, Retriever, Verifier
 from openfactcheck.graph import Graph, GraphBuilder, StepContext
-from openfactcheck.types import Claim, ClaimReport, Evidence, FactCheckResult, Input
+from openfactcheck.types import Claim, ClaimReport, Evidence, FactCheckResult, Input, Query
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,8 +29,11 @@ class Components:
     processor: ClaimProcessor
     """Produces atomic claims from the input."""
 
+    generator: QueryGenerator
+    """Generates search queries for one claim."""
+
     retriever: Retriever
-    """Fetches evidence for one claim."""
+    """Fetches evidence for one claim's queries."""
 
     verifier: Verifier
     """Judges one claim against its evidence."""
@@ -56,10 +59,10 @@ def build_pipeline() -> Graph[Input, FactCheckResult, PipelineState, Components]
     """Build the default fact-check graph.
 
     The returned graph records the input, processes it into claims, fans out to
-    retrieve and verify each claim concurrently, collects the per-claim reports,
-    and assembles them with an overall judgment into a result. Supply the
-    components as ``deps`` and a fresh [`PipelineState`][PipelineState] as
-    ``state`` when running it.
+    generate queries, retrieve evidence, and verify each claim concurrently,
+    collects the per-claim reports, and assembles them with an overall judgment
+    into a result. Supply the components as ``deps`` and a fresh
+    [`PipelineState`][PipelineState] as ``state`` when running it.
 
     Returns:
         A built [`Graph`][openfactcheck.graph.Graph] taking an
@@ -79,7 +82,11 @@ def build_pipeline() -> Graph[Input, FactCheckResult, PipelineState, Components]
         return await ctx.deps.processor(ctx.inputs)
 
     @g.step_node
-    async def retrieve(ctx: StepContext[Claim, PipelineState, Components]) -> Evidence:
+    async def generate(ctx: StepContext[Claim, PipelineState, Components]) -> Query:
+        return await ctx.deps.generator(ctx.inputs)
+
+    @g.step_node
+    async def retrieve(ctx: StepContext[Query, PipelineState, Components]) -> Evidence:
         return await ctx.deps.retriever(ctx.inputs)
 
     @g.step_node
@@ -106,7 +113,8 @@ def build_pipeline() -> Graph[Input, FactCheckResult, PipelineState, Components]
 
     g.add(
         g.edge_from(g.start_node).to(process),
-        g.edge_from(process).map().to(retrieve),
+        g.edge_from(process).map().to(generate),
+        g.edge_from(generate).to(retrieve),
         g.edge_from(retrieve).to(verify),
         g.edge_from(verify).to(reports),
         g.edge_from(reports).to(assemble),

--- a/src/openfactcheck/types.py
+++ b/src/openfactcheck/types.py
@@ -47,8 +47,8 @@ class WebMetadata(SourceMetadata):
     url: str
     """Address of the web page."""
 
-    title: str
-    """Title of the web page."""
+    title: str | None = None
+    """Title of the web page, or ``None`` when the source provides none."""
 
 
 class Source(BaseModel):
@@ -86,11 +86,17 @@ class Verdict(BaseModel):
     label: Literal["supported", "refuted", "not_enough_evidence"]
     """Whether the evidence supports, refutes, or is insufficient for the claim."""
 
-    confidence: float
-    """How strongly the evidence backs the assigned label."""
+    confidence: float | None = None
+    """How strongly the evidence backs the assigned label, or ``None`` when the verifier reports no confidence."""
 
     reasoning: str
     """Explanation for the assigned label."""
+
+    error: str | None = None
+    """The factual error found in the claim, or ``None`` when the claim is accurate or the verifier finds no error."""
+
+    correction: str | None = None
+    """A corrected version of the claim, or ``None`` when there is nothing to correct."""
 
 
 class OverallVerdict(BaseModel):

--- a/tests/components/dummy/test_query_generator.py
+++ b/tests/components/dummy/test_query_generator.py
@@ -1,0 +1,22 @@
+"""Tests for DummyQueryGenerator."""
+
+import pytest
+
+from openfactcheck.components import QueryGenerator
+from openfactcheck.components.dummy import DummyQueryGenerator
+from openfactcheck.types import Claim
+
+
+def test_DummyQueryGenerator_satisfies_protocol() -> None:
+    assert isinstance(DummyQueryGenerator(), QueryGenerator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_DummyQueryGenerator_returns_no_questions() -> None:
+    generator = DummyQueryGenerator()
+    claim = Claim(text="the earth is round")
+
+    query = await generator(claim)
+
+    assert query.claim == claim
+    assert query.questions == []

--- a/tests/components/dummy/test_retriever.py
+++ b/tests/components/dummy/test_retriever.py
@@ -4,7 +4,7 @@ import pytest
 
 from openfactcheck.components import Retriever
 from openfactcheck.components.dummy import DummyRetriever
-from openfactcheck.types import Claim
+from openfactcheck.types import Claim, Query
 
 
 def test_DummyRetriever_satisfies_protocol() -> None:
@@ -15,8 +15,9 @@ def test_DummyRetriever_satisfies_protocol() -> None:
 async def test_DummyRetriever_returns_no_sources() -> None:
     retriever = DummyRetriever()
     claim = Claim(text="water is wet")
+    query = Query(claim=claim, questions=["is water wet?"])
 
-    evidence = await retriever(claim)
+    evidence = await retriever(query)
 
     assert evidence.claim == claim
     assert evidence.sources == []

--- a/tests/components/factool/test_aggregator.py
+++ b/tests/components/factool/test_aggregator.py
@@ -1,0 +1,39 @@
+"""Tests for FactoolAggregator."""
+
+import pytest
+
+from openfactcheck.components import Aggregator
+from openfactcheck.components.factool import FactoolAggregator
+from openfactcheck.types import Claim, Verdict
+
+
+def _verdict(label: str) -> Verdict:
+    return Verdict(claim=Claim(text="c"), label=label, reasoning="")  # type: ignore[arg-type]
+
+
+def test_FactoolAggregator_satisfies_protocol() -> None:
+    assert isinstance(FactoolAggregator(), Aggregator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolAggregator_all_supported_is_factual() -> None:
+    result = await FactoolAggregator()([_verdict("supported"), _verdict("supported")])
+
+    assert result.label == "factual"
+    assert result.score == 1.0
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolAggregator_any_refuted_is_non_factual() -> None:
+    result = await FactoolAggregator()([_verdict("supported"), _verdict("refuted")])
+
+    assert result.label == "non_factual"
+    assert result.score == 0.5
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolAggregator_empty_is_not_enough_evidence() -> None:
+    result = await FactoolAggregator()([])
+
+    assert result.label == "not_enough_evidence"
+    assert result.score == 0.0

--- a/tests/components/factool/test_claim_processor.py
+++ b/tests/components/factool/test_claim_processor.py
@@ -1,0 +1,30 @@
+"""Tests for FactoolClaimProcessor. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import ClaimProcessor
+from openfactcheck.components.factool import FactoolClaimProcessor
+from openfactcheck.types import Claim, Input
+
+
+class _FakeClient:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+
+def test_FactoolClaimProcessor_satisfies_protocol() -> None:
+    assert isinstance(FactoolClaimProcessor(client=_FakeClient(None)), ClaimProcessor)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolClaimProcessor_returns_extracted_claims() -> None:
+    processor = FactoolClaimProcessor(client=_FakeClient(SimpleNamespace(claims=["a", "b"])))
+
+    result = await processor(Input(content="some text"))
+
+    assert result == [Claim(text="a"), Claim(text="b")]

--- a/tests/components/factool/test_prompts.py
+++ b/tests/components/factool/test_prompts.py
@@ -1,0 +1,28 @@
+"""The transcribed Factool prompts load and fill cleanly."""
+
+from pathlib import Path
+
+import pytest
+
+import openfactcheck.components.factool as factool_pkg
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(factool_pkg.__file__).resolve().parent / "prompts"
+
+
+@pytest.mark.parametrize(
+    ("filename", "values"),
+    [
+        ("claim_processor.md", {"input": "The earth is flat."}),
+        ("query_generator.md", {"input": "The earth is flat."}),
+        ("verifier.md", {"claim": "The earth is flat.", "evidence": "['The earth is an oblate spheroid.']"}),
+    ],
+)
+def test_factool_prompt_loads_and_fills(filename: str, values: dict[str, str]) -> None:
+    template = PromptTemplate.from_file(_PROMPTS_DIR / filename)
+
+    messages = template.to_messages(**values)
+
+    assert len(messages) == 2  # noqa: PLR2004 - a system and a user message.
+    rendered = "\n".join(message.content for message in messages)
+    assert "{{" not in rendered  # every placeholder was substituted

--- a/tests/components/factool/test_provenance.py
+++ b/tests/components/factool/test_provenance.py
@@ -1,0 +1,15 @@
+"""Tests for the Factool provenance record."""
+
+from openfactcheck.components import Provenance
+from openfactcheck.components.factool import PROVENANCE
+
+
+def test_factool_provenance_records_pinned_source() -> None:
+    assert isinstance(PROVENANCE, Provenance)
+    assert PROVENANCE.paper_url.endswith("2307.13528")
+    assert PROVENANCE.repository_url == "https://github.com/GAIR-NLP/factool"
+    assert len(PROVENANCE.repository_commit) == 40  # noqa: PLR2004 - a full git SHA-1.
+    assert PROVENANCE.license == "Apache-2.0"
+    assert PROVENANCE.default_model == "gpt-4o-mini"
+    assert "@article{" in PROVENANCE.citation
+    assert "2307.13528" in PROVENANCE.citation

--- a/tests/components/factool/test_query_generator.py
+++ b/tests/components/factool/test_query_generator.py
@@ -1,0 +1,31 @@
+"""Tests for FactoolQueryGenerator. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import QueryGenerator
+from openfactcheck.components.factool import FactoolQueryGenerator
+from openfactcheck.types import Claim
+
+
+class _FakeClient:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+
+def test_FactoolQueryGenerator_satisfies_protocol() -> None:
+    assert isinstance(FactoolQueryGenerator(client=_FakeClient(None)), QueryGenerator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolQueryGenerator_wraps_generated_queries() -> None:
+    generator = FactoolQueryGenerator(client=_FakeClient(SimpleNamespace(queries=["q1", "q2"])))
+
+    query = await generator(Claim(text="the sky is blue"))
+
+    assert query.claim.text == "the sky is blue"
+    assert query.questions == ["q1", "q2"]

--- a/tests/components/factool/test_retriever.py
+++ b/tests/components/factool/test_retriever.py
@@ -1,0 +1,59 @@
+"""Tests for FactoolRetriever. The Serper client is faked."""
+
+from collections.abc import Sequence
+
+import pytest
+
+from openfactcheck.components import Retriever
+from openfactcheck.components.factool import FactoolRetriever
+from openfactcheck.integrations.serper import SearchParams, SearchResponse
+from openfactcheck.types import Claim, Query, WebMetadata
+
+
+class _FakeSerper:
+    def __init__(self, responses: list[SearchResponse]) -> None:
+        self._responses = responses
+        self.calls: list[list[SearchParams | str]] = []
+
+    async def search_batch(self, queries: Sequence[SearchParams | str]) -> list[SearchResponse]:
+        self.calls.append(list(queries))
+        return self._responses
+
+
+def test_FactoolRetriever_satisfies_protocol() -> None:
+    assert isinstance(FactoolRetriever(serper=_FakeSerper([])), Retriever)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolRetriever_collects_snippets_into_sources() -> None:
+    responses = [
+        SearchResponse.model_validate(
+            {"organic": [{"title": "T1", "link": "u1", "snippet": "s1"}], "answerBox": {"answer": "the answer"}}
+        ),
+        SearchResponse.model_validate({"organic": [{"title": "T2", "link": "u2", "snippet": "s2"}]}),
+    ]
+    serper = _FakeSerper(responses)
+    retriever = FactoolRetriever(serper=serper, num_results=5)
+    claim = Claim(text="c")
+
+    evidence = await retriever(Query(claim=claim, questions=["q1", "q2"]))
+
+    contents = [source.content for source in evidence.sources]
+    assert {"the answer", "s1", "s2"} <= set(contents)
+    organic = [s for s in evidence.sources if isinstance(s.metadata, WebMetadata)]
+    assert {s.metadata.url for s in organic if isinstance(s.metadata, WebMetadata)} == {"u1", "u2"}
+    # Both queries are searched together, carrying the requested result count.
+    assert len(serper.calls[0]) == 2
+    assert all(isinstance(param, SearchParams) and param.num == 5 for param in serper.calls[0])
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolRetriever_no_questions_skips_search() -> None:
+    serper = _FakeSerper([])
+    retriever = FactoolRetriever(serper=serper)
+    claim = Claim(text="c")
+
+    evidence = await retriever(Query(claim=claim, questions=[]))
+
+    assert evidence.sources == []
+    assert serper.calls == []

--- a/tests/components/factool/test_verifier.py
+++ b/tests/components/factool/test_verifier.py
@@ -1,0 +1,51 @@
+"""Tests for FactoolVerifier. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import Verifier
+from openfactcheck.components.factool import FactoolVerifier
+from openfactcheck.types import Claim, Evidence, Source
+
+
+class _FakeClient:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+
+def test_FactoolVerifier_satisfies_protocol() -> None:
+    assert isinstance(FactoolVerifier(client=_FakeClient(None)), Verifier)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolVerifier_factual_claim_is_supported() -> None:
+    # Factool emits the literal string "None" for the no-error case; it normalises to None.
+    client = _FakeClient(SimpleNamespace(reasoning="ok", factuality=True, error="None", correction="None"))
+    verifier = FactoolVerifier(client=client)
+    claim = Claim(text="the earth is round")
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[Source(content="it is round")]))
+
+    assert verdict.label == "supported"
+    assert verdict.confidence is None
+    assert verdict.error is None
+    assert verdict.correction is None
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolVerifier_non_factual_claim_is_refuted_with_correction() -> None:
+    client = _FakeClient(
+        SimpleNamespace(reasoning="contradicted", factuality=False, error="not flat", correction="the earth is round")
+    )
+    verifier = FactoolVerifier(client=client)
+    claim = Claim(text="the earth is flat")
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[]))
+
+    assert verdict.label == "refuted"
+    assert verdict.error == "not flat"
+    assert verdict.correction == "the earth is round"

--- a/tests/components/test_protocols.py
+++ b/tests/components/test_protocols.py
@@ -50,13 +50,14 @@ async def test_Retriever_accepts_conforming_implementation() -> None:
     """A class with matching async __call__ satisfies the Retriever Protocol."""
 
     class DummyRetriever:
-        async def __call__(self, claim: Claim) -> Evidence:
-            return Evidence(claim=claim, sources=[Source(content="dummy source")])
+        async def __call__(self, query: Query) -> Evidence:
+            return Evidence(claim=query.claim, sources=[Source(content="dummy source")])
 
     retriever: Retriever = DummyRetriever()
 
     assert isinstance(retriever, Retriever)
-    result = await retriever(Claim(text="water is wet"))
+    claim = Claim(text="water is wet")
+    result = await retriever(Query(claim=claim, questions=["is water wet?"]))
     assert result.claim.text == "water is wet"
     assert len(result.sources) == 1
 

--- a/tests/integrations/serper/test_client.py
+++ b/tests/integrations/serper/test_client.py
@@ -1,0 +1,134 @@
+"""Tests for the SerperClient. httpx is faked at the request boundary."""
+
+from typing import Any
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from openfactcheck.integrations.serper import SearchParams, SerperClient, SerperConfigError, SerperRequestError
+
+
+class _FakeResponse:
+    def __init__(self, json_data: object, *, status_error: bool = False) -> None:
+        self._json = json_data
+        self._status_error = status_error
+
+    def raise_for_status(self) -> None:
+        if self._status_error:
+            request = httpx.Request("POST", "https://google.serper.dev/search")
+            response = httpx.Response(429, request=request)
+            raise httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+    def json(self) -> object:
+        return self._json
+
+
+class _FakeAsyncClient:
+    """Stand-in for httpx.AsyncClient that records the request and returns a fixed response."""
+
+    def __init__(self, response: _FakeResponse, recorder: dict[str, Any]) -> None:
+        self._response = response
+        self._recorder = recorder
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    async def post(self, url: str, *, headers: dict[str, str] | None = None, json: object = None) -> _FakeResponse:
+        self._recorder.update(url=url, headers=headers, json=json)
+        return self._response
+
+
+def _patch_httpx(mocker: MockerFixture, response: _FakeResponse) -> dict[str, Any]:
+    recorder: dict[str, Any] = {}
+    mocker.patch(
+        "openfactcheck.integrations.serper.client.httpx.AsyncClient",
+        lambda **_: _FakeAsyncClient(response, recorder),
+    )
+    return recorder
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_search_parses_response(mocker: MockerFixture) -> None:
+    response = _FakeResponse({"organic": [{"title": "OpenAI", "link": "https://openai.com", "position": 1}]})
+    _patch_httpx(mocker, response)
+    client = SerperClient(api_key="test-key")
+
+    result = await client.search("openai")
+
+    assert result.organic[0].title == "OpenAI"
+    assert result.organic[0].link == "https://openai.com"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_search_sends_key_query_and_endpoint(mocker: MockerFixture) -> None:
+    recorder = _patch_httpx(mocker, _FakeResponse({"organic": []}))
+    client = SerperClient(api_key="test-key", gl="us")
+
+    await client.search("openai")
+
+    assert recorder["url"] == "https://google.serper.dev/search"
+    assert recorder["headers"]["X-API-KEY"] == "test-key"
+    assert recorder["json"] == {"q": "openai", "gl": "us"}
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_search_accepts_search_params(mocker: MockerFixture) -> None:
+    recorder = _patch_httpx(mocker, _FakeResponse({"organic": []}))
+    client = SerperClient(api_key="test-key")
+
+    await client.search(SearchParams(q="openai", num=5, tbs="qdr:d"))
+
+    assert recorder["json"] == {"q": "openai", "num": 5, "tbs": "qdr:d"}
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_search_batch_parses_list(mocker: MockerFixture) -> None:
+    response = _FakeResponse([{"organic": [{"title": "a", "link": "u1"}]}, {"organic": [{"title": "b", "link": "u2"}]}])
+    recorder = _patch_httpx(mocker, response)
+    client = SerperClient(api_key="test-key")
+
+    results = await client.search_batch(["a", "b"])
+
+    assert [r.organic[0].title for r in results] == ["a", "b"]
+    assert recorder["json"] == [{"q": "a"}, {"q": "b"}]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_search_batch_rejects_non_list(mocker: MockerFixture) -> None:
+    _patch_httpx(mocker, _FakeResponse({"organic": []}))
+    client = SerperClient(api_key="test-key")
+
+    with pytest.raises(SerperRequestError):
+        await client.search_batch(["a"])
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_scrape_parses_and_targets_scrape_host(mocker: MockerFixture) -> None:
+    recorder = _patch_httpx(mocker, _FakeResponse({"text": "hello", "markdown": "# hello"}))
+    client = SerperClient(api_key="test-key")
+
+    result = await client.scrape("https://example.com", include_markdown=True)
+
+    assert result.text == "hello"
+    assert recorder["url"] == "https://scrape.serper.dev"
+    assert recorder["json"] == {"url": "https://example.com", "includeMarkdown": True}
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_SerperClient_wraps_http_error(mocker: MockerFixture) -> None:
+    _patch_httpx(mocker, _FakeResponse({}, status_error=True))
+    client = SerperClient(api_key="test-key")
+
+    with pytest.raises(SerperRequestError):
+        await client.search("openai")
+
+
+def test_SerperClient_missing_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SERPER_API_KEY", raising=False)
+
+    with pytest.raises(SerperConfigError):
+        SerperClient()

--- a/tests/integrations/serper/test_responses.py
+++ b/tests/integrations/serper/test_responses.py
@@ -1,0 +1,78 @@
+"""Tests for Serper response parsing."""
+
+from openfactcheck.integrations.serper import ScrapeResponse, SearchResponse
+
+_SEARCH_PAYLOAD = {
+    "searchParameters": {"q": "openai", "type": "search", "gl": "us", "hl": "en", "num": 10},
+    "knowledgeGraph": {
+        "title": "OpenAI",
+        "type": "Company",
+        "website": "https://openai.com",
+        "description": "AI research lab",
+        "attributes": {"Founded": "2015", "CEO": "Sam Altman"},
+    },
+    "answerBox": {
+        "snippet": "OpenAI is an AI research lab.",
+        "snippetHighlighted": ["AI research lab"],
+        "title": "OpenAI",
+        "link": "https://openai.com",
+    },
+    "organic": [
+        {
+            "title": "OpenAI",
+            "link": "https://openai.com",
+            "snippet": "Official site",
+            "position": 1,
+            "sitelinks": [{"title": "About", "link": "https://openai.com/about"}],
+        },
+        {"title": "OpenAI - Wikipedia", "link": "https://en.wikipedia.org/wiki/OpenAI", "position": 2},
+    ],
+    "peopleAlsoAsk": [{"question": "Who founded OpenAI?", "snippet": "Founded in 2015.", "link": "https://x"}],
+    "relatedSearches": [{"query": "openai chatgpt"}],
+    "topStories": [{"title": "A news item"}],
+}
+
+
+def test_SearchResponse_parses_camelcase_fields() -> None:
+    response = SearchResponse.model_validate(_SEARCH_PAYLOAD)
+
+    assert response.search_parameters is not None
+    assert response.search_parameters.q == "openai"
+    assert response.search_parameters.type == "search"
+    assert response.organic[0].title == "OpenAI"
+    assert response.organic[0].sitelinks[0].title == "About"
+    assert response.organic[1].snippet is None
+    assert response.knowledge_graph is not None
+    assert response.knowledge_graph.attributes["CEO"] == "Sam Altman"
+    assert response.answer_box is not None
+    assert response.answer_box.snippet_highlighted == ["AI research lab"]
+    assert response.people_also_ask[0].question == "Who founded OpenAI?"
+    assert response.related_searches[0].query == "openai chatgpt"
+
+
+def test_SearchResponse_preserves_unmodeled_fields() -> None:
+    response = SearchResponse.model_validate(_SEARCH_PAYLOAD)
+
+    # Unknown top-level keys are kept rather than rejected.
+    assert response.model_extra is not None
+    assert "topStories" in response.model_extra
+
+
+def test_SearchResponse_defaults_for_empty_payload() -> None:
+    response = SearchResponse.model_validate({})
+
+    assert response.organic == []
+    assert response.people_also_ask == []
+    assert response.knowledge_graph is None
+    assert response.answer_box is None
+
+
+def test_ScrapeResponse_parses_fields() -> None:
+    response = ScrapeResponse.model_validate(
+        {"text": "page text", "markdown": "# page text", "metadata": {"title": "Page"}, "credits": 1}
+    )
+
+    assert response.text == "page text"
+    assert response.markdown == "# page text"
+    assert response.metadata["title"] == "Page"
+    assert response.credits == 1

--- a/tests/integrations/test_boundary.py
+++ b/tests/integrations/test_boundary.py
@@ -1,0 +1,41 @@
+"""Boundary tests — integrations stay free of the fact-checking domain."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+INTEGRATIONS_ROOT = Path(__file__).resolve().parent.parent.parent / "src" / "openfactcheck" / "integrations"
+
+# Integrations are domain-agnostic service clients. They return service-shaped
+# data; components (not integrations) map that into the fact-checking domain.
+FORBIDDEN_PREFIXES = (
+    "openfactcheck.types",
+    "openfactcheck.components",
+    "openfactcheck.pipeline",
+)
+
+
+def _collect_imports(py_file: Path) -> list[tuple[int, str]]:
+    """Return (line, module) for every import in the file."""
+    imports: list[tuple[int, str]] = []
+    tree = ast.parse(py_file.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imports.append((node.lineno, node.module))
+        elif isinstance(node, ast.Import):
+            imports.append((node.lineno, ".".join(alias.name for alias in node.names)))
+    return imports
+
+
+def test_integrations_import_no_domain_modules() -> None:
+    """No file under integrations/ imports a fact-checking domain module."""
+    violations: list[str] = []
+
+    for py_file in INTEGRATIONS_ROOT.rglob("*.py"):
+        for lineno, module in _collect_imports(py_file):
+            if module.startswith(FORBIDDEN_PREFIXES):
+                rel = py_file.relative_to(INTEGRATIONS_ROOT)
+                violations.append(f"{rel}:{lineno} imports '{module}'")
+
+    assert violations == [], "integrations must stay domain-agnostic:\n" + "\n".join(violations)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,19 +5,24 @@ import asyncio
 from openfactcheck.components.dummy import (
     DummyAggregator,
     DummyClaimProcessor,
+    DummyQueryGenerator,
     DummyRetriever,
     DummyVerifier,
 )
 from openfactcheck.pipeline import Components, PipelineState, build_pipeline
-from openfactcheck.types import Claim, Evidence, Input, OverallVerdict, Source, Verdict
+from openfactcheck.types import Claim, Evidence, Input, OverallVerdict, Query, Source, Verdict
 
 
 async def _process(text: Input) -> list[Claim]:
     return [Claim(text=sentence.strip()) for sentence in text.content.split(".") if sentence.strip()]
 
 
-async def _retrieve(claim: Claim) -> Evidence:
-    return Evidence(claim=claim, sources=[Source(content=f"evidence for {claim.text}")])
+async def _generate(claim: Claim) -> Query:
+    return Query(claim=claim, questions=[f"is '{claim.text}' true?"])
+
+
+async def _retrieve(query: Query) -> Evidence:
+    return Evidence(claim=query.claim, sources=[Source(content=f"evidence for {query.claim.text}")])
 
 
 async def _verify(claim: Claim, evidence: Evidence) -> Verdict:
@@ -35,7 +40,9 @@ async def _aggregate(verdicts: list[Verdict]) -> OverallVerdict:
 
 
 def test_build_pipeline_runs_end_to_end() -> None:
-    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(
+        processor=_process, generator=_generate, retriever=_retrieve, verifier=_verify, aggregator=_aggregate
+    )
 
     result = build_pipeline().run(
         Input(content="The sky is blue. Water is wet."), state=PipelineState(), deps=components
@@ -54,11 +61,13 @@ def test_build_pipeline_runs_end_to_end() -> None:
 def test_build_pipeline_preserves_claim_order() -> None:
     delays = {"a": 0.03, "b": 0.0, "c": 0.0}
 
-    async def slow_retrieve(claim: Claim) -> Evidence:
-        await asyncio.sleep(delays.get(claim.text, 0.0))
-        return Evidence(claim=claim, sources=[Source(content=f"e:{claim.text}")])
+    async def slow_retrieve(query: Query) -> Evidence:
+        await asyncio.sleep(delays.get(query.claim.text, 0.0))
+        return Evidence(claim=query.claim, sources=[Source(content=f"e:{query.claim.text}")])
 
-    components = Components(processor=_process, retriever=slow_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(
+        processor=_process, generator=_generate, retriever=slow_retrieve, verifier=_verify, aggregator=_aggregate
+    )
 
     result = build_pipeline().run(Input(content="a. b. c."), state=PipelineState(), deps=components)
 
@@ -69,7 +78,9 @@ def test_build_pipeline_preserves_claim_order() -> None:
 
 
 def test_build_pipeline_zero_claims() -> None:
-    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(
+        processor=_process, generator=_generate, retriever=_retrieve, verifier=_verify, aggregator=_aggregate
+    )
 
     result = build_pipeline().run(Input(content="   "), state=PipelineState(), deps=components)
 
@@ -81,7 +92,9 @@ def test_build_pipeline_zero_claims() -> None:
 
 
 def test_build_pipeline_duplicate_claims() -> None:
-    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(
+        processor=_process, generator=_generate, retriever=_retrieve, verifier=_verify, aggregator=_aggregate
+    )
 
     result = build_pipeline().run(Input(content="dup. dup."), state=PipelineState(), deps=components)
 
@@ -90,7 +103,9 @@ def test_build_pipeline_duplicate_claims() -> None:
 
 
 def test_build_pipeline_state_records_input() -> None:
-    components = Components(processor=_process, retriever=_retrieve, verifier=_verify, aggregator=_aggregate)
+    components = Components(
+        processor=_process, generator=_generate, retriever=_retrieve, verifier=_verify, aggregator=_aggregate
+    )
     state = PipelineState()
 
     build_pipeline().run(Input(content="The sky is blue."), state=state, deps=components)
@@ -101,6 +116,7 @@ def test_build_pipeline_state_records_input() -> None:
 def test_build_pipeline_with_dummy_components() -> None:
     components = Components(
         processor=DummyClaimProcessor(),
+        generator=DummyQueryGenerator(),
         retriever=DummyRetriever(),
         verifier=DummyVerifier(),
         aggregator=DummyAggregator(),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -50,6 +50,11 @@ def test_source_with_web_metadata() -> None:
     assert source.metadata.title == "NASA"
 
 
+def test_web_metadata_title_defaults_to_none() -> None:
+    metadata = WebMetadata(url="https://nasa.gov")
+    assert metadata.title is None
+
+
 def test_evidence() -> None:
     claim = Claim(text="The earth is round")
     evidence = Evidence(
@@ -73,6 +78,29 @@ def test_verdict() -> None:
     )
     assert verdict.label == "supported"
     assert verdict.confidence == 0.95
+
+
+def test_verdict_optional_fields_default_to_none() -> None:
+    claim = Claim(text="The earth is round")
+    verdict = Verdict(claim=claim, label="supported", reasoning="confirmed")
+
+    assert verdict.confidence is None
+    assert verdict.error is None
+    assert verdict.correction is None
+
+
+def test_verdict_carries_error_and_correction() -> None:
+    claim = Claim(text="The earth is flat")
+    verdict = Verdict(
+        claim=claim,
+        label="refuted",
+        reasoning="Contradicted by evidence.",
+        error="The earth is not flat.",
+        correction="The earth is round.",
+    )
+
+    assert verdict.error == "The earth is not flat."
+    assert verdict.correction == "The earth is round."
 
 
 def test_fact_check_result() -> None:


### PR DESCRIPTION
Ports the **Factool** knowledge-QA factuality pipeline as plug-and-play components on the graph layer, and evolves the component contracts to support it. First real paper port; each port stress-tests the contracts before we lock them.

## Contract evolution (breaking, pre-release)

- `Retriever` now takes `Query` (not `Claim`), so `QueryGenerator` is a first-class spine stage.
- `Verdict` gains optional `error` + `correction` (claim repair); `confidence` is now optional.
- `WebMetadata.title` is optional (Serper snippets carry none).
- Dummy family gains `DummyQueryGenerator`; `pipeline.py` runs `process → generate → retrieve → verify → aggregate`.

## Serper integration (new `integrations/` layer)

Typed async `SerperClient` covering search + scrape (built to extend to the other endpoints); domain-agnostic, returns service-shaped data, boundary-tested so it never imports the domain.

## Factool components (`components/factool/`)

Claim processor, query generator, Serper-backed retriever, verifier (binary factuality → `supported`/`refuted`, filling `error`/`correction`), AND-rule aggregator. Per-component prompts (task instructions verbatim; response-format scaffolding replaced by structured output; self-documenting frontmatter). Shared `Provenance` type with paper/repo/pinned-commit/license/citation/models.

## Verification

- pyright 0, 582 tests, ruff clean, `mkdocs --strict` clean.
- Reproduced behaviorally end-to-end on gpt-4o-mini (catches a false claim, fills the correction, aggregates to `non_factual`).

## Follow-ups (tracked)

- #30 — prompt-and-parse fallback (the paper's gpt-3.5-turbo can't run our structured-output path; default is gpt-4o-mini meanwhile).
- #67 `config.prompts_dir` override · #68 opt-in node input on events · #69 codec variable auto-infer · #70 token-level graph streaming.
- Rigorous benchmark reproduction (a `datasets/knowledge_qa/` slice vs the paper's output) remains open.
