### PR TITLE
feat: reuse one SDK client per chat backend with close/aclose

### DIFF
--- a/src/openfactcheck/chat/backends/anthropic/backend.py
+++ b/src/openfactcheck/chat/backends/anthropic/backend.py
@@ -47,13 +47,30 @@ class AnthropicBackend:
     must be set on the config.
     """
 
+    def __init__(self) -> None:
+        """Build the backend with no client yet; clients are created on first use."""
+        self._sync_client: Anthropic | None = None
+        self._async_client: AsyncAnthropic | None = None
+
     def _client(self, request: ChatRequest) -> Anthropic:
-        """Build a sync SDK client for ``request``."""
-        return load_anthropic()(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
+        """Return the reused sync SDK client, scoped to this request's runtime.
+
+        Builds the client once and shares its connection pool across calls; the
+        returned view overrides only the per-request timeout and retry count.
+        """
+        if self._sync_client is None:
+            self._sync_client = load_anthropic()()
+        return self._sync_client.with_options(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
 
     def _aclient(self, request: ChatRequest) -> AsyncAnthropic:
-        """Build an async SDK client for ``request``."""
-        return load_async_anthropic()(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
+        """Return the reused async SDK client, scoped to this request's runtime.
+
+        Builds the client once and shares its connection pool across calls; the
+        returned view overrides only the per-request timeout and retry count.
+        """
+        if self._async_client is None:
+            self._async_client = load_async_anthropic()()
+        return self._async_client.with_options(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
 
     def _prepare(self, request: ChatRequest) -> tuple[Kwargs, list[AnthropicInputMessage]]:
         """Build SDK kwargs and convert messages. System prompt is merged into kwargs."""
@@ -194,3 +211,21 @@ class AnthropicBackend:
             raise map_error(exc) from exc
 
         yield to_stream_end(stop_reason, input_tokens, output_tokens)
+
+    def close(self) -> None:
+        """Release the sync SDK client and its connection pool, if one was built.
+
+        Idempotent: the client is rebuilt on the next sync call.
+        """
+        if self._sync_client is not None:
+            self._sync_client.close()
+            self._sync_client = None
+
+    async def aclose(self) -> None:
+        """Release the async SDK client and its connection pool, if one was built.
+
+        Idempotent: the client is rebuilt on the next async call.
+        """
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None

--- a/src/openfactcheck/chat/backends/base.py
+++ b/src/openfactcheck/chat/backends/base.py
@@ -5,11 +5,16 @@ A backend owns the actual SDK call for a given provider.
 [`ChatClient`][ChatClient] talks to; the rest of the chat layer depends
 only on the protocol, never on a concrete backend.
 
-Four methods describe the full surface: sync and async variants of
+Four call methods describe the request surface: sync and async variants of
 single-shot completion and streaming. Implementations accept a
 [`ChatRequest`][ChatRequest] and produce a [`ChatResponse`][ChatResponse]
 or a stream of [`StreamEvent`][StreamEvent] values, mapping any SDK or
 transport error to a [`ChatModelError`][ChatModelError] subclass.
+
+A backend reuses one underlying client per axis across calls, so it owns a
+connection pool. The lifecycle pair `close` and `aclose` release that pool;
+[`ChatClient`][ChatClient] forwards them through its own lifecycle methods
+and context managers.
 
 See [`OpenAIBackend`][OpenAIBackend] for a reference implementation.
 """
@@ -97,5 +102,21 @@ class ChatBackend(Protocol):
 
         Raises:
             ChatModelError: On any failure.
+        """
+        ...
+
+    def close(self) -> None:
+        """Release the sync client and its connection pool.
+
+        Idempotent, and a no-op when no sync call has been made. Closes only
+        the sync side; call [`aclose`][ChatBackend.aclose] for the async side.
+        """
+        ...
+
+    async def aclose(self) -> None:
+        """Release the async client and its connection pool.
+
+        Idempotent, and a no-op when no async call has been made. Closes only
+        the async side; call [`close`][ChatBackend.close] for the sync side.
         """
         ...

--- a/src/openfactcheck/chat/backends/openai/backend.py
+++ b/src/openfactcheck/chat/backends/openai/backend.py
@@ -59,24 +59,28 @@ class OpenAIBackend:
         """
         self._base_url = base_url
         self._api_key = api_key
+        self._sync_client: OpenAI | None = None
+        self._async_client: AsyncOpenAI | None = None
 
     def _client(self, request: ChatRequest) -> OpenAI:
-        """Build a sync SDK client for ``request``."""
-        return load_openai()(
-            timeout=request.runtime.timeout,
-            max_retries=request.runtime.max_retries,
-            base_url=self._base_url,
-            api_key=self._api_key,
-        )
+        """Return the reused sync SDK client, scoped to this request's runtime.
+
+        Builds the client once and shares its connection pool across calls; the
+        returned view overrides only the per-request timeout and retry count.
+        """
+        if self._sync_client is None:
+            self._sync_client = load_openai()(base_url=self._base_url, api_key=self._api_key)
+        return self._sync_client.with_options(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
 
     def _aclient(self, request: ChatRequest) -> AsyncOpenAI:
-        """Build an async SDK client for ``request``."""
-        return load_async_openai()(
-            timeout=request.runtime.timeout,
-            max_retries=request.runtime.max_retries,
-            base_url=self._base_url,
-            api_key=self._api_key,
-        )
+        """Return the reused async SDK client, scoped to this request's runtime.
+
+        Builds the client once and shares its connection pool across calls; the
+        returned view overrides only the per-request timeout and retry count.
+        """
+        if self._async_client is None:
+            self._async_client = load_async_openai()(base_url=self._base_url, api_key=self._api_key)
+        return self._async_client.with_options(timeout=request.runtime.timeout, max_retries=request.runtime.max_retries)
 
     def _prepare(self, request: ChatRequest) -> tuple[Kwargs, list[OpenAIMessage]]:
         """Build SDK kwargs and convert messages for ``request``."""
@@ -213,3 +217,21 @@ class OpenAIBackend:
             raise map_error(exc) from exc
 
         yield to_stream_end(last_chunk, accumulated_usage)
+
+    def close(self) -> None:
+        """Release the sync SDK client and its connection pool, if one was built.
+
+        Idempotent: the client is rebuilt on the next sync call.
+        """
+        if self._sync_client is not None:
+            self._sync_client.close()
+            self._sync_client = None
+
+    async def aclose(self) -> None:
+        """Release the async SDK client and its connection pool, if one was built.
+
+        Idempotent: the client is rebuilt on the next async call.
+        """
+        if self._async_client is not None:
+            await self._async_client.close()
+            self._async_client = None

--- a/src/openfactcheck/chat/client.py
+++ b/src/openfactcheck/chat/client.py
@@ -28,7 +28,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Self, cast
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
@@ -65,6 +65,16 @@ class ChatClient:
     [`RateLimitError`][RateLimitError],
     [`ProviderError`][ProviderError], or
     [`UnsupportedFeatureError`][UnsupportedFeatureError].
+
+    The client keeps one pooled connection open across calls. Close it with
+    [`close`][ChatClient.close] (or a `with` block) for sync use, and
+    [`aclose`][ChatClient.aclose] (or an `async with` block) for async use, to
+    release the pool when done.
+
+    Note:
+        Use one client within a single event loop. Sharing a client across
+        separate `asyncio.run` calls reuses a pool bound to a loop that has
+        since closed; run the work under one loop instead.
     """
 
     def __init__(
@@ -450,3 +460,35 @@ class ChatClient:
                 raw=raw,
                 validation_error=exc,
             ) from exc
+
+    def close(self) -> None:
+        """Release the pooled sync connection.
+
+        Pairs with the sync call methods; safe to call more than once. Prefer a
+        `with` block, which calls this on exit.
+        """
+        self._backend.close()
+
+    async def aclose(self) -> None:
+        """Release the pooled async connection.
+
+        Pairs with the async call methods; safe to call more than once. Prefer an
+        `async with` block, which calls this on exit.
+        """
+        await self._backend.aclose()
+
+    def __enter__(self) -> Self:
+        """Enter a sync context that closes the client on exit."""
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        """Close the client on leaving a `with` block."""
+        self.close()
+
+    async def __aenter__(self) -> Self:
+        """Enter an async context that closes the client on exit."""
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        """Close the client on leaving an `async with` block."""
+        await self.aclose()

--- a/tests/chat/backends/anthropic/test_backend.py
+++ b/tests/chat/backends/anthropic/test_backend.py
@@ -58,14 +58,26 @@ async def _fake_astream_events():  # noqa: ANN202
         yield event
 
 
+def _fake_client(mocker, create, *, is_async: bool = False):  # noqa: ANN001, ANN202
+    """Wrap a ``create`` mock in a reusable, closable fake Anthropic client and its class.
+
+    ``with_options`` returns the same client, mirroring the SDK sharing one pool
+    across per-request views. ``close`` stands in for the SDK lifecycle method,
+    which is a coroutine on the async client.
+    """
+    client = SimpleNamespace(messages=SimpleNamespace(create=create))
+    client.with_options = lambda **_: client
+    client.close = mocker.AsyncMock() if is_async else mocker.MagicMock()
+    cls = mocker.MagicMock(return_value=client)
+    return cls, client
+
+
 def _patch_sync_client(mocker, response) -> object:  # noqa: ANN001
     """Mock the sync Anthropic client to return the given response."""
-    mock_client = SimpleNamespace(
-        messages=SimpleNamespace(create=mocker.MagicMock(return_value=response)),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=mock_cls)
-    return mock_client.messages.create
+    create = mocker.MagicMock(return_value=response)
+    cls, _ = _fake_client(mocker, create)
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=cls)
+    return create
 
 
 def _patch_async_client(mocker, response, *, is_coro: bool = True):  # noqa: ANN001, ANN202
@@ -80,11 +92,8 @@ def _patch_async_client(mocker, response, *, is_coro: bool = True):  # noqa: ANN
             return response
 
     mock_create = mocker.MagicMock(side_effect=_create)
-    mock_client = SimpleNamespace(
-        messages=SimpleNamespace(create=mock_create),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_async_anthropic", return_value=mock_cls)
+    cls, _ = _fake_client(mocker, mock_create, is_async=True)
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_async_anthropic", return_value=cls)
     return mock_create
 
 
@@ -132,11 +141,8 @@ def test_AnthropicBackend_completion_maps_errors_sync(mocker) -> None:  # noqa: 
         response=httpx.Response(status_code=401, request=httpx.Request("POST", "https://api.anthropic.com")),
         body=None,
     )
-    mock_client = SimpleNamespace(
-        messages=SimpleNamespace(create=mocker.MagicMock(side_effect=err)),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=mock_cls)
+    cls, _ = _fake_client(mocker, mocker.MagicMock(side_effect=err))
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=cls)
     backend = AnthropicBackend()
 
     with pytest.raises(AuthenticationError):
@@ -256,3 +262,72 @@ async def test_AnthropicBackend_astream_surfaces_tool_input_json(mocker) -> None
 
     deltas = [e for e in events if isinstance(e, TextDelta)]
     assert "".join(d.content for d in deltas) == '{"name": "Ada", "age": 36}'
+
+
+# ---------------------------------------------------------------------------
+# Client reuse and lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_AnthropicBackend_reuses_one_sync_client(mocker) -> None:  # noqa: ANN001
+    """The sync client is built once and reused across calls."""
+    cls, _ = _fake_client(mocker, mocker.MagicMock(return_value=_fake_response()))
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=cls)
+    backend = AnthropicBackend()
+
+    backend.completion(_build_request())
+    backend.completion(_build_request())
+
+    assert cls.call_count == 1
+
+
+def test_AnthropicBackend_close_releases_sync_client(mocker) -> None:  # noqa: ANN001
+    """close shuts the sync client, is idempotent, and lets a later call rebuild it."""
+    cls, client = _fake_client(mocker, mocker.MagicMock(return_value=_fake_response()))
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_anthropic", return_value=cls)
+    backend = AnthropicBackend()
+
+    backend.completion(_build_request())
+    backend.close()
+    backend.close()
+    backend.completion(_build_request())
+
+    client.close.assert_called_once()
+    assert cls.call_count == 2
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_AnthropicBackend_reuses_one_async_client(mocker) -> None:  # noqa: ANN001
+    """The async client is built once and reused across calls."""
+
+    async def _create(**kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        return _fake_response()
+
+    cls, _ = _fake_client(mocker, mocker.MagicMock(side_effect=_create), is_async=True)
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_async_anthropic", return_value=cls)
+    backend = AnthropicBackend()
+
+    await backend.acompletion(_build_request())
+    await backend.acompletion(_build_request())
+
+    assert cls.call_count == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_AnthropicBackend_aclose_releases_async_client(mocker) -> None:  # noqa: ANN001
+    """aclose shuts the async client, is idempotent, and lets a later call rebuild it."""
+
+    async def _create(**kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        return _fake_response()
+
+    cls, client = _fake_client(mocker, mocker.MagicMock(side_effect=_create), is_async=True)
+    mocker.patch("openfactcheck.chat.backends.anthropic.backend.load_async_anthropic", return_value=cls)
+    backend = AnthropicBackend()
+
+    await backend.acompletion(_build_request())
+    await backend.aclose()
+    await backend.aclose()
+    await backend.acompletion(_build_request())
+
+    client.close.assert_awaited_once()
+    assert cls.call_count == 2

--- a/tests/chat/backends/openai/test_backend.py
+++ b/tests/chat/backends/openai/test_backend.py
@@ -54,16 +54,26 @@ async def _fake_astream_chunks():  # noqa: ANN202
         yield chunk
 
 
+def _fake_client(mocker, create, *, is_async: bool = False):  # noqa: ANN001, ANN202
+    """Wrap a ``create`` mock in a reusable, closable fake OpenAI client and its class.
+
+    ``with_options`` returns the same client, mirroring the SDK sharing one pool
+    across per-request views. ``close`` stands in for the SDK lifecycle method,
+    which is a coroutine on the async client.
+    """
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    client.with_options = lambda **_: client
+    client.close = mocker.AsyncMock() if is_async else mocker.MagicMock()
+    cls = mocker.MagicMock(return_value=client)
+    return cls, client
+
+
 def _patch_sync_client(mocker, response) -> object:  # noqa: ANN001
     """Mock the sync OpenAI client to return the given response."""
-    mock_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(create=mocker.MagicMock(return_value=response)),
-        ),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=mock_cls)
-    return mock_client.chat.completions.create
+    create = mocker.MagicMock(return_value=response)
+    cls, _ = _fake_client(mocker, create)
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=cls)
+    return create
 
 
 def _patch_async_client(mocker, response, *, is_coro: bool = True):  # noqa: ANN001, ANN202
@@ -78,11 +88,8 @@ def _patch_async_client(mocker, response, *, is_coro: bool = True):  # noqa: ANN
             return response
 
     mock_create = mocker.MagicMock(side_effect=_create)
-    mock_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=mock_create)),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.openai.backend.load_async_openai", return_value=mock_cls)
+    cls, _ = _fake_client(mocker, mock_create, is_async=True)
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_async_openai", return_value=cls)
     return mock_create
 
 
@@ -116,13 +123,8 @@ def test_OpenAIBackend_completion_maps_errors_sync(mocker) -> None:  # noqa: ANN
         response=httpx.Response(status_code=401, request=httpx.Request("POST", "https://api.openai.com")),
         body=None,
     )
-    mock_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(create=mocker.MagicMock(side_effect=err)),
-        ),
-    )
-    mock_cls = mocker.MagicMock(return_value=mock_client)
-    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=mock_cls)
+    cls, _ = _fake_client(mocker, mocker.MagicMock(side_effect=err))
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=cls)
     backend = OpenAIBackend()
 
     with pytest.raises(AuthenticationError):
@@ -186,3 +188,72 @@ async def test_OpenAIBackend_astream_yields_events(mocker) -> None:  # noqa: ANN
     assert ends[0].finish_reason == FinishReason.STOP
     assert ends[0].usage is not None
     assert ends[0].usage.output_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# Client reuse and lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_OpenAIBackend_reuses_one_sync_client(mocker) -> None:  # noqa: ANN001
+    """The sync client is built once and reused across calls."""
+    cls, _ = _fake_client(mocker, mocker.MagicMock(return_value=_fake_response()))
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=cls)
+    backend = OpenAIBackend()
+
+    backend.completion(_build_request())
+    backend.completion(_build_request())
+
+    assert cls.call_count == 1
+
+
+def test_OpenAIBackend_close_releases_sync_client(mocker) -> None:  # noqa: ANN001
+    """close shuts the sync client, is idempotent, and lets a later call rebuild it."""
+    cls, client = _fake_client(mocker, mocker.MagicMock(return_value=_fake_response()))
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=cls)
+    backend = OpenAIBackend()
+
+    backend.completion(_build_request())
+    backend.close()
+    backend.close()
+    backend.completion(_build_request())
+
+    client.close.assert_called_once()
+    assert cls.call_count == 2
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_OpenAIBackend_reuses_one_async_client(mocker) -> None:  # noqa: ANN001
+    """The async client is built once and reused across calls."""
+
+    async def _create(**kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        return _fake_response()
+
+    cls, _ = _fake_client(mocker, mocker.MagicMock(side_effect=_create), is_async=True)
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_async_openai", return_value=cls)
+    backend = OpenAIBackend()
+
+    await backend.acompletion(_build_request())
+    await backend.acompletion(_build_request())
+
+    assert cls.call_count == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_OpenAIBackend_aclose_releases_async_client(mocker) -> None:  # noqa: ANN001
+    """aclose shuts the async client, is idempotent, and lets a later call rebuild it."""
+
+    async def _create(**kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        return _fake_response()
+
+    cls, client = _fake_client(mocker, mocker.MagicMock(side_effect=_create), is_async=True)
+    mocker.patch("openfactcheck.chat.backends.openai.backend.load_async_openai", return_value=cls)
+    backend = OpenAIBackend()
+
+    await backend.acompletion(_build_request())
+    await backend.aclose()
+    await backend.aclose()
+    await backend.acompletion(_build_request())
+
+    client.close.assert_awaited_once()
+    assert cls.call_count == 2

--- a/tests/chat/backends/openrouter/test_backend.py
+++ b/tests/chat/backends/openrouter/test_backend.py
@@ -44,6 +44,8 @@ def _patch_sync_client(mocker) -> object:  # noqa: ANN001
             completions=SimpleNamespace(create=mocker.MagicMock(return_value=_fake_response())),
         ),
     )
+    mock_client.with_options = lambda **_: mock_client
+    mock_client.close = mocker.MagicMock()
     mock_cls = mocker.MagicMock(return_value=mock_client)
     mocker.patch("openfactcheck.chat.backends.openai.backend.load_openai", return_value=mock_cls)
     return mock_cls

--- a/tests/chat/test_client.py
+++ b/tests/chat/test_client.py
@@ -67,6 +67,20 @@ class FakeBackend:
         yield StreamEnd(finish_reason=FinishReason.STOP, usage=Usage(input_tokens=5, output_tokens=3))
 
 
+class _LifecycleBackend:
+    """Backend double that records how often it is closed."""
+
+    def __init__(self) -> None:
+        self.closed = 0
+        self.aclosed = 0
+
+    def close(self) -> None:
+        self.closed += 1
+
+    async def aclose(self) -> None:
+        self.aclosed += 1
+
+
 @pytest.fixture()
 def fake_response() -> ChatResponse:
     """A canned ChatResponse for testing."""
@@ -393,3 +407,50 @@ def test_ChatClient_stream_with_response_model_unsupported_raises(openai_config:
 
     with pytest.raises(UnsupportedFeatureError):
         list(client.stream([UserMessage(content="hi")], response_model=_Person))
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_ChatClient_close_delegates_to_backend(openai_config: OpenAIConfig) -> None:
+    """close forwards to the backend's sync lifecycle method."""
+    backend = _LifecycleBackend()
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    client.close()
+
+    assert backend.closed == 1
+
+
+def test_ChatClient_context_manager_closes(openai_config: OpenAIConfig) -> None:
+    """Leaving a with block closes the backend, and __enter__ yields the client."""
+    backend = _LifecycleBackend()
+
+    with ChatClient(config=openai_config, backend=backend) as client:  # type: ignore[arg-type]
+        assert isinstance(client, ChatClient)
+
+    assert backend.closed == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_aclose_delegates_to_backend(openai_config: OpenAIConfig) -> None:
+    """aclose forwards to the backend's async lifecycle method."""
+    backend = _LifecycleBackend()
+    client = ChatClient(config=openai_config, backend=backend)  # type: ignore[arg-type]
+
+    await client.aclose()
+
+    assert backend.aclosed == 1
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_ChatClient_async_context_manager_closes(openai_config: OpenAIConfig) -> None:
+    """Leaving an async with block closes the backend, and __aenter__ yields the client."""
+    backend = _LifecycleBackend()
+
+    async with ChatClient(config=openai_config, backend=backend) as client:  # type: ignore[arg-type]
+        assert isinstance(client, ChatClient)
+
+    assert backend.aclosed == 1


### PR DESCRIPTION
## What

Chat backends built a fresh provider SDK client on every call and never closed it. That discarded connection pooling (a TLS handshake per call) and, when a client outlived its event loop, the GC'd client's pool cleanup fired on a closed loop and flooded stderr with `RuntimeError: Event loop is closed`.

Each backend now lazily builds and reuses one client per axis (sync/async) and hands out per-request `with_options(timeout, max_retries)` views that share the pool, so per-request runtime behavior is unchanged. `ChatClient` and `ChatBackend` gain `close()`/`aclose()` plus `with`/`async with` to release the pool; OpenRouter inherits the OpenAI behavior.

## Verification

- `pyright src`: 0 errors
- chat suite + 12 new lifecycle tests: 629 passing
- `mkdocs build --strict`: clean
- Real-SDK check (no network): `with_options` views share one httpx pool, per-request timeout/retries honored, `close`/`aclose` shut the pool and reset to lazy.

Closes #74.