### PR TITLE
feat: add Pipeline.astream with opt-in token streaming

### DIFF
--- a/src/openfactcheck/components/dummy/claim_processor.py
+++ b/src/openfactcheck/components/dummy/claim_processor.py
@@ -1,5 +1,6 @@
 """Dummy claim processor."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from openfactcheck.components.types import Claim, Input
@@ -13,11 +14,17 @@ class DummyClaimProcessor:
     blank.
     """
 
-    async def __call__(self, text: Input) -> list[Claim]:
+    async def __call__(
+        self,
+        text: Input,
+        *,
+        on_partial: Callable[[object], None] | None = None,
+    ) -> list[Claim]:
         """Wrap ``text`` as a single claim.
 
         Args:
             text: Input to turn into claims.
+            on_partial: Ignored; this component produces its result in one step.
 
         Returns:
             One claim holding the full input content, or an empty list when the

--- a/src/openfactcheck/components/dummy/query_generator.py
+++ b/src/openfactcheck/components/dummy/query_generator.py
@@ -1,5 +1,6 @@
 """Dummy query generator."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from openfactcheck.components.types import Claim, Query
@@ -13,11 +14,17 @@ class DummyQueryGenerator:
     retriever has nothing to search for.
     """
 
-    async def __call__(self, claim: Claim) -> Query:
+    async def __call__(
+        self,
+        claim: Claim,
+        *,
+        on_partial: Callable[[object], None] | None = None,
+    ) -> Query:
         """Return a query carrying ``claim`` with no questions.
 
         Args:
             claim: Claim to generate queries for.
+            on_partial: Ignored; this component produces its result in one step.
 
         Returns:
             A query holding ``claim`` and an empty question list.

--- a/src/openfactcheck/components/dummy/verifier.py
+++ b/src/openfactcheck/components/dummy/verifier.py
@@ -1,5 +1,6 @@
 """Dummy verifier."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from openfactcheck.components.types import Claim, Evidence, Verdict
@@ -12,12 +13,19 @@ class DummyVerifier:
     Returns a fixed inconclusive verdict for any claim, ignoring the evidence.
     """
 
-    async def __call__(self, claim: Claim, evidence: Evidence) -> Verdict:
+    async def __call__(
+        self,
+        claim: Claim,
+        evidence: Evidence,
+        *,
+        on_partial: Callable[[object], None] | None = None,
+    ) -> Verdict:
         """Return a fixed inconclusive verdict for ``claim``.
 
         Args:
             claim: Claim under evaluation.
             evidence: Sources bearing on the claim; ignored.
+            on_partial: Ignored; this component produces its result in one step.
 
         Returns:
             A verdict labelled ``not_enough_evidence`` with zero confidence.

--- a/src/openfactcheck/components/protocols.py
+++ b/src/openfactcheck/components/protocols.py
@@ -6,6 +6,7 @@ implementation must match. Implementations live in sibling subpackages
 interchangeable with any other implementation of the same category.
 """
 
+from collections.abc import Callable
 from typing import Protocol, runtime_checkable
 
 from openfactcheck.components.types import Assessment, Claim, Evidence, Input, Query, Verdict
@@ -19,11 +20,15 @@ class ClaimProcessor(Protocol):
     valid (for example, when the input contains no checkable claims).
     """
 
-    async def __call__(self, text: Input) -> list[Claim]:
+    async def __call__(self, text: Input, *, on_partial: Callable[[object], None] | None = None) -> list[Claim]:
         """Produce atomic claims from ``text``.
 
         Args:
             text: Input text to process into claims.
+            on_partial: Optional sink called with the in-progress result as it
+                streams in, each call carrying more of it. Omit it for a single
+                non-streaming call; an implementation without streaming may
+                ignore it.
 
         Returns:
             Atomic factual claims drawn from ``text``; empty when there are
@@ -41,11 +46,15 @@ class QueryGenerator(Protocol):
     any number of questions.
     """
 
-    async def __call__(self, claim: Claim) -> Query:
+    async def __call__(self, claim: Claim, *, on_partial: Callable[[object], None] | None = None) -> Query:
         """Generate a query for ``claim``.
 
         Args:
             claim: Claim to fetch evidence for.
+            on_partial: Optional sink called with the in-progress result as it
+                streams in, each call carrying more of it. Omit it for a single
+                non-streaming call; an implementation without streaming may
+                ignore it.
 
         Returns:
             Search query derived from the claim.
@@ -81,12 +90,18 @@ class Retriever(Protocol):
 class Verifier(Protocol):
     """Decide whether evidence supports, refutes, or is insufficient for a claim."""
 
-    async def __call__(self, claim: Claim, evidence: Evidence) -> Verdict:
+    async def __call__(
+        self, claim: Claim, evidence: Evidence, *, on_partial: Callable[[object], None] | None = None
+    ) -> Verdict:
         """Verify ``claim`` against ``evidence``.
 
         Args:
             claim: Claim under evaluation.
             evidence: Sources bearing on the claim's truthfulness.
+            on_partial: Optional sink called with the in-progress result as it
+                streams in, each call carrying more of it. Omit it for a single
+                non-streaming call; an implementation without streaming may
+                ignore it.
 
         Returns:
             Verdict describing whether the evidence supports, refutes, or

--- a/src/openfactcheck/graph/graph.py
+++ b/src/openfactcheck/graph/graph.py
@@ -569,7 +569,9 @@ class _GraphRun[StateT, DepsT, OutputT]:
     async def _worker(self, node_id: str, value: object, stack: ForkStack, task_id: int) -> None:
         """Run one step, with retries and timeout, and report its result."""
         step = self._spec.steps[node_id]
-        ctx: StepContext[object, StateT, DepsT] = StepContext(inputs=value, state=self._state, deps=self._deps)
+        ctx: StepContext[object, StateT, DepsT] = StepContext(
+            inputs=value, state=self._state, deps=self._deps, streaming=self._stream_node_data
+        )
         if self._stream_node_data:
 
             def emit(data: object) -> None:

--- a/src/openfactcheck/graph/step.py
+++ b/src/openfactcheck/graph/step.py
@@ -84,6 +84,15 @@ class StepContext(Generic[InputT, StateT, DepsT]):
     node can emit unconditionally at no cost when nothing observes it.
     """
 
+    streaming: bool = False
+    """Whether emitted data is observed on this run.
+
+    True only when the run sets ``stream_node_data`` on
+    [`RunOptions`][openfactcheck.graph.RunOptions]. A node that can stream partial
+    results (for instance through a component's ``on_partial`` hook) should do so
+    only when this is set, and take its cheaper one-shot path otherwise.
+    """
+
 
 @dataclass(frozen=True, slots=True)
 class Step[InputT, OutputT, StateT, DepsT]:

--- a/src/openfactcheck/pipeline/pipeline.py
+++ b/src/openfactcheck/pipeline/pipeline.py
@@ -1,9 +1,9 @@
 """The runnable fact-check pipeline and the default graph that powers it.
 
-A [`Pipeline`][openfactcheck.pipeline.Pipeline] pairs a built
-[`Graph`][openfactcheck.graph.Graph] with the [`Components`][openfactcheck.pipeline.Components] that fill
+A [`Pipeline`][Pipeline] pairs a built
+[`Graph`][Graph] with the [`Components`][Components] that fill
 it, exposing a plain ``run(text) -> Report`` surface so a caller never touches the graph's
-``state``/``deps`` plumbing. [`build_graph`][openfactcheck.pipeline.build_graph] builds the
+``state``/``deps`` plumbing. [`build_graph`][build_graph] builds the
 default claim-to-verdict topology; an established pipeline pairs that graph with a component family (see the
 ``factool`` module).
 
@@ -13,11 +13,12 @@ result = pipeline.run("The capital of Australia is Sydney.")
 ```
 """
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
 from openfactcheck.components.protocols import Aggregator, ClaimProcessor, QueryGenerator, Retriever, Verifier
 from openfactcheck.components.types import Claim, Evidence, Input, Query, Report, Verdict
-from openfactcheck.graph import Graph, GraphBuilder, StepContext
+from openfactcheck.graph import Graph, GraphBuilder, GraphEvent, RunOptions, StepContext
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,13 +61,11 @@ def build_graph() -> Graph[Input, Report, PipelineState, Components]:
     generate queries, retrieve evidence, and verify each claim concurrently,
     collects the checked claims, and assembles them with an overall judgment
     into a result. Supply the components as ``deps`` and a fresh
-    [`PipelineState`][openfactcheck.pipeline.PipelineState] as ``state`` when running it, or wrap it in a
-    [`Pipeline`][openfactcheck.pipeline.Pipeline] that does so.
+    [`PipelineState`][PipelineState] as ``state`` when running it, or wrap it in a
+    [`Pipeline`][Pipeline] that does so.
 
     Returns:
-        A built [`Graph`][openfactcheck.graph.Graph] taking an
-        [`Input`][openfactcheck.components.types.Input] and returning a
-        [`Report`][openfactcheck.components.types.Report].
+        A built [`Graph`][Graph] taking an [`Input`][Input] and returning a [`Report`][Report].
     """
     g = GraphBuilder(
         deps_type=Components,
@@ -78,11 +77,11 @@ def build_graph() -> Graph[Input, Report, PipelineState, Components]:
     @g.step_node
     async def claim_processor(ctx: StepContext[Input, PipelineState, Components]) -> list[Claim]:
         ctx.state.input = ctx.inputs
-        return await ctx.deps.claim_processor(ctx.inputs)
+        return await ctx.deps.claim_processor(ctx.inputs, on_partial=ctx.emit if ctx.streaming else None)
 
     @g.step_node
     async def query_generator(ctx: StepContext[Claim, PipelineState, Components]) -> Query:
-        return await ctx.deps.query_generator(ctx.inputs)
+        return await ctx.deps.query_generator(ctx.inputs, on_partial=ctx.emit if ctx.streaming else None)
 
     @g.step_node
     async def retriever(ctx: StepContext[Query, PipelineState, Components]) -> Evidence:
@@ -90,7 +89,7 @@ def build_graph() -> Graph[Input, Report, PipelineState, Components]:
 
     @g.step_node
     async def verifier(ctx: StepContext[Evidence, PipelineState, Components]) -> Verdict:
-        verdict = await ctx.deps.verifier(ctx.inputs.claim, ctx.inputs)
+        verdict = await ctx.deps.verifier(ctx.inputs.claim, ctx.inputs, on_partial=ctx.emit if ctx.streaming else None)
         return verdict.model_copy(update={"evidence": ctx.inputs})
 
     @g.step_node
@@ -117,8 +116,8 @@ class Pipeline:
 
     Pairs a built graph with the components that fill it, and hides the graph's
     run-time plumbing (wrapping the input, a fresh state, and the component
-    dependencies) behind [`run`][openfactcheck.pipeline.Pipeline.run] and its async peer
-    [`arun`][openfactcheck.pipeline.Pipeline.arun].
+    dependencies) behind [`run`][Pipeline.run], its async peer [`arun`][Pipeline.arun], and the
+    event-streaming [`astream`][Pipeline.astream].
     """
 
     graph: Graph[Input, Report, PipelineState, Components]
@@ -132,25 +131,45 @@ class Pipeline:
 
         Args:
             text: The content to check, as a string or an
-                [`Input`][openfactcheck.components.types.Input].
+                [`Input`][Input].
 
         Returns:
             The completed fact-check result.
         """
-        return self.graph.run(self._as_input(text), state=PipelineState(), deps=self.components)
+        source = text if isinstance(text, Input) else Input(content=text)
+        return self.graph.run(source, state=PipelineState(), deps=self.components)
 
     async def arun(self, text: str | Input) -> Report:
         """Fact-check text and return the assembled result.
 
         Args:
             text: The content to check, as a string or an
-                [`Input`][openfactcheck.components.types.Input].
+                [`Input`][Input].
 
         Returns:
             The completed fact-check result.
         """
-        return await self.graph.arun(self._as_input(text), state=PipelineState(), deps=self.components)
+        source = text if isinstance(text, Input) else Input(content=text)
+        return await self.graph.arun(source, state=PipelineState(), deps=self.components)
 
-    @staticmethod
-    def _as_input(text: str | Input) -> Input:
-        return text if isinstance(text, Input) else Input(content=text)
+    def astream(self, text: str | Input, *, stream_partials: bool = False) -> AsyncIterator[GraphEvent]:
+        """Fact-check text and stream progress events as the run unfolds.
+
+        Yields the run's node-level events: a node started, then finished (or
+        failed), and a final run-finished. With ``stream_partials`` set, the
+        streaming-capable components also surface their in-progress result as
+        [`NodeEmitted`][openfactcheck.graph.NodeEmitted] events while they run, for
+        token-by-token progress.
+
+        Args:
+            text: The content to check, as a string or an
+                [`Input`][Input].
+            stream_partials: Also stream each component's in-progress result, not
+                just the node-level events.
+
+        Returns:
+            An async iterator over the run's [`GraphEvent`][GraphEvent]s.
+        """
+        source = text if isinstance(text, Input) else Input(content=text)
+        options = RunOptions(stream_node_data=stream_partials)
+        return self.graph.astream(source, state=PipelineState(), deps=self.components, options=options)

--- a/tests/graph/test_streaming.py
+++ b/tests/graph/test_streaming.py
@@ -172,3 +172,28 @@ def test_Graph_astream_node_data_tagged_by_fork_branch() -> None:
     assert {e.data for e in emitted} == {"a", "b", "c"}
     # Each mapped item ran in its own branch, so every emission carries a distinct fork stack.
     assert len({e.fork_stack for e in emitted}) == 3
+
+
+def test_StepContext_streaming_reflects_run_option() -> None:
+    g = GraphBuilder(input_type=str, output_type=str, state_type=list)
+
+    @g.step_node
+    async def record(ctx: StepContext[str, list[bool]]) -> str:
+        ctx.state.append(ctx.streaming)
+        return ctx.inputs
+
+    g.add(
+        g.edge_from(g.start_node).to(record),
+        g.edge_from(record).to(g.end_node),
+    )
+    graph = g.build()
+
+    default_state: list[bool] = []
+    graph.run("x", state=default_state, deps=None)
+
+    streaming_state: list[bool] = []
+    graph.run("x", state=streaming_state, deps=None, options=RunOptions(stream_node_data=True))
+
+    # The flag mirrors stream_node_data: a node knows when its emitted data is observed.
+    assert default_state == [False]
+    assert streaming_state == [True]

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,6 +1,7 @@
 """Tests for the fact-check pipeline and its default graph."""
 
 import asyncio
+from collections.abc import AsyncIterator, Callable
 
 from openfactcheck.components.dummy import (
     DummyAggregator,
@@ -10,25 +11,35 @@ from openfactcheck.components.dummy import (
     DummyVerifier,
 )
 from openfactcheck.components.protocols import Retriever
-from openfactcheck.components.types import Assessment, Claim, Evidence, Input, Query, Source, Verdict
+from openfactcheck.components.types import Assessment, Claim, Evidence, Input, Query, Report, Source, Verdict
+from openfactcheck.graph import GraphEvent, NodeEmitted, RunFinished
 from openfactcheck.pipeline import Components, Pipeline, PipelineState, build_graph
 
 
-async def _process(text: Input) -> list[Claim]:
-    return [Claim(text=sentence.strip()) for sentence in text.content.split(".") if sentence.strip()]
+async def _process(text: Input, *, on_partial: Callable[[object], None] | None = None) -> list[Claim]:
+    claims = [Claim(text=sentence.strip()) for sentence in text.content.split(".") if sentence.strip()]
+    if on_partial is not None:
+        on_partial(claims)
+    return claims
 
 
-async def _generate(claim: Claim) -> Query:
-    return Query(claim=claim, questions=[f"is '{claim.text}' true?"])
+async def _generate(claim: Claim, *, on_partial: Callable[[object], None] | None = None) -> Query:
+    query = Query(claim=claim, questions=[f"is '{claim.text}' true?"])
+    if on_partial is not None:
+        on_partial(query)
+    return query
 
 
 async def _retrieve(query: Query) -> Evidence:
     return Evidence(claim=query.claim, sources=[Source(content=f"evidence for {query.claim.text}")])
 
 
-async def _verify(claim: Claim, evidence: Evidence) -> Verdict:
+async def _verify(claim: Claim, evidence: Evidence, *, on_partial: Callable[[object], None] | None = None) -> Verdict:
     label = "supported" if evidence.sources else "not_enough_evidence"
-    return Verdict(claim=claim, label=label, confidence=0.9, reasoning="stub")
+    verdict = Verdict(claim=claim, label=label, confidence=0.9, reasoning="stub")
+    if on_partial is not None:
+        on_partial(verdict)
+    return verdict
 
 
 async def _aggregate(verdicts: list[Verdict]) -> Assessment:
@@ -162,3 +173,39 @@ def test_Pipeline_run_with_dummy_components() -> None:
     assert [v.label for v in result.verdicts] == ["not_enough_evidence"]
     assert result.assessment.label == "not_enough_evidence"
     assert result.assessment.score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Pipeline.astream: node-level events and opt-in token partials
+# ---------------------------------------------------------------------------
+
+
+async def _collect(stream: AsyncIterator[GraphEvent]) -> list[GraphEvent]:
+    return [event async for event in stream]
+
+
+def test_Pipeline_astream_emits_node_events() -> None:
+    pipeline = Pipeline(build_graph(), _stub_components())
+
+    events = asyncio.run(_collect(pipeline.astream("The sky is blue. Water is wet.")))
+
+    assert any(type(event).__name__ == "NodeStarted" for event in events)
+    assert isinstance(events[-1], RunFinished)
+    assert isinstance(events[-1].output, Report)
+
+
+def test_Pipeline_astream_omits_partials_by_default() -> None:
+    pipeline = Pipeline(build_graph(), _stub_components())
+
+    events = asyncio.run(_collect(pipeline.astream("The sky is blue.")))
+
+    # The components' on_partial is not bridged unless partial streaming is requested.
+    assert not any(isinstance(event, NodeEmitted) for event in events)
+
+
+def test_Pipeline_astream_streams_partials_when_requested() -> None:
+    pipeline = Pipeline(build_graph(), _stub_components())
+
+    events = asyncio.run(_collect(pipeline.astream("The sky is blue.", stream_partials=True)))
+
+    assert any(isinstance(event, NodeEmitted) for event in events)


### PR DESCRIPTION
Streams a fact-check run through the flat `Pipeline` surface, at two levels.

Stacked on #73 (`feat/pipeline-package`) — review/merge that first; the diff here is only the streaming work.

## Pipeline surface

- `Pipeline.astream(text, *, stream_partials=False) -> AsyncIterator[GraphEvent]` — wraps `graph.astream`, so a caller streams progress without touching the graph's `state`/`deps`.
- Default: **node-level** events (`NodeStarted` / `NodeFinished` / `RunFinished`).
- `stream_partials=True`: the LLM components additionally surface their in-progress structured result as `NodeEmitted` events while they run (token-by-token progress).

## Component contract (B1)

- `on_partial: Callable[[object], None] | None` (keyword-only) added to the `ClaimProcessor` / `QueryGenerator` / `Verifier` protocols. Typed `object` to keep the contract provider-agnostic; the Factool components keep their precise partial types and still conform by contravariance.
- The dummy components accept-and-ignore it.

## Gating (graph layer)

- New `StepContext.streaming` flag, set from `RunOptions.stream_node_data`. The Factool components take the no-retry streaming path whenever `on_partial` is non-`None`, so `build_graph`'s steps pass `on_partial=ctx.emit` **only** when `ctx.streaming` is set. That keeps `Pipeline.run`/`arun` (and plain `astream`) on the retrying one-shot path.

Green: `pyright src` 0, 617 tests (incl. astream node-events, partials-on, partials-off gating, and the `StepContext.streaming` flag), ruff + format, `mkdocs --strict`.
