### PR TITLE
feat: streaming across the graph, chat, and components

### DIFF
--- a/src/openfactcheck/chat/backends/anthropic/backend.py
+++ b/src/openfactcheck/chat/backends/anthropic/backend.py
@@ -136,8 +136,12 @@ class AnthropicBackend:
             for event in stream_iter:
                 if event.type == "message_start":
                     input_tokens = event.message.usage.input_tokens
-                elif event.type == "content_block_delta" and event.delta.type == "text_delta":
-                    yield TextDelta(content=event.delta.text)
+                elif event.type == "content_block_delta":
+                    if event.delta.type == "text_delta":
+                        yield TextDelta(content=event.delta.text)
+                    elif event.delta.type == "input_json_delta":
+                        # Structured output uses a forced tool call; its input JSON streams here.
+                        yield TextDelta(content=event.delta.partial_json)
                 elif event.type == "message_delta":
                     output_tokens = event.usage.output_tokens
                     if event.delta.stop_reason is not None:
@@ -176,8 +180,12 @@ class AnthropicBackend:
             async for event in stream_iter:
                 if event.type == "message_start":
                     input_tokens = event.message.usage.input_tokens
-                elif event.type == "content_block_delta" and event.delta.type == "text_delta":
-                    yield TextDelta(content=event.delta.text)
+                elif event.type == "content_block_delta":
+                    if event.delta.type == "text_delta":
+                        yield TextDelta(content=event.delta.text)
+                    elif event.delta.type == "input_json_delta":
+                        # Structured output uses a forced tool call; its input JSON streams here.
+                        yield TextDelta(content=event.delta.partial_json)
                 elif event.type == "message_delta":
                     output_tokens = event.usage.output_tokens
                     if event.delta.stop_reason is not None:

--- a/src/openfactcheck/chat/client.py
+++ b/src/openfactcheck/chat/client.py
@@ -28,19 +28,21 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from openfactcheck.chat.backends import default_backend
 from openfactcheck.chat.config import RuntimeConfig
 from openfactcheck.chat.errors import StructuredOutputError, UnsupportedFeatureError
+from openfactcheck.chat.partial import partial_model
 from openfactcheck.chat.providers import get_provider
 from openfactcheck.chat.requests import ChatRequest, ResponseFormat
+from openfactcheck.chat.responses import TextDelta
 from openfactcheck.messages import UserMessage
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncIterator, Callable, Iterator
 
     from openfactcheck.chat.backends.base import ChatBackend
     from openfactcheck.chat.config import ModelConfig
@@ -108,6 +110,17 @@ class ChatClient:
         if not self._provider.capabilities.structured_output:
             raise UnsupportedFeatureError(f"provider '{self._config.provider}' does not support structured output.")
 
+    def _format_for(self, response_model: type[BaseModel] | None) -> ResponseFormat | None:
+        """Build the structured-output format for ``response_model``, or ``None`` for free text.
+
+        Requires provider support when a model is given, so the constraint surfaces
+        the same way as for [`acompletion_as`][ChatClient.acompletion_as].
+        """
+        if response_model is None:
+            return None
+        self._require_structured_output()
+        return ResponseFormat(name=response_model.__name__, json_schema=response_model.model_json_schema())
+
     def completion(self, messages: list[Message]) -> ChatResponse:
         """Send messages and return a complete response.
 
@@ -130,30 +143,122 @@ class ChatClient:
         """
         return await self._backend.acompletion(self._build_request(messages))
 
-    def stream(self, messages: list[Message]) -> Iterator[StreamEvent]:
+    def stream(
+        self, messages: list[Message], *, response_model: type[BaseModel] | None = None
+    ) -> Iterator[StreamEvent]:
         """Stream a response as typed events.
 
         Args:
             messages: The conversation to send.
+            response_model: When given, the reply is constrained to this model's
+                JSON schema and the streamed text is that JSON, chunk by chunk.
+                Omit it for free text. See [`stream_as`][ChatClient.stream_as] to
+                receive parsed objects instead of raw JSON.
 
         Yields:
             A [`TextDelta`][TextDelta] for each content chunk, then a final
             [`StreamEnd`][StreamEnd] carrying ``finish_reason`` and ``usage``.
-        """
-        yield from self._backend.stream(self._build_request(messages))
 
-    async def astream(self, messages: list[Message]) -> AsyncIterator[StreamEvent]:
+        Raises:
+            UnsupportedFeatureError: ``response_model`` is given but the provider
+                does not support structured output.
+        """
+        yield from self._backend.stream(self._build_request(messages, self._format_for(response_model)))
+
+    async def astream(
+        self, messages: list[Message], *, response_model: type[BaseModel] | None = None
+    ) -> AsyncIterator[StreamEvent]:
         """Stream a response as typed events over an async iterator.
 
         Args:
             messages: The conversation to send.
+            response_model: When given, the reply is constrained to this model's
+                JSON schema and the streamed text is that JSON, chunk by chunk.
+                Omit it for free text. See [`astream_as`][ChatClient.astream_as] to
+                receive parsed objects instead of raw JSON.
 
         Yields:
             A [`TextDelta`][TextDelta] for each content chunk, then a final
             [`StreamEnd`][StreamEnd] carrying ``finish_reason`` and ``usage``.
+
+        Raises:
+            UnsupportedFeatureError: ``response_model`` is given but the provider
+                does not support structured output.
         """
-        async for event in self._backend.astream(self._build_request(messages)):
+        async for event in self._backend.astream(self._build_request(messages, self._format_for(response_model))):
             yield event
+
+    def stream_collect(
+        self,
+        messages: list[Message],
+        *,
+        response_model: type[BaseModel] | None = None,
+        on_delta: Callable[[TextDelta], None] | None = None,
+    ) -> str:
+        """Stream a response, observe each chunk, and return the assembled text.
+
+        A convenience over [`stream`][ChatClient.stream] for callers that want both
+        the streaming side effect (a live display, a progress sink) and the final
+        text in one call, instead of collecting chunks by hand.
+
+        Args:
+            messages: The conversation to send.
+            response_model: When given, constrains the reply to this model's JSON
+                schema; the assembled text (and each chunk) is then that JSON.
+            on_delta: Called with each [`TextDelta`][TextDelta] as it arrives, for
+                example to forward tokens to a progress sink. The terminal
+                [`StreamEnd`][StreamEnd] is not passed.
+
+        Returns:
+            The concatenated text of every chunk (the JSON when ``response_model``
+            is given).
+
+        Raises:
+            UnsupportedFeatureError: ``response_model`` is given but the provider
+                does not support structured output.
+        """
+        parts: list[str] = []
+        for event in self.stream(messages, response_model=response_model):
+            if isinstance(event, TextDelta):
+                parts.append(event.content)
+                if on_delta is not None:
+                    on_delta(event)
+        return "".join(parts)
+
+    async def astream_collect(
+        self,
+        messages: list[Message],
+        *,
+        response_model: type[BaseModel] | None = None,
+        on_delta: Callable[[TextDelta], None] | None = None,
+    ) -> str:
+        """Stream a response over an async iterator, observe each chunk, and return the assembled text.
+
+        Async peer of [`stream_collect`][ChatClient.stream_collect]; same behavior.
+
+        Args:
+            messages: The conversation to send.
+            response_model: When given, constrains the reply to this model's JSON
+                schema; the assembled text (and each chunk) is then that JSON.
+            on_delta: Called with each [`TextDelta`][TextDelta] as it arrives, for
+                example to forward tokens to a progress sink. The terminal
+                [`StreamEnd`][StreamEnd] is not passed.
+
+        Returns:
+            The concatenated text of every chunk (the JSON when ``response_model``
+            is given).
+
+        Raises:
+            UnsupportedFeatureError: ``response_model`` is given but the provider
+                does not support structured output.
+        """
+        parts: list[str] = []
+        async for event in self.astream(messages, response_model=response_model):
+            if isinstance(event, TextDelta):
+                parts.append(event.content)
+                if on_delta is not None:
+                    on_delta(event)
+        return "".join(parts)
 
     def completion_as[T: BaseModel](self, messages: list[Message], response_model: type[T]) -> T:
         """Send messages and return a validated instance of ``response_model``.
@@ -251,3 +356,97 @@ class ChatClient:
                     ),
                 )
                 conversation = [*conversation, response.message, reprompt]
+
+    def stream_as[T: BaseModel](self, messages: list[Message], response_model: type[T]) -> Iterator[T]:
+        """Stream a structured reply as progressively complete instances.
+
+        Asks the model to reply with JSON matching ``response_model`` and yields
+        the object as it is built: each item carries the fields that have arrived
+        so far, the rest left unset, and the final item is the complete, validated
+        instance. Useful for showing a field (a verdict's reasoning, an answer)
+        filling in live while still ending with a fully typed result.
+
+        Unlike [`completion_as`][ChatClient.completion_as], a failed final
+        validation is not retried; streaming cannot replay a partial reply.
+
+        Args:
+            messages: The conversation to send.
+            response_model: The Pydantic model the reply must conform to.
+
+        Yields:
+            Progressively complete instances of ``response_model``; the final one
+            is fully validated.
+
+        Raises:
+            UnsupportedFeatureError: The provider does not support structured
+                output.
+            StructuredOutputError: The complete reply failed validation.
+        """
+        self._require_structured_output()
+        response_format = ResponseFormat(
+            name=response_model.__name__,
+            json_schema=response_model.model_json_schema(),
+        )
+        adapter = TypeAdapter(partial_model(response_model))
+        raw = ""
+        for event in self._backend.stream(self._build_request(messages, response_format)):
+            if not isinstance(event, TextDelta):
+                continue
+            raw += event.content
+            try:
+                partial = adapter.validate_json(raw, experimental_allow_partial="trailing-strings")
+            except ValidationError:
+                continue
+            yield cast("T", partial)
+        try:
+            yield response_model.model_validate_json(raw)
+        except ValidationError as exc:
+            raise StructuredOutputError(
+                f"reply did not match {response_model.__name__}.",
+                raw=raw,
+                validation_error=exc,
+            ) from exc
+
+    async def astream_as[T: BaseModel](self, messages: list[Message], response_model: type[T]) -> AsyncIterator[T]:
+        """Stream a structured reply over an async iterator as progressively complete instances.
+
+        Async peer of [`stream_as`][ChatClient.stream_as]; same progressive
+        behavior and same no-retry contract.
+
+        Args:
+            messages: The conversation to send.
+            response_model: The Pydantic model the reply must conform to.
+
+        Yields:
+            Progressively complete instances of ``response_model``; the final one
+            is fully validated.
+
+        Raises:
+            UnsupportedFeatureError: The provider does not support structured
+                output.
+            StructuredOutputError: The complete reply failed validation.
+        """
+        self._require_structured_output()
+        response_format = ResponseFormat(
+            name=response_model.__name__,
+            json_schema=response_model.model_json_schema(),
+        )
+        adapter = TypeAdapter(partial_model(response_model))
+        raw = ""
+        async for event in self._backend.astream(self._build_request(messages, response_format)):
+            if not isinstance(event, TextDelta):
+                continue
+            raw += event.content
+            try:
+                partial = adapter.validate_json(raw, experimental_allow_partial="trailing-strings")
+            except ValidationError:
+                continue
+            yield cast("T", partial)
+        try:
+            yield response_model.model_validate_json(raw)
+        except ValidationError as exc:
+            raise StructuredOutputError(
+                f"reply did not match {response_model.__name__}.",
+                raw=raw,
+                validation_error=exc,
+            ) from exc

--- a/src/openfactcheck/chat/partial.py
+++ b/src/openfactcheck/chat/partial.py
@@ -1,0 +1,50 @@
+"""All-optional model variants for validating partial structured output.
+
+Streaming structured output validates JSON that is still being written. A
+model's required fields would reject a half-finished object, so each model is
+mirrored into a variant whose every field is optional; partial JSON then
+validates into a progressively filled instance, and the final, complete JSON is
+validated against the original model.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ConfigDict, create_model
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+_PARTIAL_MODELS: dict[type[BaseModel], type[BaseModel]] = {}
+"""Cache mapping a source model to its all-optional partial variant."""
+
+
+def partial_model(model: type[BaseModel]) -> type[BaseModel]:
+    """Return a variant of ``model`` with every top-level field optional.
+
+    Each field keeps its annotation but gains ``| None`` and a ``None`` default,
+    so partial JSON validates into an instance carrying only the fields that have
+    arrived so far, the rest left ``None``. A nested model keeps its own schema,
+    so a nested object appears once enough of it has streamed to validate.
+
+    Results are cached, so repeated calls for the same model return one shared
+    variant.
+
+    Args:
+        model: The model whose fields should be made optional.
+
+    Returns:
+        A model class named ``Partial<Name>`` with every field optional.
+    """
+    cached = _PARTIAL_MODELS.get(model)
+    if cached is not None:
+        return cached
+    # Field definitions are built dynamically, so their value type is Any.
+    fields: dict[str, Any] = {}
+    for name, info in model.model_fields.items():
+        annotation = info.annotation or object
+        fields[name] = (annotation | None, None)
+    partial = create_model(f"Partial{model.__name__}", __config__=ConfigDict(extra="ignore"), **fields)
+    _PARTIAL_MODELS[model] = partial
+    return partial

--- a/src/openfactcheck/components/dummy/__init__.py
+++ b/src/openfactcheck/components/dummy/__init__.py
@@ -6,6 +6,8 @@ external dependencies, which makes them handy as placeholders and as test
 fixtures.
 """
 
+from typing import TYPE_CHECKING
+
 from openfactcheck.components.dummy.aggregator import DummyAggregator
 from openfactcheck.components.dummy.claim_processor import DummyClaimProcessor
 from openfactcheck.components.dummy.query_generator import DummyQueryGenerator
@@ -20,3 +22,21 @@ __all__ = [
     "DummyRetriever",
     "DummyVerifier",
 ]
+
+
+if TYPE_CHECKING:
+    from openfactcheck.components.protocols import (
+        Aggregator,
+        ClaimProcessor,
+        QueryGenerator,
+        Retriever,
+        Verifier,
+    )
+
+    # Type-only conformance: each dummy component must satisfy its category protocol,
+    # so pyright fails the gate the moment one drifts. Absent at runtime.
+    _processor: type[ClaimProcessor] = DummyClaimProcessor
+    _generator: type[QueryGenerator] = DummyQueryGenerator
+    _retriever: type[Retriever] = DummyRetriever
+    _verifier: type[Verifier] = DummyVerifier
+    _aggregator: type[Aggregator] = DummyAggregator

--- a/src/openfactcheck/components/factool/__init__.py
+++ b/src/openfactcheck/components/factool/__init__.py
@@ -11,11 +11,13 @@ recommended default model along with the source paper, repository, pinned
 commit, and license. Import from ``openfactcheck.components.factool``.
 """
 
+from typing import TYPE_CHECKING
+
 from openfactcheck.components.factool.aggregator import FactoolAggregator
-from openfactcheck.components.factool.claim_processor import FactoolClaimProcessor
-from openfactcheck.components.factool.query_generator import FactoolQueryGenerator
+from openfactcheck.components.factool.claim_processor import ClaimExtraction, FactoolClaimProcessor
+from openfactcheck.components.factool.query_generator import FactoolQueryGenerator, GeneratedQueries
 from openfactcheck.components.factool.retriever import FactoolRetriever
-from openfactcheck.components.factool.verifier import FactoolVerifier
+from openfactcheck.components.factool.verifier import FactoolVerifier, Verification
 from openfactcheck.components.provenance import Provenance
 
 _CITATION = """\
@@ -56,7 +58,32 @@ __all__ = [
     "FactoolVerifier",
 ]
 
+# Structured outputs (the value each component's ``on_partial`` hook streams)
+__all__ += [
+    "ClaimExtraction",
+    "GeneratedQueries",
+    "Verification",
+]
+
 # Provenance
 __all__ += [
     "PROVENANCE",
 ]
+
+
+if TYPE_CHECKING:
+    from openfactcheck.components.protocols import (
+        Aggregator,
+        ClaimProcessor,
+        QueryGenerator,
+        Retriever,
+        Verifier,
+    )
+
+    # Type-only conformance: each Factool component must satisfy its category protocol,
+    # so pyright fails the gate the moment one drifts. Absent at runtime.
+    _processor: type[ClaimProcessor] = FactoolClaimProcessor
+    _generator: type[QueryGenerator] = FactoolQueryGenerator
+    _retriever: type[Retriever] = FactoolRetriever
+    _verifier: type[Verifier] = FactoolVerifier
+    _aggregator: type[Aggregator] = FactoolAggregator

--- a/src/openfactcheck/components/factool/claim_processor.py
+++ b/src/openfactcheck/components/factool/claim_processor.py
@@ -1,19 +1,26 @@
 """Factool claim processor."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic import BaseModel
 
 from openfactcheck.chat import ChatClient
+from openfactcheck.messages import Message
 from openfactcheck.prompts import PromptTemplate
 from openfactcheck.types import Claim, Input
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 
 
-class _ClaimExtraction(BaseModel):
-    """Structured output: the claims extracted from a piece of text."""
+class ClaimExtraction(BaseModel):
+    """Factool's structured claim-extraction result.
+
+    The claim processor maps this onto a list of
+    [`Claim`][openfactcheck.types.Claim]. It is also the value handed to a call's
+    ``on_partial`` hook, the claim list growing as the model writes it.
+    """
 
     claims: list[str]
 
@@ -34,15 +41,37 @@ class FactoolClaimProcessor:
     )
     """The claim-extraction prompt. Defaults to Factool's; override to customise."""
 
-    async def __call__(self, text: Input) -> list[Claim]:
+    async def __call__(
+        self,
+        text: Input,
+        *,
+        on_partial: Callable[[ClaimExtraction], None] | None = None,
+    ) -> list[Claim]:
         """Extract atomic claims from ``text``.
 
         Args:
             text: Input text to process into claims.
+            on_partial: Called with the extraction as it streams in, each call
+                carrying the claims found so far. Omit it for a single
+                non-streaming call. The returned claims are the same either way.
 
         Returns:
             The extracted claims; empty when the model finds none.
         """
         messages = self.prompt.to_messages(input=text.content)
-        extraction = await self.client.acompletion_as(messages, _ClaimExtraction)
-        return [Claim(text=claim) for claim in extraction.claims]
+        result = (
+            await self.client.acompletion_as(messages, ClaimExtraction)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return [Claim(text=claim) for claim in result.claims]
+
+    async def _stream(self, messages: list[Message], on_partial: Callable[[ClaimExtraction], None]) -> ClaimExtraction:
+        """Stream the extraction, forwarding each partial result to ``on_partial``."""
+        result: ClaimExtraction | None = None
+        async for partial in self.client.astream_as(messages, ClaimExtraction):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("claim processor stream produced no value")
+        return result

--- a/src/openfactcheck/components/factool/query_generator.py
+++ b/src/openfactcheck/components/factool/query_generator.py
@@ -1,19 +1,26 @@
 """Factool query generator."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic import BaseModel
 
 from openfactcheck.chat import ChatClient
+from openfactcheck.messages import Message
 from openfactcheck.prompts import PromptTemplate
 from openfactcheck.types import Claim, Query
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 
 
-class _GeneratedQueries(BaseModel):
-    """Structured output: the search queries generated for a claim."""
+class GeneratedQueries(BaseModel):
+    """Factool's structured query-generation result.
+
+    The query generator maps this onto a [`Query`][openfactcheck.types.Query]. It
+    is also the value handed to a call's ``on_partial`` hook, the query list
+    growing as the model writes it.
+    """
 
     queries: list[str]
 
@@ -34,15 +41,39 @@ class FactoolQueryGenerator:
     )
     """The query-generation prompt. Defaults to Factool's; override to customise."""
 
-    async def __call__(self, claim: Claim) -> Query:
+    async def __call__(
+        self,
+        claim: Claim,
+        *,
+        on_partial: Callable[[GeneratedQueries], None] | None = None,
+    ) -> Query:
         """Generate search queries for ``claim``.
 
         Args:
             claim: Claim to generate queries for.
+            on_partial: Called with the generated queries as they stream in, each
+                call carrying the queries produced so far. Omit it for a single
+                non-streaming call. The returned query is the same either way.
 
         Returns:
             The claim paired with the generated search questions.
         """
         messages = self.prompt.to_messages(input=claim.text)
-        generated = await self.client.acompletion_as(messages, _GeneratedQueries)
-        return Query(claim=claim, questions=generated.queries)
+        result = (
+            await self.client.acompletion_as(messages, GeneratedQueries)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return Query(claim=claim, questions=result.queries)
+
+    async def _stream(
+        self, messages: list[Message], on_partial: Callable[[GeneratedQueries], None]
+    ) -> GeneratedQueries:
+        """Stream the query generation, forwarding each partial result to ``on_partial``."""
+        result: GeneratedQueries | None = None
+        async for partial in self.client.astream_as(messages, GeneratedQueries):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("query generator stream produced no value")
+        return result

--- a/src/openfactcheck/components/factool/verifier.py
+++ b/src/openfactcheck/components/factool/verifier.py
@@ -1,19 +1,26 @@
 """Factool verifier."""
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic import BaseModel
 
 from openfactcheck.chat import ChatClient
+from openfactcheck.messages import Message
 from openfactcheck.prompts import PromptTemplate
 from openfactcheck.types import Claim, Evidence, Verdict
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 
 
-class _Verification(BaseModel):
-    """Structured output: Factool's per-claim verification result."""
+class Verification(BaseModel):
+    """Factool's structured per-claim verification result.
+
+    The verifier maps this onto a [`Verdict`][openfactcheck.types.Verdict]. It is
+    also the value handed to a verifier call's ``on_partial`` hook, filling in
+    field by field as the model writes it.
+    """
 
     reasoning: str
     factuality: bool
@@ -36,19 +43,34 @@ class FactoolVerifier:
     prompt: PromptTemplate = field(default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "verifier.md"))
     """The verification prompt. Defaults to Factool's; override to customise."""
 
-    async def __call__(self, claim: Claim, evidence: Evidence) -> Verdict:
+    async def __call__(
+        self,
+        claim: Claim,
+        evidence: Evidence,
+        *,
+        on_partial: Callable[[Verification], None] | None = None,
+    ) -> Verdict:
         """Verify ``claim`` against ``evidence``.
 
         Args:
             claim: Claim under evaluation.
             evidence: Sources bearing on the claim's truthfulness.
+            on_partial: Called with the verification result as it streams in, each
+                call carrying the fields filled so far. Omit it for a single
+                non-streaming call; supply it (for example a progress sink) to
+                surface the reasoning and verdict as they are written. The returned
+                verdict is the same either way.
 
         Returns:
             A verdict labelled ``supported`` or ``refuted``, with the error and
             correction filled when the claim is judged non-factual.
         """
         messages = self.prompt.to_messages(claim=claim.text, evidence=self._format_evidence(evidence))
-        result = await self.client.acompletion_as(messages, _Verification)
+        result = (
+            await self.client.acompletion_as(messages, Verification)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
         return Verdict(
             claim=claim,
             label="supported" if result.factuality else "refuted",
@@ -57,6 +79,16 @@ class FactoolVerifier:
             error=self._clean(result.error),
             correction=self._clean(result.correction),
         )
+
+    async def _stream(self, messages: list[Message], on_partial: Callable[[Verification], None]) -> Verification:
+        """Stream the verification, forwarding each partial result to ``on_partial``."""
+        result: Verification | None = None
+        async for partial in self.client.astream_as(messages, Verification):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("verifier stream produced no value")
+        return result
 
     @staticmethod
     def _format_evidence(evidence: Evidence) -> str:

--- a/src/openfactcheck/graph/__init__.py
+++ b/src/openfactcheck/graph/__init__.py
@@ -49,6 +49,7 @@ from openfactcheck.graph.errors import (
 from openfactcheck.graph.events import (
     GraphEvent,
     GraphObserver,
+    NodeEmitted,
     NodeFailed,
     NodeFinished,
     NodeStarted,
@@ -117,6 +118,7 @@ __all__ += [
 __all__ += [
     "GraphEvent",
     "GraphObserver",
+    "NodeEmitted",
     "NodeFailed",
     "NodeFinished",
     "NodeStarted",

--- a/src/openfactcheck/graph/events.py
+++ b/src/openfactcheck/graph/events.py
@@ -7,6 +7,11 @@ during [`Graph.arun`][Graph.arun]. A node start and finish (or failure) is
 emitted per task, so a fanned-out collection reports one finish per item, and a
 single run-finished event closes a successful run.
 
+A run can also surface data a node emits from inside its own task (for example
+LLM token fragments) as [`NodeEmitted`][NodeEmitted] events, but only when it
+opts in via ``stream_node_data`` on [`RunOptions`][RunOptions]; the default
+stream stays node-level.
+
 Match on the event class to handle each kind:
 
 ```python
@@ -15,6 +20,26 @@ match event:
         ...
     case RunFinished(output=result):
         ...
+```
+
+To stream a node's LLM tokens through the run, the node forwards them to its
+``emit`` hook and the consumer opts in to receive them:
+
+```python
+async def answer(ctx):
+    parts = []
+    async for chunk in ctx.deps.client.astream(messages):
+        if isinstance(chunk, TextDelta):
+            ctx.emit(chunk)  # surfaced as NodeEmitted when the run opts in
+            parts.append(chunk.content)
+    return "".join(parts)
+
+
+options = RunOptions(stream_node_data=True)
+async for event in graph.astream(text, state=None, deps=deps, options=options):
+    match event:
+        case NodeEmitted(node_id=node, data=TextDelta(content=token)):
+            print(f"[{node}] {token}", end="")
 ```
 """
 
@@ -83,6 +108,32 @@ class NodeFailed:
 
 
 @dataclass(frozen=True, slots=True)
+class NodeEmitted:
+    """A datum a node emitted from inside its task while running.
+
+    Surfaced only when a run opts in via ``stream_node_data`` on
+    [`RunOptions`][RunOptions]; the default stream carries node lifecycle events
+    only. A node pushes the datum through [`StepContext.emit`][StepContext], so
+    its meaning is whatever that node chose, for example a chat token fragment.
+    Emissions are produced inside the node's own task, so those from concurrent
+    fan-out branches interleave; ``fork_stack`` identifies the branch each
+    belongs to.
+    """
+
+    node_id: str
+    """Identifier of the node that emitted the datum."""
+
+    data: object
+    """The emitted value, of whatever type the node passed to its ``emit`` hook."""
+
+    fork_stack: ForkStack
+    """The fork branch the emitting task belongs to."""
+
+    type: Literal["node_emitted"] = "node_emitted"
+    """Event tag identifying a node-emitted datum."""
+
+
+@dataclass(frozen=True, slots=True)
 class RunFinished:
     """The run completed and produced its terminal output."""
 
@@ -93,7 +144,7 @@ class RunFinished:
     """Event tag identifying the end of a run."""
 
 
-type GraphEvent = NodeStarted | NodeFinished | NodeFailed | RunFinished
+type GraphEvent = NodeStarted | NodeFinished | NodeFailed | NodeEmitted | RunFinished
 """Any progress event a run emits, distinguished by class or by its ``type`` tag."""
 
 type GraphObserver = Callable[[GraphEvent], None]

--- a/src/openfactcheck/graph/graph.py
+++ b/src/openfactcheck/graph/graph.py
@@ -26,7 +26,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from openfactcheck.graph._typevars import DepsT, InputT, OutputT, StateT
 from openfactcheck.graph.errors import GraphPaused, GraphPersistenceError, GraphRuntimeError
-from openfactcheck.graph.events import NodeFailed, NodeFinished, NodeStarted, RunFinished
+from openfactcheck.graph.events import NodeEmitted, NodeFailed, NodeFinished, NodeStarted, RunFinished
 from openfactcheck.graph.forks import ForkStackItem
 from openfactcheck.graph.join import ReducerContext
 from openfactcheck.graph.mermaid import (
@@ -83,6 +83,15 @@ class RunOptions:
 
     on_event: GraphObserver | None = None
     """A callback invoked with each progress event during a run, or ``None`` for none."""
+
+    stream_node_data: bool = False
+    """Whether to surface data a node emits via its ``emit`` hook.
+
+    When ``False`` (the default) the stream carries node lifecycle events only and
+    a node's ``emit`` calls are discarded. When ``True`` each emitted datum becomes
+    a [`NodeEmitted`][openfactcheck.graph.events.NodeEmitted] event tagged with the
+    emitting node and its fork branch.
+    """
 
     store: StateStore | None = None
     """A store to snapshot the run to after each task, or ``None`` to not persist."""
@@ -167,6 +176,7 @@ class _GraphRun[StateT, DepsT, OutputT]:
         self._timeout = options.timeout
         self._on_error = options.on_error
         self._observer = options.on_event
+        self._stream_node_data = options.stream_node_data
         self._store = options.store
         self._run_id = options.run_id
         self._results: asyncio.Queue[_TaskResult] = asyncio.Queue()
@@ -559,6 +569,12 @@ class _GraphRun[StateT, DepsT, OutputT]:
         """Run one step, with retries and timeout, and report its result."""
         step = self._spec.steps[node_id]
         ctx: StepContext[object, StateT, DepsT] = StepContext(inputs=value, state=self._state, deps=self._deps)
+        if self._stream_node_data:
+
+            def emit(data: object) -> None:
+                self._emit(NodeEmitted(node_id, data, stack))
+
+            ctx = replace(ctx, emit=emit)
         started = perf_counter()
         try:
             output = await self._run_step(step, ctx)
@@ -835,8 +851,11 @@ class Graph(Generic[InputT, OutputT, StateT, DepsT]):
         Yields a [`NodeStarted`][openfactcheck.graph.events.NodeStarted] and a
         [`NodeFinished`][openfactcheck.graph.events.NodeFinished] (or
         [`NodeFailed`][openfactcheck.graph.events.NodeFailed]) per task, then a
-        final [`RunFinished`][openfactcheck.graph.events.RunFinished]. Any
-        ``on_event`` set in ``options`` is ignored; the stream is the observer.
+        final [`RunFinished`][openfactcheck.graph.events.RunFinished]. When
+        ``stream_node_data`` is set, a node's ``emit`` calls additionally appear as
+        [`NodeEmitted`][openfactcheck.graph.events.NodeEmitted] events between its
+        start and finish. Any ``on_event`` set in ``options`` is ignored; the
+        stream is the observer.
 
         Args:
             inputs: The value handed to the first node.

--- a/src/openfactcheck/graph/step.py
+++ b/src/openfactcheck/graph/step.py
@@ -31,6 +31,10 @@ END_ID = "__end__"
 """Fixed identifier of every graph's end node."""
 
 
+def _discard(_data: object) -> None:
+    """Drop an emitted datum; the default ``emit`` sink when nothing observes node data."""
+
+
 @dataclass(frozen=True, slots=True)
 class StepContext(Generic[InputT, StateT, DepsT]):
     """Context passed to a step function on each invocation.
@@ -68,6 +72,17 @@ class StepContext(Generic[InputT, StateT, DepsT]):
 
     deps: DepsT
     """Run-scoped dependencies (clients, configuration) injected into nodes."""
+
+    emit: Callable[[object], None] = _discard
+    """Emit a progress datum from inside this node while it runs.
+
+    Call it with any value to surface that value as a
+    [`NodeEmitted`][openfactcheck.graph.events.NodeEmitted] event tagged with this
+    node, for instance to forward chat token fragments as they arrive. The datum
+    is forwarded only when the run sets ``stream_node_data`` on
+    [`RunOptions`][openfactcheck.graph.RunOptions]; otherwise it is discarded, so a
+    node can emit unconditionally at no cost when nothing observes it.
+    """
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/chat/backends/anthropic/test_backend.py
+++ b/tests/chat/backends/anthropic/test_backend.py
@@ -203,3 +203,56 @@ async def test_AnthropicBackend_astream_yields_events(mocker) -> None:  # noqa: 
     assert ends[0].finish_reason == FinishReason.STOP
     assert ends[0].usage is not None
     assert ends[0].usage.output_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# Structured output: the forced tool's input JSON streams as text
+# ---------------------------------------------------------------------------
+
+
+def _fake_tool_stream_events():  # noqa: ANN202
+    """Sync iterable mimicking a forced-tool-use (structured output) stream."""
+    yield SimpleNamespace(type="message_start", message=SimpleNamespace(usage=SimpleNamespace(input_tokens=5)))
+    yield SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="input_json_delta", partial_json='{"name": "Ada"'),
+    )
+    yield SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="input_json_delta", partial_json=', "age": 36}'),
+    )
+    yield SimpleNamespace(
+        type="message_delta",
+        delta=SimpleNamespace(stop_reason="tool_use"),
+        usage=SimpleNamespace(output_tokens=7),
+    )
+    yield SimpleNamespace(type="message_stop")
+
+
+async def _fake_tool_astream_events():  # noqa: ANN202
+    """Async iterable of the structured-output stream events."""
+    for event in _fake_tool_stream_events():
+        yield event
+
+
+def test_AnthropicBackend_stream_surfaces_tool_input_json(mocker) -> None:  # noqa: ANN001
+    """Structured output streams the forced tool's input JSON as TextDelta chunks."""
+    _patch_sync_client(mocker, _fake_tool_stream_events())
+    backend = AnthropicBackend()
+
+    events = list(backend.stream(_build_request()))
+
+    deltas = [e for e in events if isinstance(e, TextDelta)]
+    assert "".join(d.content for d in deltas) == '{"name": "Ada", "age": 36}'
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_AnthropicBackend_astream_surfaces_tool_input_json(mocker) -> None:  # noqa: ANN001
+    """Structured output streams the forced tool's input JSON over the async iterator."""
+    _patch_async_client(mocker, _fake_tool_astream_events())
+    backend = AnthropicBackend()
+
+    events = [event async for event in backend.astream(_build_request())]
+
+    deltas = [e for e in events if isinstance(e, TextDelta)]
+    assert "".join(d.content for d in deltas) == '{"name": "Ada", "age": 36}'

--- a/tests/chat/test_client.py
+++ b/tests/chat/test_client.py
@@ -156,6 +156,58 @@ async def test_ChatClient_astream_yields_events(fake_response: ChatResponse, ope
     assert events[2].usage.output_tokens == 3
 
 
+def test_ChatClient_stream_collect_returns_text(fake_response: ChatResponse, openai_config: OpenAIConfig) -> None:
+    """ChatClient.stream_collect returns the concatenated chunk text."""
+    backend = FakeBackend(fake_response)
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    text = client.stream_collect([UserMessage(content="Hi")])
+
+    assert text == "Hello, world!"
+
+
+def test_ChatClient_stream_collect_forwards_each_delta(
+    fake_response: ChatResponse, openai_config: OpenAIConfig
+) -> None:
+    """ChatClient.stream_collect forwards each TextDelta to on_delta, skipping the terminator."""
+    backend = FakeBackend(fake_response)
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+    seen: list[str] = []
+
+    text = client.stream_collect([UserMessage(content="Hi")], on_delta=lambda delta: seen.append(delta.content))
+
+    assert seen == ["Hello", ", world!"]
+    assert text == "Hello, world!"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_collect_returns_text(
+    fake_response: ChatResponse, openai_config: OpenAIConfig
+) -> None:
+    """ChatClient.astream_collect returns the concatenated chunk text."""
+    backend = FakeBackend(fake_response)
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    text = await client.astream_collect([UserMessage(content="Hi")])
+
+    assert text == "Hello, world!"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_collect_forwards_each_delta(
+    fake_response: ChatResponse, openai_config: OpenAIConfig
+) -> None:
+    """ChatClient.astream_collect forwards each TextDelta to on_delta."""
+    backend = FakeBackend(fake_response)
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+    seen: list[TextDelta] = []
+
+    text = await client.astream_collect([UserMessage(content="Hi")], on_delta=seen.append)
+
+    assert [delta.content for delta in seen] == ["Hello", ", world!"]
+    assert text == "Hello, world!"
+
+
 def test_ChatClient_default_runtime(openai_config: OpenAIConfig, fake_response: ChatResponse) -> None:
     """ChatClient creates default RuntimeConfig when none provided."""
     backend = FakeBackend(fake_response)
@@ -239,3 +291,105 @@ def test_ChatClient_completion_as_unsupported_raises(openai_config: OpenAIConfig
 
     with pytest.raises(UnsupportedFeatureError):
         client.completion_as([UserMessage(content="Make a person")], _Person)
+
+
+class _StreamingJsonBackend:
+    """Backend double that streams a structured reply as JSON fragments."""
+
+    def __init__(self, fragments: list[str]) -> None:
+        self.fragments = fragments
+        self.last_request: ChatRequest | None = None
+
+    def completion(self, request):  # noqa: ANN001, ANN201 - unused by streaming tests.
+        raise NotImplementedError
+
+    async def acompletion(self, request):  # noqa: ANN001, ANN201 - unused by streaming tests.
+        raise NotImplementedError
+
+    def stream(self, request):  # noqa: ANN001, ANN201 - test double.
+        self.last_request = request
+        for fragment in self.fragments:
+            yield TextDelta(content=fragment)
+        yield StreamEnd(finish_reason=FinishReason.STOP)
+
+    async def astream(self, request):  # noqa: ANN001, ANN201 - test double.
+        self.last_request = request
+        for fragment in self.fragments:
+            yield TextDelta(content=fragment)
+        yield StreamEnd(finish_reason=FinishReason.STOP)
+
+
+def test_ChatClient_stream_as_yields_progressive_then_final(openai_config: OpenAIConfig) -> None:
+    """stream_as yields progressively filled instances, ending with the validated model."""
+    backend = _StreamingJsonBackend(['{"name": "A', 'da", "age', '": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    items = list(client.stream_as([UserMessage(content="hi")], _Person))
+
+    # The name fills in before the age arrives.
+    assert any(item.name is not None and item.age is None for item in items)
+    final = items[-1]
+    assert isinstance(final, _Person)
+    assert final == _Person(name="Ada", age=36)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_as_yields_progressive_then_final(openai_config: OpenAIConfig) -> None:
+    """astream_as yields progressively filled instances over the async iterator."""
+    backend = _StreamingJsonBackend(['{"name": "A', 'da", "age', '": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    items = [item async for item in client.astream_as([UserMessage(content="hi")], _Person)]
+
+    assert any(item.name is not None and item.age is None for item in items)
+    assert isinstance(items[-1], _Person)
+    assert items[-1] == _Person(name="Ada", age=36)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_as_raises_on_invalid_final(openai_config: OpenAIConfig) -> None:
+    """astream_as raises StructuredOutputError when the complete reply fails validation."""
+    backend = _StreamingJsonBackend(['{"name": "Ada", "age": "not-a-number"}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    with pytest.raises(StructuredOutputError):
+        _ = [item async for item in client.astream_as([UserMessage(content="hi")], _Person)]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_with_response_model_streams_json(openai_config: OpenAIConfig) -> None:
+    """astream with a response_model streams the JSON as plain text deltas and sets the format."""
+    backend = _StreamingJsonBackend(['{"name": "A', 'da", "age', '": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    chunks = [
+        event.content
+        async for event in client.astream([UserMessage(content="hi")], response_model=_Person)
+        if isinstance(event, TextDelta)
+    ]
+
+    assert "".join(chunks) == '{"name": "Ada", "age": 36}'
+    assert backend.last_request is not None
+    assert backend.last_request.response_format is not None  # structured format was applied
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_astream_collect_with_response_model_returns_json(openai_config: OpenAIConfig) -> None:
+    """astream_collect with a response_model returns the assembled JSON string."""
+    backend = _StreamingJsonBackend(['{"name": "A', 'da", "age', '": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    raw = await client.astream_collect([UserMessage(content="hi")], response_model=_Person)
+
+    assert raw == '{"name": "Ada", "age": 36}'
+    assert _Person.model_validate_json(raw) == _Person(name="Ada", age=36)
+
+
+def test_ChatClient_stream_with_response_model_unsupported_raises(openai_config: OpenAIConfig, mocker) -> None:  # noqa: ANN001 - pytest-mock fixture.
+    """Streaming with a response_model raises when the provider lacks structured output."""
+    backend = _StreamingJsonBackend(['{"name": "Ada", "age": 36}'])
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+    mocker.patch.object(client._provider, "capabilities", SimpleNamespace(structured_output=False))
+
+    with pytest.raises(UnsupportedFeatureError):
+        list(client.stream([UserMessage(content="hi")], response_model=_Person))

--- a/tests/chat/test_partial.py
+++ b/tests/chat/test_partial.py
@@ -1,0 +1,39 @@
+"""Tests for the all-optional partial-model builder."""
+
+from pydantic import BaseModel, TypeAdapter
+
+from openfactcheck.chat.partial import partial_model
+
+
+class _Verdict(BaseModel):
+    reasoning: str
+    factuality: bool
+    correction: str | None = None
+
+
+def test_partial_model_makes_every_field_optional() -> None:
+    """A partial variant validates an empty object, leaving every field None."""
+    partial = partial_model(_Verdict)
+
+    instance = partial.model_validate({})
+
+    assert instance.model_dump() == {"reasoning": None, "factuality": None, "correction": None}
+
+
+def test_partial_model_validates_incomplete_json_progressively() -> None:
+    """Partial validation fills only the fields present so far in a half-written object."""
+    adapter = TypeAdapter(partial_model(_Verdict))
+
+    instance = adapter.validate_json(
+        '{"reasoning": "Canberra is the capi',
+        experimental_allow_partial="trailing-strings",
+    )
+
+    dumped = instance.model_dump()
+    assert dumped["reasoning"] == "Canberra is the capi"
+    assert dumped["factuality"] is None
+
+
+def test_partial_model_is_cached() -> None:
+    """Repeated calls for the same model return one shared variant."""
+    assert partial_model(_Verdict) is partial_model(_Verdict)

--- a/tests/components/factool/test_claim_processor.py
+++ b/tests/components/factool/test_claim_processor.py
@@ -10,11 +10,16 @@ from openfactcheck.types import Claim, Input
 
 
 class _FakeClient:
-    def __init__(self, result: object) -> None:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
         self._result = result
+        self._stream = stream or []
 
     async def acompletion_as(self, messages: object, response_model: object) -> object:
         return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
 
 
 def test_FactoolClaimProcessor_satisfies_protocol() -> None:
@@ -27,4 +32,20 @@ async def test_FactoolClaimProcessor_returns_extracted_claims() -> None:
 
     result = await processor(Input(content="some text"))
 
+    assert result == [Claim(text="a"), Claim(text="b")]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolClaimProcessor_streams_partials_via_on_partial() -> None:
+    # The claim list fills in as the model writes it.
+    partials = [
+        SimpleNamespace(claims=["a"]),
+        SimpleNamespace(claims=["a", "b"]),
+    ]
+    processor = FactoolClaimProcessor(client=_FakeClient(None, stream=partials))
+    seen: list[SimpleNamespace] = []
+
+    result = await processor(Input(content="some text"), on_partial=seen.append)
+
+    assert [partial.claims for partial in seen] == [["a"], ["a", "b"]]
     assert result == [Claim(text="a"), Claim(text="b")]

--- a/tests/components/factool/test_query_generator.py
+++ b/tests/components/factool/test_query_generator.py
@@ -10,11 +10,16 @@ from openfactcheck.types import Claim
 
 
 class _FakeClient:
-    def __init__(self, result: object) -> None:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
         self._result = result
+        self._stream = stream or []
 
     async def acompletion_as(self, messages: object, response_model: object) -> object:
         return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
 
 
 def test_FactoolQueryGenerator_satisfies_protocol() -> None:
@@ -28,4 +33,19 @@ async def test_FactoolQueryGenerator_wraps_generated_queries() -> None:
     query = await generator(Claim(text="the sky is blue"))
 
     assert query.claim.text == "the sky is blue"
+    assert query.questions == ["q1", "q2"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolQueryGenerator_streams_partials_via_on_partial() -> None:
+    partials = [
+        SimpleNamespace(queries=["q1"]),
+        SimpleNamespace(queries=["q1", "q2"]),
+    ]
+    generator = FactoolQueryGenerator(client=_FakeClient(None, stream=partials))
+    seen: list[SimpleNamespace] = []
+
+    query = await generator(Claim(text="the sky is blue"), on_partial=seen.append)
+
+    assert [partial.queries for partial in seen] == [["q1"], ["q1", "q2"]]
     assert query.questions == ["q1", "q2"]

--- a/tests/components/factool/test_verifier.py
+++ b/tests/components/factool/test_verifier.py
@@ -10,11 +10,16 @@ from openfactcheck.types import Claim, Evidence, Source
 
 
 class _FakeClient:
-    def __init__(self, result: object) -> None:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
         self._result = result
+        self._stream = stream or []
 
     async def acompletion_as(self, messages: object, response_model: object) -> object:
         return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
 
 
 def test_FactoolVerifier_satisfies_protocol() -> None:
@@ -49,3 +54,29 @@ async def test_FactoolVerifier_non_factual_claim_is_refuted_with_correction() ->
     assert verdict.label == "refuted"
     assert verdict.error == "not flat"
     assert verdict.correction == "the earth is round"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactoolVerifier_streams_partials_via_on_partial() -> None:
+    # Progressive structured output: reasoning fills in, factuality/correction arrive last.
+    partials = [
+        SimpleNamespace(reasoning="Canberra", factuality=None, error=None, correction=None),
+        SimpleNamespace(reasoning="Canberra is the", factuality=None, error=None, correction=None),
+        SimpleNamespace(
+            reasoning="Canberra is the capital", factuality=False, error="not Sydney", correction="Canberra"
+        ),
+    ]
+    client = _FakeClient(None, stream=partials)
+    verifier = FactoolVerifier(client=client)
+    claim = Claim(text="the capital of Australia is Sydney")
+    seen: list[SimpleNamespace] = []
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[]), on_partial=seen.append)
+
+    # The whole structured object was forwarded as it filled in.
+    assert [partial.reasoning for partial in seen] == ["Canberra", "Canberra is the", "Canberra is the capital"]
+    assert seen[-1].factuality is False
+    # And the final verdict is mapped from the complete structured result.
+    assert verdict.label == "refuted"
+    assert verdict.reasoning == "Canberra is the capital"
+    assert verdict.correction == "Canberra"

--- a/tests/graph/test_streaming.py
+++ b/tests/graph/test_streaming.py
@@ -5,6 +5,7 @@ import asyncio
 from openfactcheck.graph import (
     GraphBuilder,
     GraphEvent,
+    NodeEmitted,
     NodeFinished,
     NodeStarted,
     RunFinished,
@@ -59,3 +60,115 @@ def test_Graph_on_event_observes_each_event() -> None:
 
     assert result == "HI!"
     assert seen == ["NodeStarted", "NodeFinished", "NodeStarted", "NodeFinished", "RunFinished"]
+
+
+def _emitting_graph() -> GraphBuilder[str, str]:
+    g = GraphBuilder[str, str]()
+
+    @g.step_node
+    async def echo(ctx: StepContext[str]) -> str:
+        ctx.emit(f"tok:{ctx.inputs}")
+        ctx.emit("done")
+        return ctx.inputs.upper()
+
+    g.add(
+        g.edge_from(g.start_node).to(echo),
+        g.edge_from(echo).to(g.end_node),
+    )
+    return g
+
+
+def test_Graph_astream_discards_node_data_by_default() -> None:
+    graph = _emitting_graph().build()
+
+    async def collect() -> list[GraphEvent]:
+        return [event async for event in graph.astream("hi", state=None, deps=None)]
+
+    events = asyncio.run(collect())
+
+    assert not any(isinstance(e, NodeEmitted) for e in events)
+    assert [type(e).__name__ for e in events] == ["NodeStarted", "NodeFinished", "RunFinished"]
+
+
+def test_Graph_astream_emits_node_data_when_enabled() -> None:
+    graph = _emitting_graph().build()
+
+    async def collect() -> list[GraphEvent]:
+        options = RunOptions(stream_node_data=True)
+        return [event async for event in graph.astream("hi", state=None, deps=None, options=options)]
+
+    events = asyncio.run(collect())
+
+    emitted = [e for e in events if isinstance(e, NodeEmitted)]
+    assert [(e.node_id, e.data) for e in emitted] == [("echo", "tok:hi"), ("echo", "done")]
+    # Emissions fall between the node's start and its finish.
+    kinds = [type(e).__name__ for e in events]
+    assert kinds == ["NodeStarted", "NodeEmitted", "NodeEmitted", "NodeFinished", "RunFinished"]
+
+
+def test_Graph_astream_node_data_carries_arbitrary_objects() -> None:
+    sentinel = object()
+    g = GraphBuilder[str, str]()
+
+    @g.step_node
+    async def pass_object(ctx: StepContext[str]) -> str:
+        ctx.emit(sentinel)
+        return ctx.inputs
+
+    g.add(g.edge_from(g.start_node).to(pass_object), g.edge_from(pass_object).to(g.end_node))
+
+    async def collect() -> list[GraphEvent]:
+        options = RunOptions(stream_node_data=True)
+        return [event async for event in g.build().astream("x", state=None, deps=None, options=options)]
+
+    events = asyncio.run(collect())
+
+    emitted = [e for e in events if isinstance(e, NodeEmitted)]
+    assert len(emitted) == 1
+    assert emitted[0].data is sentinel
+
+
+def test_Graph_on_event_includes_node_data_when_enabled() -> None:
+    graph = _emitting_graph().build()
+    emitted: list[object] = []
+
+    def observe(event: GraphEvent) -> None:
+        if isinstance(event, NodeEmitted):
+            emitted.append(event.data)
+
+    graph.run("hi", state=None, deps=None, options=RunOptions(on_event=observe, stream_node_data=True))
+
+    assert emitted == ["tok:hi", "done"]
+
+
+def test_Graph_astream_node_data_tagged_by_fork_branch() -> None:
+    g = GraphBuilder[str, list[str]]()
+
+    @g.step_node
+    async def split(ctx: StepContext[str]) -> list[str]:
+        return ctx.inputs.split()
+
+    @g.step_node
+    async def echo(ctx: StepContext[str]) -> str:
+        ctx.emit(ctx.inputs)
+        return ctx.inputs.upper()
+
+    collect = g.collect_node(str, node_id="collect")
+    g.add(
+        g.edge_from(g.start_node).to(split),
+        g.edge_from(split).map().to(echo),
+        g.edge_from(echo).to(collect),
+        g.edge_from(collect).to(g.end_node),
+    )
+
+    async def run() -> list[GraphEvent]:
+        options = RunOptions(stream_node_data=True)
+        return [event async for event in g.build().astream("a b c", state=None, deps=None, options=options)]
+
+    events = asyncio.run(run())
+
+    emitted = [e for e in events if isinstance(e, NodeEmitted)]
+    assert all(e.node_id == "echo" for e in emitted)
+    assert {e.data for e in emitted} == {"a", "b", "c"}
+    # Each mapped item ran in its own branch, so every emission carries a distinct fork stack.
+    assert len({e.fork_stack for e in emitted}) == 3


### PR DESCRIPTION
Adds streaming across three layers, plus type-level protocol conformance. Reviewable commit-by-commit.

### Graph token streaming (closes #70)
An opt-in `NodeEmitted` event lets a node surface data (e.g. LLM tokens) through the run's event stream as it executes. `StepContext.emit` forwards a datum tagged with the node + fork branch; `RunOptions.stream_node_data` gates it; the default stream stays node-level (the emit hook is a no-op sink unless opted in).

### Chat client streaming
- `stream_collect`/`astream_collect` — stream, tee each chunk to a sink, return the assembled text.
- `stream_as`/`astream_as` — stream a structured reply as **progressively complete instances** (via an all-optional partial model), with the final item fully validated.
- `response_model` on the streaming methods — stream structured output as **plain JSON**.
- Anthropic backend now surfaces a tool call's `input_json_delta` as `TextDelta`, so structured output streams there too.

### Factool component streaming + conformance
- The Factool LLM components gain an optional `on_partial` hook that forwards the structured result as it fills in, while still returning the domain type.
- Their structured outputs are promoted to public types (`Verification`, `ClaimExtraction`, `GeneratedQueries`).
- Type-only conformance blocks in `dummy/` and `factool/` make `pyright` prove every shipped component satisfies its category protocol.

**Verification:** `pyright src` 0 · 605 tests · ruff clean · `mkdocs --strict` clean. All three providers' streaming live-verified (OpenAI + Anthropic) plus an end-to-end Factool run.
