### PR TITLE
feat: port FactcheckGPT pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ api = [
 cloud = [
     "boto3>=1.43",
 ]
+factcheckgpt = [
+    "beautifulsoup4>=4.15.0",
+    "sentence-transformers>=5.6.0",
+]
 
 ###############################################################################
 # Build System
@@ -110,6 +114,21 @@ reportUnknownArgumentType = false
 reportAttributeAccessIssue = false
 reportArgumentType = false
 reportCallIssue = false
+
+# Optional [factcheckgpt] deps (beautifulsoup4, sentence-transformers) are not
+# installed in the base dev env; they are lazily imported and mocked in tests,
+# so their symbols are unresolved and pyright cannot infer their types here.
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/integrations/google_scraper"
+reportMissingImports = false
+reportMissingModuleSource = false
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportUnknownArgumentType = false
+reportUnknownParameterType = false
+reportUnknownLambdaType = false
+reportAttributeAccessIssue = false
+reportArgumentType = false
 
 ###############################################################################
 # Linting

--- a/src/openfactcheck/components/__init__.py
+++ b/src/openfactcheck/components/__init__.py
@@ -2,7 +2,7 @@
 
 A component is a callable implementing one of the category contracts:
 ``ClaimProcessor``, ``Retriever``, ``Verifier``, and ``Aggregator`` (plus the
-optional ``QueryGenerator``). Any implementation of a contract is
+optional ``QueryGenerator`` and ``Reviser``). Any implementation of a contract is
 interchangeable with any other. The contracts are defined in terms of the data
 types in this layer (``Claim``, ``Evidence``, ``Verdict``, and so on). Import
 both from ``openfactcheck.components``; concrete implementations live in
@@ -14,6 +14,7 @@ from openfactcheck.components.protocols import (
     ClaimProcessor,
     QueryGenerator,
     Retriever,
+    Reviser,
     Verifier,
 )
 from openfactcheck.components.provenance import Provenance
@@ -36,6 +37,7 @@ __all__ = [
     "ClaimProcessor",
     "QueryGenerator",
     "Retriever",
+    "Reviser",
     "Verifier",
 ]
 

--- a/src/openfactcheck/components/factcheckgpt/__init__.py
+++ b/src/openfactcheck/components/factcheckgpt/__init__.py
@@ -1,0 +1,91 @@
+"""FactcheckGPT components.
+
+A port of the FactcheckGPT pipeline from Wang et al. (2024). The components
+mirror the paper's stages: decompose the response into atomic checkworthy
+claims, generate search queries, retrieve web evidence, verify each claim
+against that evidence (with a correction when it is wrong), aggregate to a
+response-level judgment, and revise the response to fix its errors.
+
+The LLM components run on an injected chat client;
+[`PROVENANCE`][openfactcheck.components.factcheckgpt.PROVENANCE] records the
+recommended default model along with the source paper, repository, pinned
+commit, and license. Import from ``openfactcheck.components.factcheckgpt``.
+"""
+
+from typing import TYPE_CHECKING
+
+from openfactcheck.components.factcheckgpt.aggregator import FactcheckGPTAggregator
+from openfactcheck.components.factcheckgpt.claim_processor import ClaimExtraction, FactcheckGPTClaimProcessor
+from openfactcheck.components.factcheckgpt.query_generator import FactcheckGPTQueryGenerator, GeneratedQueries
+from openfactcheck.components.factcheckgpt.retriever import FactcheckGPTRetriever
+from openfactcheck.components.factcheckgpt.reviser import FactcheckGPTReviser, Revision
+from openfactcheck.components.factcheckgpt.verifier import FactcheckGPTVerifier, Verification
+from openfactcheck.components.provenance import Provenance
+
+_CITATION = """\
+@inproceedings{wang-etal-2024-factcheck-bench,
+    title={Factcheck-Bench: Fine-Grained Evaluation Benchmark for Automatic Fact-Checkers},
+    author={Wang, Yuxia and Reddy, Revanth Gangi and Mujahid, Zain Muhammad and
+            Arora, Arnav and Rubashevskii, Aleksandr and Geng, Jiahui and
+            Mohammed Afzal, Osama and Pan, Liangming and Borenstein, Nadav and
+            Pillai, Aditya and Augenstein, Isabelle and Gurevych, Iryna and
+            Nakov, Preslav},
+    booktitle={Findings of the Association for Computational Linguistics: EMNLP 2024},
+    year={2024},
+    url={https://aclanthology.org/2024.findings-emnlp.830/},
+}"""
+
+PROVENANCE = Provenance(
+    paper_title="Factcheck-Bench: Fine-Grained Evaluation Benchmark for Automatic Fact-Checkers",
+    paper_url="https://aclanthology.org/2024.findings-emnlp.830/",
+    citation=_CITATION,
+    repository_url="https://github.com/yuxiaw/Factcheck-GPT",
+    repository_commit="a9e6a04a953ad880806529c504a679dd1ad06528",
+    license="Apache-2.0",
+    default_model="gpt-4o-mini",
+    paper_models=("gpt-3.5-turbo-0613",),
+)
+"""Provenance for the FactcheckGPT components."""
+
+# Components
+__all__ = [
+    "FactcheckGPTAggregator",
+    "FactcheckGPTClaimProcessor",
+    "FactcheckGPTQueryGenerator",
+    "FactcheckGPTRetriever",
+    "FactcheckGPTReviser",
+    "FactcheckGPTVerifier",
+]
+
+# Structured outputs (the value each component's ``on_partial`` hook streams)
+__all__ += [
+    "ClaimExtraction",
+    "GeneratedQueries",
+    "Revision",
+    "Verification",
+]
+
+# Provenance
+__all__ += [
+    "PROVENANCE",
+]
+
+
+if TYPE_CHECKING:
+    from openfactcheck.components.protocols import (
+        Aggregator,
+        ClaimProcessor,
+        QueryGenerator,
+        Retriever,
+        Reviser,
+        Verifier,
+    )
+
+    # Type-only conformance: each FactcheckGPT component must satisfy its category protocol,
+    # so pyright fails the gate the moment one drifts. Absent at runtime.
+    _processor: type[ClaimProcessor] = FactcheckGPTClaimProcessor
+    _generator: type[QueryGenerator] = FactcheckGPTQueryGenerator
+    _retriever: type[Retriever] = FactcheckGPTRetriever
+    _verifier: type[Verifier] = FactcheckGPTVerifier
+    _aggregator: type[Aggregator] = FactcheckGPTAggregator
+    _reviser: type[Reviser] = FactcheckGPTReviser

--- a/src/openfactcheck/components/factcheckgpt/aggregator.py
+++ b/src/openfactcheck/components/factcheckgpt/aggregator.py
@@ -1,0 +1,31 @@
+"""FactcheckGPT aggregator."""
+
+from dataclasses import dataclass
+
+from openfactcheck.components.types import Assessment, Verdict
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTAggregator:
+    """Combine per-claim verdicts with FactcheckGPT's response-level rule.
+
+    A response is factual only when every claim is supported; a single
+    unsupported claim makes the whole response non-factual. The score reports
+    the fraction of supported claims.
+    """
+
+    async def __call__(self, verdicts: list[Verdict]) -> Assessment:
+        """Aggregate per-claim verdicts into one overall judgment.
+
+        Args:
+            verdicts: Per-claim verdicts; may be empty.
+
+        Returns:
+            An overall judgment labelled ``factual`` or ``non_factual``, or
+            ``not_enough_evidence`` when there are no verdicts.
+        """
+        if not verdicts:
+            return Assessment(label="not_enough_evidence", score=0.0)
+        supported = sum(1 for verdict in verdicts if verdict.label == "supported")
+        label = "factual" if supported == len(verdicts) else "non_factual"
+        return Assessment(label=label, score=supported / len(verdicts))

--- a/src/openfactcheck/components/factcheckgpt/claim_processor.py
+++ b/src/openfactcheck/components/factcheckgpt/claim_processor.py
@@ -1,0 +1,78 @@
+"""FactcheckGPT claim processor."""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.components.types import Claim, Input
+from openfactcheck.messages import Message
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class ClaimExtraction(BaseModel):
+    """FactcheckGPT's structured claim-decomposition result.
+
+    The claim processor maps this onto a list of
+    [`Claim`][openfactcheck.components.types.Claim]. It is also the value handed
+    to a call's ``on_partial`` hook, the claim list growing as the model writes it.
+    """
+
+    claims: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTClaimProcessor:
+    """Decompose text into atomic, checkworthy claims, following FactcheckGPT's method.
+
+    One call decomposes the input into context-independent atomic claims and
+    keeps only the ones worth checking, dropping opinions, questions, and other
+    non-factual text.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(
+        default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "claim_processor.md")
+    )
+    """The claim-extraction prompt. Defaults to FactcheckGPT's; override to customise."""
+
+    async def __call__(
+        self,
+        text: Input,
+        *,
+        on_partial: Callable[[ClaimExtraction], None] | None = None,
+    ) -> list[Claim]:
+        """Decompose ``text`` into atomic, checkworthy claims.
+
+        Args:
+            text: Input text to process into claims.
+            on_partial: Called with the extraction as it streams in, each call
+                carrying the claims found so far. Omit it for a single
+                non-streaming call. The returned claims are the same either way.
+
+        Returns:
+            The checkworthy atomic claims; empty when the model finds none.
+        """
+        messages = self.prompt.to_messages(input=text.content)
+        result = (
+            await self.client.acompletion_as(messages, ClaimExtraction)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return [Claim(text=claim) for claim in result.claims]
+
+    async def _stream(self, messages: list[Message], on_partial: Callable[[ClaimExtraction], None]) -> ClaimExtraction:
+        """Stream the extraction, forwarding each partial result to ``on_partial``."""
+        result: ClaimExtraction | None = None
+        async for partial in self.client.astream_as(messages, ClaimExtraction):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("claim processor stream produced no value")
+        return result

--- a/src/openfactcheck/components/factcheckgpt/prompts/claim_processor.md
+++ b/src/openfactcheck/components/factcheckgpt/prompts/claim_processor.md
@@ -1,0 +1,52 @@
+---
+name: claim_processor
+description: Decompose text into atomic, context-independent, checkworthy factual claims.
+variables:
+  input:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are good at decomposing and decontextualizing text.
+
+</system>
+
+<user>
+
+# User Prompt
+
+Your task is to decompose the text into atomic claims, keeping only the ones worth fact-checking.
+
+- Each claim should be a context-independent claim, representing one fact. Resolve coreferences (pronouns and other referring expressions) to the entities they refer to, so each claim stands on its own.
+- Keep only **checkworthy** claims: factual statements that can be verified. Drop opinions, questions, imperatives, and anything else that is not a verifiable fact.
+
+## Examples
+
+**Text:**
+
+> Mary is a five-year old girl, she likes playing piano and she doesn't like cookies.
+
+**Claims:**
+
+- Mary is a five-year old girl.
+- Mary likes playing piano.
+- Mary doesn't like cookies.
+
+**Text:**
+
+> I think Apple is a great company. Apple was founded in 1976 by Steve Jobs and Steve Wozniak.
+
+**Claims:**
+
+- Apple was founded in 1976.
+- Apple was founded by Steve Jobs and Steve Wozniak.
+
+## Text to decompose
+
+{{input}}
+
+</user>

--- a/src/openfactcheck/components/factcheckgpt/prompts/query_generator.md
+++ b/src/openfactcheck/components/factcheckgpt/prompts/query_generator.md
@@ -1,0 +1,73 @@
+---
+name: query_generator
+description: Generate web search queries that help verify a claim.
+variables:
+  input:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a helpful factchecker assistant.
+
+</system>
+
+<user>
+
+# User Prompt
+
+I will check things you said and ask questions. For the given claim, generate the search engine queries you would look up to verify it.
+
+## Examples
+
+**Claim:** Your nose switches back and forth between nostrils. When you sleep, you switch about every 45 minutes. This is to prevent a buildup of mucus. It's called the nasal cycle.
+
+**Queries:**
+
+- Does your nose switch between nostrils?
+- How often does your nostrils switch?
+- Why does your nostril switch?
+- What is nasal cycle?
+
+**Claim:** The Stanford Prison Experiment was conducted in the basement of Encina Hall, Stanford's psychology building.
+
+**Queries:**
+
+- Where was Stanford Prison Experiment conducted?
+
+**Claim:** The Havel-Hakimi algorithm is an algorithm for converting the adjacency matrix of a graph into its adjacency list. It is named after Vaclav Havel and Samih Hakimi.
+
+**Queries:**
+
+- What does Havel-Hakimi algorithm do?
+- Who are Havel-Hakimi algorithm named after?
+
+**Claim:** "Time of My Life" is a song by American singer-songwriter Bill Medley from the soundtrack of the 1987 film Dirty Dancing. The song was produced by Michael Lloyd.
+
+**Queries:**
+
+- Who sings the song "Time of My Life"?
+- Which film is the song "Time of My Life" from?
+- Who produced the song "Time of My Life"?
+
+**Claim:** Kelvin Hopins was suspended from the Labor Party due to his membership in the Conservative Party.
+
+**Queries:**
+
+- Why was Kelvin Hopins suspended from Labor Party?
+
+**Claim:** Social work is a profession that is based in the philosophical tradition of humanism. It is an intellectual discipline that has its roots in the 1800s.
+
+**Queries:**
+
+- What philosophical tradition is social work based on?
+- What year does social work have its root in?
+
+## Claim to verify
+
+{{input}}
+
+</user>

--- a/src/openfactcheck/components/factcheckgpt/prompts/reviser.md
+++ b/src/openfactcheck/components/factcheckgpt/prompts/reviser.md
@@ -1,0 +1,35 @@
+---
+name: reviser
+description: Rewrite a document to fix its factual errors, preserving style.
+variables:
+  response:
+    type: string
+    required: true
+  claims:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a helpful factchecker assistant.
+
+</system>
+
+<user>
+
+# User Prompt
+
+Given a document containing factual errors, correct the errors in the document depending on a corresponding list of factually true claims. Preserve the linguistic features and style of the original document; only correct the factual errors.
+
+## Document
+
+{{response}}
+
+## True claims
+
+{{claims}}
+
+</user>

--- a/src/openfactcheck/components/factcheckgpt/prompts/verifier.md
+++ b/src/openfactcheck/components/factcheckgpt/prompts/verifier.md
@@ -1,0 +1,39 @@
+---
+name: verifier
+description: Judge whether a claim is factual against evidence, and correct it if not.
+variables:
+  claim:
+    type: string
+    required: true
+  evidence:
+    type: string
+    required: true
+---
+
+<system>
+
+# System Prompt
+
+You are a helpful factchecker assistant.
+
+</system>
+
+<user>
+
+# User Prompt
+
+You are given a piece of text. Your task is to identify whether there are any **factual errors** within the text.
+
+When you judge the factuality of the given text, you may reference the provided evidence if needed. The provided evidence may be helpful. Some evidence may contradict each other, so you must be careful when using it to judge the factuality of the given text.
+
+Provide your **reasoning** for whether the text is factual or not. Be careful: when you decide something is non-factual, you must point to evidence supporting your decision. Then decide the **factuality** of the text: **true** if it is factual, **false** otherwise. If there is a factual error, describe the **error** and provide a **correction** of the text; if the text is factual, leave the error and correction empty.
+
+## Text
+
+{{claim}}
+
+## Evidence
+
+{{evidence}}
+
+</user>

--- a/src/openfactcheck/components/factcheckgpt/query_generator.py
+++ b/src/openfactcheck/components/factcheckgpt/query_generator.py
@@ -1,0 +1,79 @@
+"""FactcheckGPT query generator."""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.components.types import Claim, Query
+from openfactcheck.messages import Message
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class GeneratedQueries(BaseModel):
+    """FactcheckGPT's structured query-generation result.
+
+    The query generator maps this onto a [`Query`][openfactcheck.components.types.Query].
+    It is also the value handed to a call's ``on_partial`` hook, the query list
+    growing as the model writes it.
+    """
+
+    queries: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTQueryGenerator:
+    """Generate web search queries for a claim, following FactcheckGPT's method.
+
+    Prompts the model for the search questions a reader would look up to verify
+    the claim.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(
+        default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "query_generator.md")
+    )
+    """The query-generation prompt. Defaults to FactcheckGPT's; override to customise."""
+
+    async def __call__(
+        self,
+        claim: Claim,
+        *,
+        on_partial: Callable[[GeneratedQueries], None] | None = None,
+    ) -> Query:
+        """Generate search queries for ``claim``.
+
+        Args:
+            claim: Claim to generate queries for.
+            on_partial: Called with the generated queries as they stream in, each
+                call carrying the queries produced so far. Omit it for a single
+                non-streaming call. The returned query is the same either way.
+
+        Returns:
+            The claim paired with the generated search questions.
+        """
+        messages = self.prompt.to_messages(input=claim.text)
+        result = (
+            await self.client.acompletion_as(messages, GeneratedQueries)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return Query(claim=claim, questions=result.queries)
+
+    async def _stream(
+        self, messages: list[Message], on_partial: Callable[[GeneratedQueries], None]
+    ) -> GeneratedQueries:
+        """Stream the query generation, forwarding each partial result to ``on_partial``."""
+        result: GeneratedQueries | None = None
+        async for partial in self.client.astream_as(messages, GeneratedQueries):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("query generator stream produced no value")
+        return result

--- a/src/openfactcheck/components/factcheckgpt/retriever.py
+++ b/src/openfactcheck/components/factcheckgpt/retriever.py
@@ -1,0 +1,40 @@
+"""FactcheckGPT retriever, backed by Google scraping."""
+
+import asyncio
+from dataclasses import dataclass
+
+from openfactcheck.components.types import Evidence, Query, Source, WebMetadata
+from openfactcheck.integrations.google_scraper import GoogleScraperClient, Passage
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTRetriever:
+    """Retrieve evidence for a claim's queries by scraping Google, following FactcheckGPT's method.
+
+    Runs every search question attached to the claim, scrapes and reranks the
+    result pages, and collects the top passages into one evidence set.
+    """
+
+    scraper: GoogleScraperClient
+    """The Google scraper client used for web retrieval."""
+
+    async def __call__(self, query: Query) -> Evidence:
+        """Fetch evidence for ``query``.
+
+        Args:
+            query: The claim and the search questions to run.
+
+        Returns:
+            Evidence for the claim, with one source per retrieved passage; an
+            empty source list when the query carries no questions.
+        """
+        if not query.questions:
+            return Evidence(claim=query.claim, sources=[])
+        results = await asyncio.gather(*(self.scraper.retrieve(question) for question in query.questions))
+        sources = [self._source(passage) for passages in results for passage in passages]
+        return Evidence(claim=query.claim, sources=sources)
+
+    @staticmethod
+    def _source(passage: Passage) -> Source:
+        """Map a scraped passage onto an evidence source."""
+        return Source(content=passage.text, metadata=WebMetadata(url=passage.url, title=None))

--- a/src/openfactcheck/components/factcheckgpt/reviser.py
+++ b/src/openfactcheck/components/factcheckgpt/reviser.py
@@ -1,0 +1,83 @@
+"""FactcheckGPT reviser."""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.components.types import Input, Verdict
+from openfactcheck.messages import Message
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class Revision(BaseModel):
+    """FactcheckGPT's structured response-revision result.
+
+    The reviser returns the [`revised`][openfactcheck.components.factcheckgpt.Revision.revised]
+    text. It is also the value handed to a call's ``on_partial`` hook, the text
+    filling in as the model writes it.
+    """
+
+    revised: str
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTReviser:
+    """Rewrite the input to correct its factual errors, following FactcheckGPT's method.
+
+    Builds the list of factually true claims from the verdicts (each claim's
+    correction when it has one, otherwise the claim itself) and rewrites the
+    original text against that list, preserving its wording and style.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "reviser.md"))
+    """The revision prompt. Defaults to FactcheckGPT's; override to customise."""
+
+    async def __call__(
+        self,
+        text: Input,
+        verdicts: list[Verdict],
+        *,
+        on_partial: Callable[[Revision], None] | None = None,
+    ) -> str:
+        """Rewrite ``text`` to fix the errors recorded in ``verdicts``.
+
+        Args:
+            text: The original input that was checked.
+            verdicts: Per-claim verdicts, carrying the corrections to apply.
+            on_partial: Called with the revision as it streams in, each call
+                carrying more of the rewritten text. Omit it for a single
+                non-streaming call. The returned text is the same either way.
+
+        Returns:
+            The input rewritten so its claims read as factually correct.
+        """
+        messages = self.prompt.to_messages(response=text.content, claims=self._true_claims(verdicts))
+        result = (
+            await self.client.acompletion_as(messages, Revision)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return result.revised
+
+    @staticmethod
+    def _true_claims(verdicts: list[Verdict]) -> str:
+        """List each claim in its corrected form, one per line, for the prompt."""
+        return "\n".join(f"- {verdict.correction or verdict.claim.text}" for verdict in verdicts)
+
+    async def _stream(self, messages: list[Message], on_partial: Callable[[Revision], None]) -> Revision:
+        """Stream the revision, forwarding each partial result to ``on_partial``."""
+        result: Revision | None = None
+        async for partial in self.client.astream_as(messages, Revision):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("reviser stream produced no value")
+        return result

--- a/src/openfactcheck/components/factcheckgpt/verifier.py
+++ b/src/openfactcheck/components/factcheckgpt/verifier.py
@@ -1,0 +1,101 @@
+"""FactcheckGPT verifier."""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.components.types import Claim, Evidence, Verdict
+from openfactcheck.messages import Message
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+
+
+class Verification(BaseModel):
+    """FactcheckGPT's structured per-claim verification result.
+
+    The verifier maps this onto a [`Verdict`][openfactcheck.components.types.Verdict].
+    It is also the value handed to a verifier call's ``on_partial`` hook, filling
+    in field by field as the model writes it.
+    """
+
+    reasoning: str
+    factuality: bool
+    error: str | None = None
+    correction: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FactcheckGPTVerifier:
+    """Judge a claim against its evidence, following FactcheckGPT's method.
+
+    FactcheckGPT reports factuality as a boolean and, when the claim is wrong,
+    the error and a correction. The boolean maps to ``supported`` or ``refuted``;
+    FactcheckGPT emits no confidence, so the verdict leaves it unset.
+    """
+
+    client: ChatClient
+    """The chat client used to call the model."""
+
+    prompt: PromptTemplate = field(default_factory=lambda: PromptTemplate.from_file(_PROMPTS_DIR / "verifier.md"))
+    """The verification prompt. Defaults to FactcheckGPT's; override to customise."""
+
+    async def __call__(
+        self,
+        claim: Claim,
+        evidence: Evidence,
+        *,
+        on_partial: Callable[[Verification], None] | None = None,
+    ) -> Verdict:
+        """Verify ``claim`` against ``evidence``.
+
+        Args:
+            claim: Claim under evaluation.
+            evidence: Sources bearing on the claim's truthfulness.
+            on_partial: Called with the verification result as it streams in, each
+                call carrying the fields filled so far. Omit it for a single
+                non-streaming call. The returned verdict is the same either way.
+
+        Returns:
+            A verdict labelled ``supported`` or ``refuted``, with the error and
+            correction filled when the claim is judged non-factual.
+        """
+        messages = self.prompt.to_messages(claim=claim.text, evidence=self._format_evidence(evidence))
+        result = (
+            await self.client.acompletion_as(messages, Verification)
+            if on_partial is None
+            else await self._stream(messages, on_partial)
+        )
+        return Verdict(
+            claim=claim,
+            label="supported" if result.factuality else "refuted",
+            confidence=None,
+            reasoning=result.reasoning,
+            error=self._clean(result.error),
+            correction=self._clean(result.correction),
+        )
+
+    async def _stream(self, messages: list[Message], on_partial: Callable[[Verification], None]) -> Verification:
+        """Stream the verification, forwarding each partial result to ``on_partial``."""
+        result: Verification | None = None
+        async for partial in self.client.astream_as(messages, Verification):
+            result = partial
+            on_partial(partial)
+        if result is None:  # pragma: no cover - astream_as yields the final value or raises.
+            raise RuntimeError("verifier stream produced no value")
+        return result
+
+    @staticmethod
+    def _format_evidence(evidence: Evidence) -> str:
+        """Render the evidence as a list of passage contents, as FactcheckGPT does."""
+        return str([source.content for source in evidence.sources])
+
+    @staticmethod
+    def _clean(value: str | None) -> str | None:
+        """Treat the literal string ``None`` or a blank string as no value."""
+        if value is None or value.strip() in {"", "None"}:
+            return None
+        return value

--- a/src/openfactcheck/components/protocols.py
+++ b/src/openfactcheck/components/protocols.py
@@ -130,3 +130,33 @@ class Aggregator(Protocol):
             The overall judgment, with a strategy-defined label and score.
         """
         ...
+
+
+@runtime_checkable
+class Reviser(Protocol):
+    """Rewrite input text to correct the factual errors its verdicts found.
+
+    An optional final stage: most pipelines stop at the
+    [`Verdict`][openfactcheck.components.types.Verdict] for each claim. A reviser
+    weaves the per-claim corrections back into the original text, producing a
+    revised version that preserves the wording and style of what was checked.
+    """
+
+    async def __call__(
+        self, text: Input, verdicts: list[Verdict], *, on_partial: Callable[[object], None] | None = None
+    ) -> str:
+        """Rewrite ``text`` to fix the errors recorded in ``verdicts``.
+
+        Args:
+            text: The original input that was checked.
+            verdicts: Per-claim verdicts, carrying the corrections to apply.
+            on_partial: Optional sink called with the in-progress result as it
+                streams in, each call carrying more of it. Omit it for a single
+                non-streaming call; an implementation without streaming may
+                ignore it.
+
+        Returns:
+            The input rewritten so its claims read as factually correct, with
+            the original style preserved.
+        """
+        ...

--- a/src/openfactcheck/components/types.py
+++ b/src/openfactcheck/components/types.py
@@ -133,3 +133,6 @@ class Report(BaseModel):
 
     assessment: Assessment
     """The overall judgment across all claims."""
+
+    revision: str | None = None
+    """The input rewritten to correct its factual errors, or ``None`` when no revision was produced."""

--- a/src/openfactcheck/integrations/google_scraper/__init__.py
+++ b/src/openfactcheck/integrations/google_scraper/__init__.py
@@ -1,0 +1,68 @@
+"""Web evidence retrieval by scraping Google search results.
+
+Build a [`GoogleScraperClient`][GoogleScraperClient] and call
+[`retrieve`][GoogleScraperClient.retrieve]; it searches Google, scrapes the
+result pages, and returns the passages most relevant to the query as typed
+[`Passage`][Passage] models. Import from
+``openfactcheck.integrations.google_scraper``.
+
+Needs the ``factcheckgpt`` extra (``pip install openfactcheck[factcheckgpt]``)
+for HTML parsing and cross-encoder reranking. No search API key is used, so
+retrieval is best-effort and subject to Google rate-limiting.
+
+Example:
+    ```python
+    from openfactcheck.integrations.google_scraper import GoogleScraperClient
+
+    client = GoogleScraperClient()
+    passages = await client.retrieve("who founded openai")
+    print(passages[0].url)
+    ```
+"""
+
+from openfactcheck.integrations.google_scraper.client import (
+    DEFAULT_NUM_RESULTS,
+    DEFAULT_RANKER_MODEL,
+    DEFAULT_SENTENCES_PER_PASSAGE,
+    DEFAULT_SLIDING_DISTANCE,
+    DEFAULT_TIMEOUT,
+    DEFAULT_TOP_K,
+    DEFAULT_USER_AGENT,
+    GOOGLE_SEARCH_URL,
+    GoogleScraperClient,
+)
+from openfactcheck.integrations.google_scraper.errors import (
+    GoogleScraperConfigError,
+    GoogleScraperError,
+    GoogleScraperRequestError,
+)
+from openfactcheck.integrations.google_scraper.responses import Passage
+
+# Client
+__all__ = [
+    "GoogleScraperClient",
+]
+
+# Configuration
+__all__ += [
+    "DEFAULT_NUM_RESULTS",
+    "DEFAULT_RANKER_MODEL",
+    "DEFAULT_SENTENCES_PER_PASSAGE",
+    "DEFAULT_SLIDING_DISTANCE",
+    "DEFAULT_TIMEOUT",
+    "DEFAULT_TOP_K",
+    "DEFAULT_USER_AGENT",
+    "GOOGLE_SEARCH_URL",
+]
+
+# Responses
+__all__ += [
+    "Passage",
+]
+
+# Errors
+__all__ += [
+    "GoogleScraperConfigError",
+    "GoogleScraperError",
+    "GoogleScraperRequestError",
+]

--- a/src/openfactcheck/integrations/google_scraper/client.py
+++ b/src/openfactcheck/integrations/google_scraper/client.py
@@ -1,0 +1,218 @@
+"""Async client that retrieves web evidence by scraping Google.
+
+Replicates the FactcheckGPT retrieval method: search Google, scrape the result
+pages, split them into overlapping passages, and rerank the passages against the
+query with a cross-encoder. No search API or key is involved; results come from
+parsing Google's results page directly, so retrieval is best-effort and Google
+may rate-limit or block automated requests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import httpx
+
+from openfactcheck.integrations.google_scraper.errors import GoogleScraperRequestError
+from openfactcheck.integrations.google_scraper.imports import load_cross_encoder
+from openfactcheck.integrations.google_scraper.parse import (
+    chunk_passages,
+    extract_result_urls,
+    extract_visible_text,
+)
+from openfactcheck.integrations.google_scraper.responses import Passage
+
+if TYPE_CHECKING:
+    from sentence_transformers import CrossEncoder
+
+GOOGLE_SEARCH_URL = "https://www.google.com/search"
+"""Endpoint whose results page the client parses for organic URLs."""
+
+DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0"
+"""Desktop user agent; Google serves a parseable results page to desktop agents."""
+
+DEFAULT_TIMEOUT = 10.0
+"""Default per-request timeout in seconds."""
+
+DEFAULT_NUM_RESULTS = 5
+"""Default number of search result pages to scrape per query."""
+
+DEFAULT_SENTENCES_PER_PASSAGE = 5
+"""Default passage window size, in sentences."""
+
+DEFAULT_SLIDING_DISTANCE = 2
+"""Default number of sentences to advance between passages."""
+
+DEFAULT_TOP_K = 5
+"""Default number of reranked passages to return per query."""
+
+DEFAULT_RANKER_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+"""Default cross-encoder used to rerank passages against the query."""
+
+
+class GoogleScraperClient:
+    """Async client that retrieves web evidence by scraping Google search results.
+
+    Searches Google, scrapes the result pages, chunks them into passages, and
+    reranks those passages against the query with a cross-encoder. Needs the
+    ``factcheckgpt`` extra (``beautifulsoup4`` and ``sentence-transformers``),
+    which is imported on first use.
+
+    Example:
+        ```python
+        client = GoogleScraperClient()
+        passages = await client.retrieve("who founded openai")
+        for passage in passages:
+            print(passage.score, passage.url)
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        num_results: int = DEFAULT_NUM_RESULTS,
+        sentences_per_passage: int = DEFAULT_SENTENCES_PER_PASSAGE,
+        sliding_distance: int = DEFAULT_SLIDING_DISTANCE,
+        top_k: int = DEFAULT_TOP_K,
+        ranker_model: str = DEFAULT_RANKER_MODEL,
+        lang: str = "en",
+        user_agent: str = DEFAULT_USER_AGENT,
+    ) -> None:
+        """Build a Google scraper client.
+
+        Args:
+            timeout: Per-request timeout in seconds.
+            num_results: How many search result pages to scrape per query.
+            sentences_per_passage: Passage window size, in sentences.
+            sliding_distance: Sentences to advance between passages.
+            top_k: How many reranked passages to return per query.
+            ranker_model: Cross-encoder model id used to rerank passages.
+            lang: Interface and result language code, such as ``en``.
+            user_agent: User agent sent with every request.
+        """
+        self._timeout = timeout
+        self._num_results = num_results
+        self._sentences_per_passage = sentences_per_passage
+        self._sliding_distance = sliding_distance
+        self._top_k = top_k
+        self._ranker_name = ranker_model
+        self._lang = lang
+        self._user_agent = user_agent
+        self._ranker: CrossEncoder | None = None
+
+    async def search(self, query: str) -> list[str]:
+        """Return the organic result URLs Google shows for a query.
+
+        Args:
+            query: The search query.
+
+        Returns:
+            Result URLs in rank order, capped at ``num_results``.
+
+        Raises:
+            GoogleScraperRequestError: The search request failed or was blocked.
+        """
+        async with self._http() as http:
+            return await self._search(http, query)
+
+    async def scrape(self, url: str) -> str | None:
+        """Return the visible text of a page, or ``None`` when it cannot be read.
+
+        Args:
+            url: The page to scrape.
+
+        Returns:
+            The page's visible text, or ``None`` for a non-HTML or unreachable page.
+        """
+        async with self._http() as http:
+            return await self._scrape(http, url)
+
+    async def retrieve(self, query: str) -> list[Passage]:
+        """Retrieve and rerank web passages relevant to a query.
+
+        Searches Google, scrapes each result page, splits the pages into
+        passages, and returns the passages most relevant to the query.
+
+        Args:
+            query: The query to find evidence for.
+
+        Returns:
+            The top reranked passages, highest score first; empty when nothing
+            could be scraped.
+
+        Raises:
+            GoogleScraperRequestError: The search request failed or was blocked.
+            GoogleScraperConfigError: The ``factcheckgpt`` extra is not installed.
+        """
+        async with self._http() as http:
+            urls = await self._search(http, query)
+            texts = await asyncio.gather(*(self._scrape(http, url) for url in urls))
+
+        candidates = [
+            (passage, url)
+            for url, text in zip(urls, texts, strict=True)
+            if text
+            for passage in chunk_passages(
+                text,
+                sentences_per_passage=self._sentences_per_passage,
+                sliding_distance=self._sliding_distance,
+            )
+        ]
+        if not candidates:
+            return []
+
+        ranked = await asyncio.to_thread(self._rerank, query, candidates)
+        return [Passage(text=text, url=url, score=score) for text, url, score in ranked[: self._top_k]]
+
+    def _http(self) -> httpx.AsyncClient:
+        """Build an HTTP client carrying the configured timeout and user agent."""
+        return httpx.AsyncClient(
+            timeout=self._timeout,
+            headers={"User-Agent": self._user_agent},
+            follow_redirects=True,
+        )
+
+    async def _search(self, http: httpx.AsyncClient, query: str) -> list[str]:
+        """Run the search request and parse organic result URLs from the page."""
+        params = {
+            "q": query,
+            "num": max(10, self._num_results * 2),
+            "hl": self._lang,
+            "lr": f"lang_{self._lang}",
+        }
+        try:
+            response = await http.get(GOOGLE_SEARCH_URL, params=params)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise GoogleScraperRequestError(f"Google search for {query!r} failed: {exc}.") from exc
+        return extract_result_urls(response.text, limit=self._num_results)
+
+    async def _scrape(self, http: httpx.AsyncClient, url: str) -> str | None:
+        """Fetch one page and return its visible text, or ``None`` on any failure.
+
+        A single unreachable or non-HTML page is skipped rather than failing the
+        whole retrieval.
+        """
+        try:
+            response = await http.get(url)
+            response.raise_for_status()
+        except httpx.HTTPError:
+            return None
+        if "html" not in response.headers.get("content-type", ""):
+            return None
+        return extract_visible_text(response.text) or None
+
+    def _rerank(self, query: str, candidates: list[tuple[str, str]]) -> list[tuple[str, str, float]]:
+        """Score each ``(passage, url)`` against the query and sort by score, descending."""
+        ranker = self._load_ranker()
+        scores = ranker.predict([(query, passage) for passage, _ in candidates])
+        ranked = sorted(zip(candidates, scores, strict=True), key=lambda item: item[1], reverse=True)
+        return [(passage, url, float(score)) for (passage, url), score in ranked]
+
+    def _load_ranker(self) -> CrossEncoder:
+        """Build the cross-encoder once and reuse it across calls."""
+        if self._ranker is None:
+            self._ranker = load_cross_encoder()(self._ranker_name, max_length=512)
+        return self._ranker

--- a/src/openfactcheck/integrations/google_scraper/errors.py
+++ b/src/openfactcheck/integrations/google_scraper/errors.py
@@ -1,0 +1,13 @@
+"""Error hierarchy for the Google scraper integration."""
+
+
+class GoogleScraperError(Exception):
+    """Base error for every Google scraper integration failure."""
+
+
+class GoogleScraperConfigError(GoogleScraperError):
+    """A required optional dependency is missing or the client is misconfigured."""
+
+
+class GoogleScraperRequestError(GoogleScraperError):
+    """A search request to Google failed or returned an error status."""

--- a/src/openfactcheck/integrations/google_scraper/imports.py
+++ b/src/openfactcheck/integrations/google_scraper/imports.py
@@ -1,0 +1,44 @@
+"""Lazy imports of the optional scraping and reranking dependencies.
+
+These packages ship in the ``factcheckgpt`` extra, not the base install, so they
+are imported on first use and a missing one raises a clear install hint rather
+than an ``ImportError`` at module load.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from openfactcheck.integrations.google_scraper.errors import GoogleScraperConfigError
+
+if TYPE_CHECKING:
+    from bs4 import BeautifulSoup
+    from sentence_transformers import CrossEncoder
+
+_INSTALL_HINT = "install the extra with: pip install openfactcheck[factcheckgpt]"
+
+
+def load_beautifulsoup() -> type[BeautifulSoup]:
+    """Lazily import and return the ``BeautifulSoup`` HTML parser class.
+
+    Raises:
+        GoogleScraperConfigError: ``beautifulsoup4`` is not installed.
+    """
+    try:
+        from bs4 import BeautifulSoup  # noqa: PLC0415 - lazy import for optional dependency.
+    except ImportError:
+        raise GoogleScraperConfigError(f"the Google scraper needs beautifulsoup4; {_INSTALL_HINT}") from None
+    return BeautifulSoup
+
+
+def load_cross_encoder() -> type[CrossEncoder]:
+    """Lazily import and return the ``CrossEncoder`` reranker class.
+
+    Raises:
+        GoogleScraperConfigError: ``sentence-transformers`` is not installed.
+    """
+    try:
+        from sentence_transformers import CrossEncoder  # noqa: PLC0415 - lazy import for optional dependency.
+    except ImportError:
+        raise GoogleScraperConfigError(f"the Google scraper needs sentence-transformers; {_INSTALL_HINT}") from None
+    return CrossEncoder

--- a/src/openfactcheck/integrations/google_scraper/parse.py
+++ b/src/openfactcheck/integrations/google_scraper/parse.py
@@ -1,0 +1,106 @@
+"""HTML and text helpers for the Google scraper integration.
+
+Pure functions that turn raw HTML into result URLs and visible text, and split
+text into overlapping passages. The reranker scores these passages; the client
+wires them together.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import parse_qs, urlparse
+
+from openfactcheck.integrations.google_scraper.imports import load_beautifulsoup
+
+# Hosts and paths that are Google's own chrome, not organic results.
+_NON_RESULT_MARKERS = ("google.", "gstatic.", "googleusercontent.", "/search?", "/preferences", "/policies")
+
+# Tags whose text is never page content.
+_INVISIBLE_TAGS = ("script", "style", "head", "title", "meta", "noscript", "template")
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+")
+
+
+def extract_result_urls(html: str, *, limit: int) -> list[str]:
+    """Return organic result URLs from a Google search results page, in order.
+
+    Args:
+        html: The raw HTML of a Google search results page.
+        limit: Maximum number of URLs to return.
+
+    Returns:
+        Deduplicated external result URLs, capped at ``limit``.
+    """
+    soup = load_beautifulsoup()(html, "html.parser")
+    urls: list[str] = []
+    seen: set[str] = set()
+    for anchor in soup.find_all("a", href=True):
+        url = _result_url(str(anchor["href"]))
+        if url is None or url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+        if len(urls) >= limit:
+            break
+    return urls
+
+
+def extract_visible_text(html: str) -> str:
+    """Return the visible text of a page with whitespace collapsed.
+
+    Args:
+        html: The raw HTML of a web page.
+
+    Returns:
+        The page's visible text, or an empty string when nothing is extractable.
+    """
+    soup = load_beautifulsoup()(html, "html.parser")
+    for tag in soup(list(_INVISIBLE_TAGS)):
+        tag.decompose()
+    return " ".join(soup.get_text(separator=" ").split())
+
+
+def chunk_passages(
+    text: str,
+    *,
+    sentences_per_passage: int,
+    sliding_distance: int,
+    max_sentence_chars: int = 250,
+) -> list[str]:
+    """Split text into overlapping passages with a sliding window over sentences.
+
+    Args:
+        text: The page text to split.
+        sentences_per_passage: Number of sentences per passage (the window size).
+        sliding_distance: Sentences to advance between passages; clamped to the
+            window size so passages stay contiguous.
+        max_sentence_chars: Sentences longer than this are dropped as likely
+            boilerplate or metadata.
+
+    Returns:
+        The passages, in document order.
+    """
+    sentences = [
+        sentence for raw in _SENTENCE_BOUNDARY.split(text) if 0 < len(sentence := raw.strip()) <= max_sentence_chars
+    ]
+    step = sliding_distance if 0 < sliding_distance <= sentences_per_passage else sentences_per_passage
+    passages: list[str] = []
+    for start in range(0, len(sentences), step):
+        passage = " ".join(sentences[start : start + sentences_per_passage])
+        if passage:
+            passages.append(passage)
+        if start + sentences_per_passage >= len(sentences):
+            break
+    return passages
+
+
+def _result_url(href: str) -> str | None:
+    """Resolve an anchor ``href`` to an organic result URL, or ``None`` to skip it."""
+    if href.startswith("/url?"):
+        target = parse_qs(urlparse(href).query).get("q")
+        href = target[0] if target else ""
+    if not href.startswith("http"):
+        return None
+    if any(marker in href for marker in _NON_RESULT_MARKERS) or href.lower().endswith(".pdf"):
+        return None
+    return href

--- a/src/openfactcheck/integrations/google_scraper/responses.py
+++ b/src/openfactcheck/integrations/google_scraper/responses.py
@@ -1,0 +1,18 @@
+"""Typed results from the Google scraper integration."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Passage(BaseModel):
+    """A passage scraped from a search result page, scored for a query."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", use_attribute_docstrings=True)
+
+    text: str
+    """The passage text extracted from the result page."""
+
+    url: str
+    """URL of the page the passage was taken from."""
+
+    score: float
+    """Relevance of the passage to the query, as scored by the reranker. Higher is more relevant."""

--- a/src/openfactcheck/pipeline/factcheckgpt.py
+++ b/src/openfactcheck/pipeline/factcheckgpt.py
@@ -1,0 +1,49 @@
+"""The FactcheckGPT pipeline.
+
+Pairs the [FactcheckGPT][openfactcheck.components.factcheckgpt] components with the fact-check graph,
+built with revision, into a ready-to-run [`Pipeline`][openfactcheck.pipeline.Pipeline]. The LLM components
+share an injected chat client; the retriever scrapes the web for evidence.
+"""
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.components.factcheckgpt import (
+    FactcheckGPTAggregator,
+    FactcheckGPTClaimProcessor,
+    FactcheckGPTQueryGenerator,
+    FactcheckGPTRetriever,
+    FactcheckGPTReviser,
+    FactcheckGPTVerifier,
+)
+from openfactcheck.integrations.google_scraper import GoogleScraperClient
+from openfactcheck.pipeline.pipeline import Components, Pipeline, build_graph
+
+
+def factcheckgpt(chat: ChatClient, scraper: GoogleScraperClient | None = None) -> Pipeline:
+    """Build the FactcheckGPT fact-check pipeline.
+
+    Wires the FactcheckGPT components onto the fact-check graph built with
+    revision. The claim processor, query generator, verifier, and reviser run on
+    ``chat``; the retriever runs on ``scraper``.
+
+    Args:
+        chat: Chat client backing the LLM components. Its model is the caller's
+            choice; the paper's recommended default is recorded on the
+            FactcheckGPT components' provenance.
+        scraper: Web retrieval client for the retriever. Defaults to a
+            [`GoogleScraperClient`][openfactcheck.integrations.google_scraper.GoogleScraperClient],
+            which needs the ``factcheckgpt`` extra.
+
+    Returns:
+        A pipeline that runs the FactcheckGPT method end to end, including the
+        final revision of the input.
+    """
+    scraper = scraper if scraper is not None else GoogleScraperClient()
+    components = Components(
+        claim_processor=FactcheckGPTClaimProcessor(client=chat),
+        query_generator=FactcheckGPTQueryGenerator(client=chat),
+        retriever=FactcheckGPTRetriever(scraper=scraper),
+        verifier=FactcheckGPTVerifier(client=chat),
+        aggregator=FactcheckGPTAggregator(),
+        reviser=FactcheckGPTReviser(client=chat),
+    )
+    return Pipeline(build_graph(revise=True), components)

--- a/src/openfactcheck/pipeline/pipeline.py
+++ b/src/openfactcheck/pipeline/pipeline.py
@@ -16,7 +16,14 @@ result = pipeline.run("The capital of Australia is Sydney.")
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
-from openfactcheck.components.protocols import Aggregator, ClaimProcessor, QueryGenerator, Retriever, Verifier
+from openfactcheck.components.protocols import (
+    Aggregator,
+    ClaimProcessor,
+    QueryGenerator,
+    Retriever,
+    Reviser,
+    Verifier,
+)
 from openfactcheck.components.types import Claim, Evidence, Input, Query, Report, Verdict
 from openfactcheck.graph import Graph, GraphBuilder, GraphEvent, RunOptions, StepContext
 
@@ -40,6 +47,9 @@ class Components:
     aggregator: Aggregator
     """Combines the per-claim verdicts into the overall judgment."""
 
+    reviser: Reviser | None = None
+    """Rewrites the input to fix its errors. Required only when the graph is built with revision."""
+
 
 @dataclass
 class PipelineState:
@@ -54,15 +64,21 @@ class PipelineState:
     """The run's original input, recorded by the entry step for assembly."""
 
 
-def build_graph() -> Graph[Input, Report, PipelineState, Components]:
-    """Build the default fact-check graph.
+def build_graph(*, revise: bool = False) -> Graph[Input, Report, PipelineState, Components]:
+    """Build the fact-check graph.
 
-    The returned graph records the input, processes it into claims, fans out to
-    generate queries, retrieve evidence, and verify each claim concurrently,
-    collects the checked claims, and assembles them with an overall judgment
-    into a result. Supply the components as ``deps`` and a fresh
-    [`PipelineState`][PipelineState] as ``state`` when running it, or wrap it in a
-    [`Pipeline`][Pipeline] that does so.
+    The graph records the input, processes it into claims, fans out to generate
+    queries, retrieve evidence, and verify each claim concurrently, collects the
+    checked claims, and assembles them with an overall judgment into a result.
+    With ``revise`` set, a final step rewrites the input to fix its errors and
+    records the result on the report. Supply the components as ``deps`` and a
+    fresh [`PipelineState`][PipelineState] as ``state`` when running it, or wrap
+    it in a [`Pipeline`][Pipeline] that does so.
+
+    Args:
+        revise: Append a revision step that rewrites the input from the verdicts'
+            corrections. The graph's [`Components`][Components] must then carry a
+            [`reviser`][Components.reviser].
 
     Returns:
         A built [`Graph`][Graph] taking an [`Input`][Input] and returning a [`Report`][Report].
@@ -99,13 +115,29 @@ def build_graph() -> Graph[Input, Report, PipelineState, Components]:
             raise RuntimeError("pipeline input was not recorded before assembly")
         return Report(input=ctx.state.input, verdicts=list(ctx.inputs), assessment=assessment)
 
-    g.add(
+    spine = [
         g.edge_from(g.start_node).to(claim_processor),
         g.edge_from(claim_processor).map().to(query_generator),
         g.edge_from(query_generator).to(retriever),
         g.edge_from(retriever).to(verifier),
         g.edge_from(verifier).collect().to(aggregator),
-        g.edge_from(aggregator).to(g.end_node),
+    ]
+    if not revise:
+        g.add(*spine, g.edge_from(aggregator).to(g.end_node))
+        return g.build()
+
+    @g.step_node
+    async def reviser(ctx: StepContext[Report, PipelineState, Components]) -> Report:
+        if ctx.deps.reviser is None:
+            raise RuntimeError("the graph was built with revise=True but no reviser component was supplied")
+        report = ctx.inputs
+        revision = await ctx.deps.reviser(report.input, report.verdicts, on_partial=ctx.emit if ctx.streaming else None)
+        return report.model_copy(update={"revision": revision})
+
+    g.add(
+        *spine,
+        g.edge_from(aggregator).to(reviser),
+        g.edge_from(reviser).to(g.end_node),
     )
     return g.build()
 

--- a/tests/components/factcheckgpt/test_aggregator.py
+++ b/tests/components/factcheckgpt/test_aggregator.py
@@ -1,0 +1,39 @@
+"""Tests for FactcheckGPTAggregator."""
+
+import pytest
+
+from openfactcheck.components import Aggregator
+from openfactcheck.components.factcheckgpt import FactcheckGPTAggregator
+from openfactcheck.components.types import Claim, Verdict
+
+
+def _verdict(label: str) -> Verdict:
+    return Verdict(claim=Claim(text="c"), label=label, reasoning="")  # type: ignore[arg-type]
+
+
+def test_FactcheckGPTAggregator_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTAggregator(), Aggregator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTAggregator_all_supported_is_factual() -> None:
+    result = await FactcheckGPTAggregator()([_verdict("supported"), _verdict("supported")])
+
+    assert result.label == "factual"
+    assert result.score == 1.0
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTAggregator_any_refuted_is_non_factual() -> None:
+    result = await FactcheckGPTAggregator()([_verdict("supported"), _verdict("refuted")])
+
+    assert result.label == "non_factual"
+    assert result.score == 0.5
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTAggregator_empty_is_not_enough_evidence() -> None:
+    result = await FactcheckGPTAggregator()([])
+
+    assert result.label == "not_enough_evidence"
+    assert result.score == 0.0

--- a/tests/components/factcheckgpt/test_claim_processor.py
+++ b/tests/components/factcheckgpt/test_claim_processor.py
@@ -1,0 +1,56 @@
+"""Tests for FactcheckGPTClaimProcessor. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import ClaimProcessor
+from openfactcheck.components.factcheckgpt import FactcheckGPTClaimProcessor
+from openfactcheck.components.types import Claim, Input
+
+
+class _FakeClient:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
+        self._result = result
+        self._stream = stream or []
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
+
+
+def test_FactcheckGPTClaimProcessor_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTClaimProcessor(client=_FakeClient(None)), ClaimProcessor)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTClaimProcessor_returns_extracted_claims() -> None:
+    processor = FactcheckGPTClaimProcessor(client=_FakeClient(SimpleNamespace(claims=["a", "b"])))
+
+    result = await processor(Input(content="some text"))
+
+    assert result == [Claim(text="a"), Claim(text="b")]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTClaimProcessor_no_claims_returns_empty() -> None:
+    processor = FactcheckGPTClaimProcessor(client=_FakeClient(SimpleNamespace(claims=[])))
+
+    result = await processor(Input(content="some text"))
+
+    assert result == []
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTClaimProcessor_streams_partials_via_on_partial() -> None:
+    partials = [SimpleNamespace(claims=["a"]), SimpleNamespace(claims=["a", "b"])]
+    processor = FactcheckGPTClaimProcessor(client=_FakeClient(None, stream=partials))
+    seen: list[SimpleNamespace] = []
+
+    result = await processor(Input(content="some text"), on_partial=seen.append)
+
+    assert [partial.claims for partial in seen] == [["a"], ["a", "b"]]
+    assert result == [Claim(text="a"), Claim(text="b")]

--- a/tests/components/factcheckgpt/test_prompts.py
+++ b/tests/components/factcheckgpt/test_prompts.py
@@ -1,0 +1,29 @@
+"""The transcribed FactcheckGPT prompts load and fill cleanly."""
+
+from pathlib import Path
+
+import pytest
+
+import openfactcheck.components.factcheckgpt as factcheckgpt_pkg
+from openfactcheck.prompts import PromptTemplate
+
+_PROMPTS_DIR = Path(factcheckgpt_pkg.__file__).resolve().parent / "prompts"
+
+
+@pytest.mark.parametrize(
+    ("filename", "values"),
+    [
+        ("claim_processor.md", {"input": "The earth is flat."}),
+        ("query_generator.md", {"input": "The earth is flat."}),
+        ("verifier.md", {"claim": "The earth is flat.", "evidence": "['The earth is an oblate spheroid.']"}),
+        ("reviser.md", {"response": "The earth is flat.", "claims": "- The earth is round."}),
+    ],
+)
+def test_factcheckgpt_prompt_loads_and_fills(filename: str, values: dict[str, str]) -> None:
+    template = PromptTemplate.from_file(_PROMPTS_DIR / filename)
+
+    messages = template.to_messages(**values)
+
+    assert len(messages) == 2  # noqa: PLR2004 - a system and a user message.
+    rendered = "\n".join(message.content for message in messages)
+    assert "{{" not in rendered  # every placeholder was substituted

--- a/tests/components/factcheckgpt/test_provenance.py
+++ b/tests/components/factcheckgpt/test_provenance.py
@@ -1,0 +1,15 @@
+"""Tests for the FactcheckGPT provenance record."""
+
+from openfactcheck.components import Provenance
+from openfactcheck.components.factcheckgpt import PROVENANCE
+
+
+def test_factcheckgpt_provenance_records_pinned_source() -> None:
+    assert isinstance(PROVENANCE, Provenance)
+    assert PROVENANCE.paper_url.endswith("2024.findings-emnlp.830/")
+    assert PROVENANCE.repository_url == "https://github.com/yuxiaw/Factcheck-GPT"
+    assert len(PROVENANCE.repository_commit) == 40  # noqa: PLR2004 - a full git SHA-1.
+    assert PROVENANCE.license == "Apache-2.0"
+    assert PROVENANCE.default_model == "gpt-4o-mini"
+    assert "@inproceedings{" in PROVENANCE.citation
+    assert "2024.findings-emnlp.830" in PROVENANCE.citation

--- a/tests/components/factcheckgpt/test_query_generator.py
+++ b/tests/components/factcheckgpt/test_query_generator.py
@@ -1,0 +1,49 @@
+"""Tests for FactcheckGPTQueryGenerator. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import QueryGenerator
+from openfactcheck.components.factcheckgpt import FactcheckGPTQueryGenerator
+from openfactcheck.components.types import Claim
+
+
+class _FakeClient:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
+        self._result = result
+        self._stream = stream or []
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
+
+
+def test_FactcheckGPTQueryGenerator_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTQueryGenerator(client=_FakeClient(None)), QueryGenerator)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTQueryGenerator_returns_query_with_questions() -> None:
+    generator = FactcheckGPTQueryGenerator(client=_FakeClient(SimpleNamespace(queries=["q1", "q2"])))
+    claim = Claim(text="the earth is flat")
+
+    query = await generator(claim)
+
+    assert query.claim == claim
+    assert query.questions == ["q1", "q2"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTQueryGenerator_streams_partials_via_on_partial() -> None:
+    partials = [SimpleNamespace(queries=["q1"]), SimpleNamespace(queries=["q1", "q2"])]
+    generator = FactcheckGPTQueryGenerator(client=_FakeClient(None, stream=partials))
+    seen: list[SimpleNamespace] = []
+
+    query = await generator(Claim(text="c"), on_partial=seen.append)
+
+    assert [partial.queries for partial in seen] == [["q1"], ["q1", "q2"]]
+    assert query.questions == ["q1", "q2"]

--- a/tests/components/factcheckgpt/test_retriever.py
+++ b/tests/components/factcheckgpt/test_retriever.py
@@ -1,0 +1,50 @@
+"""Tests for FactcheckGPTRetriever. The Google scraper client is faked."""
+
+import pytest
+
+from openfactcheck.components import Retriever
+from openfactcheck.components.factcheckgpt import FactcheckGPTRetriever
+from openfactcheck.components.types import Claim, Query, WebMetadata
+from openfactcheck.integrations.google_scraper import Passage
+
+
+class _FakeScraper:
+    def __init__(self, passages: list[Passage]) -> None:
+        self._passages = passages
+        self.calls: list[str] = []
+
+    async def retrieve(self, query: str) -> list[Passage]:
+        self.calls.append(query)
+        return self._passages
+
+
+def test_FactcheckGPTRetriever_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTRetriever(scraper=_FakeScraper([])), Retriever)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTRetriever_maps_passages_to_sources() -> None:
+    passages = [Passage(text="p1", url="u1", score=0.9), Passage(text="p2", url="u2", score=0.5)]
+    scraper = _FakeScraper(passages)
+    retriever = FactcheckGPTRetriever(scraper=scraper)
+    claim = Claim(text="c")
+
+    evidence = await retriever(Query(claim=claim, questions=["q1", "q2"]))
+
+    # One source per passage, per question (both questions searched).
+    assert [source.content for source in evidence.sources] == ["p1", "p2", "p1", "p2"]
+    urls = {source.metadata.url for source in evidence.sources if isinstance(source.metadata, WebMetadata)}
+    assert urls == {"u1", "u2"}
+    assert scraper.calls == ["q1", "q2"]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTRetriever_no_questions_skips_search() -> None:
+    scraper = _FakeScraper([Passage(text="p", url="u", score=1.0)])
+    retriever = FactcheckGPTRetriever(scraper=scraper)
+    claim = Claim(text="c")
+
+    evidence = await retriever(Query(claim=claim, questions=[]))
+
+    assert evidence.sources == []
+    assert scraper.calls == []

--- a/tests/components/factcheckgpt/test_reviser.py
+++ b/tests/components/factcheckgpt/test_reviser.py
@@ -1,0 +1,64 @@
+"""Tests for FactcheckGPTReviser. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import Reviser
+from openfactcheck.components.factcheckgpt import FactcheckGPTReviser
+from openfactcheck.components.types import Claim, Input, Verdict
+
+
+class _RecordingClient:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
+        self._result = result
+        self._stream = stream or []
+        self.messages: list[object] = []
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        self.messages = messages  # type: ignore[assignment]
+        return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
+
+
+def _verdict(text: str, *, label: str, correction: str | None = None) -> Verdict:
+    return Verdict(claim=Claim(text=text), label=label, reasoning="", correction=correction)  # type: ignore[arg-type]
+
+
+def test_FactcheckGPTReviser_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTReviser(client=_RecordingClient(None)), Reviser)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTReviser_returns_revised_text() -> None:
+    reviser = FactcheckGPTReviser(client=_RecordingClient(SimpleNamespace(revised="the earth is round")))
+
+    revised = await reviser(Input(content="the earth is flat"), [_verdict("the earth is flat", label="refuted")])
+
+    assert revised == "the earth is round"
+
+
+def test_FactcheckGPTReviser_true_claims_prefers_corrections() -> None:
+    verdicts = [
+        _verdict("the earth is flat", label="refuted", correction="the earth is round"),
+        _verdict("water is wet", label="supported"),
+    ]
+
+    claims = FactcheckGPTReviser._true_claims(verdicts)
+
+    assert claims == "- the earth is round\n- water is wet"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTReviser_streams_partials_via_on_partial() -> None:
+    partials = [SimpleNamespace(revised="the earth"), SimpleNamespace(revised="the earth is round")]
+    reviser = FactcheckGPTReviser(client=_RecordingClient(None, stream=partials))
+    seen: list[SimpleNamespace] = []
+
+    revised = await reviser(Input(content="the earth is flat"), [], on_partial=seen.append)
+
+    assert [partial.revised for partial in seen] == ["the earth", "the earth is round"]
+    assert revised == "the earth is round"

--- a/tests/components/factcheckgpt/test_verifier.py
+++ b/tests/components/factcheckgpt/test_verifier.py
@@ -1,0 +1,74 @@
+"""Tests for FactcheckGPTVerifier. The chat client is faked."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from openfactcheck.components import Verifier
+from openfactcheck.components.factcheckgpt import FactcheckGPTVerifier
+from openfactcheck.components.types import Claim, Evidence, Source
+
+
+class _FakeClient:
+    def __init__(self, result: object, stream: list[object] | None = None) -> None:
+        self._result = result
+        self._stream = stream or []
+
+    async def acompletion_as(self, messages: object, response_model: object) -> object:
+        return self._result
+
+    async def astream_as(self, messages: object, response_model: object) -> object:
+        for partial in self._stream:
+            yield partial
+
+
+def test_FactcheckGPTVerifier_satisfies_protocol() -> None:
+    assert isinstance(FactcheckGPTVerifier(client=_FakeClient(None)), Verifier)
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTVerifier_factual_claim_is_supported() -> None:
+    client = _FakeClient(SimpleNamespace(reasoning="ok", factuality=True, error="None", correction="None"))
+    verifier = FactcheckGPTVerifier(client=client)
+    claim = Claim(text="the earth is round")
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[Source(content="it is round")]))
+
+    assert verdict.label == "supported"
+    assert verdict.confidence is None
+    assert verdict.error is None
+    assert verdict.correction is None
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTVerifier_non_factual_claim_is_refuted_with_correction() -> None:
+    client = _FakeClient(
+        SimpleNamespace(reasoning="contradicted", factuality=False, error="not flat", correction="the earth is round")
+    )
+    verifier = FactcheckGPTVerifier(client=client)
+    claim = Claim(text="the earth is flat")
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[]))
+
+    assert verdict.label == "refuted"
+    assert verdict.error == "not flat"
+    assert verdict.correction == "the earth is round"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_FactcheckGPTVerifier_streams_partials_via_on_partial() -> None:
+    partials = [
+        SimpleNamespace(reasoning="Canberra", factuality=None, error=None, correction=None),
+        SimpleNamespace(
+            reasoning="Canberra is the capital", factuality=False, error="not Sydney", correction="Canberra"
+        ),
+    ]
+    verifier = FactcheckGPTVerifier(client=_FakeClient(None, stream=partials))
+    claim = Claim(text="the capital of Australia is Sydney")
+    seen: list[SimpleNamespace] = []
+
+    verdict = await verifier(claim, Evidence(claim=claim, sources=[]), on_partial=seen.append)
+
+    assert [partial.reasoning for partial in seen] == ["Canberra", "Canberra is the capital"]
+    assert verdict.label == "refuted"
+    assert verdict.correction == "Canberra"

--- a/tests/integrations/google_scraper/test_client.py
+++ b/tests/integrations/google_scraper/test_client.py
@@ -1,0 +1,138 @@
+"""Tests for GoogleScraperClient. httpx, the parser, and the reranker are faked."""
+
+import importlib.util
+
+import httpx
+import pytest
+from pytest_mock import MockerFixture
+
+from openfactcheck.integrations.google_scraper import (
+    GoogleScraperClient,
+    GoogleScraperConfigError,
+    GoogleScraperRequestError,
+    Passage,
+)
+from openfactcheck.integrations.google_scraper.client import GOOGLE_SEARCH_URL
+
+_CLIENT = "openfactcheck.integrations.google_scraper.client"
+
+
+class _FakeResponse:
+    def __init__(self, *, content_type: str = "text/html", status_error: bool = False) -> None:
+        self.text = "<html></html>"
+        self.headers = {"content-type": content_type}
+        self._status_error = status_error
+
+    def raise_for_status(self) -> None:
+        if self._status_error:
+            request = httpx.Request("GET", "https://example.com")
+            raise httpx.HTTPStatusError("error", request=request, response=httpx.Response(503, request=request))
+
+
+class _FakeAsyncClient:
+    def __init__(self, handler: object) -> None:
+        self._handler = handler
+        self.gets: list[tuple[str, object]] = []
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    async def get(self, url: str, *, params: object = None) -> _FakeResponse:
+        self.gets.append((url, params))
+        return self._handler(url)  # type: ignore[operator]
+
+
+def _patch_httpx(mocker: MockerFixture, handler: object) -> list[_FakeAsyncClient]:
+    created: list[_FakeAsyncClient] = []
+
+    def _factory(**_: object) -> _FakeAsyncClient:
+        client = _FakeAsyncClient(handler)
+        created.append(client)
+        return client
+
+    mocker.patch(f"{_CLIENT}.httpx.AsyncClient", _factory)
+    return created
+
+
+class _FakeRanker:
+    def __init__(self, *_: object, **__: object) -> None: ...
+
+    def predict(self, pairs: list[tuple[str, str]]) -> list[float]:
+        # Score by passage length, so reranking is deterministic in tests.
+        return [float(len(passage)) for _query, passage in pairs]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_retrieve_ranks_passages(mocker: MockerFixture) -> None:
+    mocker.patch(f"{_CLIENT}.extract_result_urls", return_value=["https://a.com"])
+    mocker.patch(f"{_CLIENT}.extract_visible_text", return_value="Short. A much longer sentence here. Mid one.")
+    mocker.patch(f"{_CLIENT}.load_cross_encoder", return_value=_FakeRanker)
+    _patch_httpx(mocker, lambda _url: _FakeResponse())
+    client = GoogleScraperClient(top_k=2, sentences_per_passage=1, sliding_distance=1)
+
+    passages = await client.retrieve("who")
+
+    assert all(isinstance(passage, Passage) for passage in passages)
+    assert len(passages) == 2  # noqa: PLR2004 - top_k.
+    assert passages[0].score >= passages[1].score
+    assert passages[0].url == "https://a.com"
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_retrieve_empty_when_no_results(mocker: MockerFixture) -> None:
+    mocker.patch(f"{_CLIENT}.extract_result_urls", return_value=[])
+    _patch_httpx(mocker, lambda _url: _FakeResponse())
+    client = GoogleScraperClient()
+
+    assert await client.retrieve("q") == []
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_search_targets_google(mocker: MockerFixture) -> None:
+    mocker.patch(f"{_CLIENT}.extract_result_urls", return_value=["https://a.com"])
+    created = _patch_httpx(mocker, lambda _url: _FakeResponse())
+    client = GoogleScraperClient()
+
+    urls = await client.search("openai")
+
+    assert urls == ["https://a.com"]
+    url, params = created[0].gets[0]
+    assert url == GOOGLE_SEARCH_URL
+    assert params["q"] == "openai"  # type: ignore[index]
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_search_wraps_http_error(mocker: MockerFixture) -> None:
+    _patch_httpx(mocker, lambda _url: _FakeResponse(status_error=True))
+    client = GoogleScraperClient()
+
+    with pytest.raises(GoogleScraperRequestError):
+        await client.search("openai")
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_scrape_skips_non_html(mocker: MockerFixture) -> None:
+    _patch_httpx(mocker, lambda _url: _FakeResponse(content_type="application/pdf"))
+    client = GoogleScraperClient()
+
+    assert await client.scrape("https://example.com/doc.pdf") is None
+
+
+@pytest.mark.asyncio(loop_scope="function")
+async def test_GoogleScraperClient_scrape_returns_none_on_error(mocker: MockerFixture) -> None:
+    _patch_httpx(mocker, lambda _url: _FakeResponse(status_error=True))
+    client = GoogleScraperClient()
+
+    assert await client.scrape("https://example.com") is None
+
+
+def test_load_cross_encoder_raises_without_dependency() -> None:
+    if importlib.util.find_spec("sentence_transformers") is not None:
+        pytest.skip("sentence-transformers is installed")
+    from openfactcheck.integrations.google_scraper.imports import load_cross_encoder
+
+    with pytest.raises(GoogleScraperConfigError):
+        load_cross_encoder()

--- a/tests/integrations/google_scraper/test_parse.py
+++ b/tests/integrations/google_scraper/test_parse.py
@@ -1,0 +1,67 @@
+"""Tests for the Google scraper parsing helpers."""
+
+import pytest
+
+from openfactcheck.integrations.google_scraper.parse import (
+    chunk_passages,
+    extract_result_urls,
+    extract_visible_text,
+)
+
+
+def test_chunk_passages_windows_over_sentences() -> None:
+    text = "One here. Two here. Three here. Four here. Five here. Six here."
+
+    passages = chunk_passages(text, sentences_per_passage=3, sliding_distance=2)
+
+    assert passages[0] == "One here. Two here. Three here."
+    # The window advances by the sliding distance.
+    assert passages[1] == "Three here. Four here. Five here."
+
+
+def test_chunk_passages_drops_overlong_sentences() -> None:
+    long_sentence = "x" * 300
+    text = f"Short one. {long_sentence}. Short two."
+
+    passages = chunk_passages(text, sentences_per_passage=5, sliding_distance=5, max_sentence_chars=250)
+
+    joined = " ".join(passages)
+    assert "Short one." in joined
+    assert "Short two." in joined
+    assert long_sentence not in joined
+
+
+def test_chunk_passages_empty_text() -> None:
+    assert chunk_passages("", sentences_per_passage=5, sliding_distance=2) == []
+
+
+# The HTML helpers call beautifulsoup4, which ships in the factcheckgpt extra.
+
+
+def test_extract_result_urls_resolves_and_filters() -> None:
+    pytest.importorskip("bs4")
+    html = """
+    <a href="/url?q=https://example.com/page&sa=U">result</a>
+    <a href="https://news.example.org/story">direct</a>
+    <a href="/search?q=more">google nav</a>
+    <a href="https://www.google.com/preferences">settings</a>
+    <a href="https://example.com/doc.pdf">a pdf</a>
+    """
+
+    urls = extract_result_urls(html, limit=10)
+
+    assert urls == ["https://example.com/page", "https://news.example.org/story"]
+
+
+def test_extract_result_urls_respects_limit() -> None:
+    pytest.importorskip("bs4")
+    html = '<a href="https://a.com">a</a><a href="https://b.com">b</a><a href="https://c.com">c</a>'
+
+    assert extract_result_urls(html, limit=2) == ["https://a.com", "https://b.com"]
+
+
+def test_extract_visible_text_drops_scripts_and_collapses_whitespace() -> None:
+    pytest.importorskip("bs4")
+    html = "<html><head><title>T</title></head><body><script>ignore()</script><p>Hello    world</p></body></html>"
+
+    assert extract_visible_text(html) == "Hello world"

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -3,6 +3,8 @@
 import asyncio
 from collections.abc import AsyncIterator, Callable
 
+import pytest
+
 from openfactcheck.components.dummy import (
     DummyAggregator,
     DummyClaimProcessor,
@@ -49,6 +51,13 @@ async def _aggregate(verdicts: list[Verdict]) -> Assessment:
     score = supported / len(verdicts)
     label = "supported" if score >= 0.5 else "refuted"  # noqa: PLR2004 - simple stub threshold.
     return Assessment(label=label, score=score)
+
+
+async def _revise(text: Input, verdicts: list[Verdict], *, on_partial: Callable[[object], None] | None = None) -> str:
+    revised = f"revised: {text.content} ({len(verdicts)} claims)"
+    if on_partial is not None:
+        on_partial(revised)
+    return revised
 
 
 def _stub_components(retriever: Retriever = _retrieve) -> Components:
@@ -127,6 +136,38 @@ def test_build_graph_records_input() -> None:
     build_graph().run(Input(content="The sky is blue."), state=state, deps=_stub_components())
 
     assert state.input == Input(content="The sky is blue.")
+
+
+# ---------------------------------------------------------------------------
+# build_graph(revise=True): the optional revision step
+# ---------------------------------------------------------------------------
+
+
+def test_build_graph_default_has_no_revision() -> None:
+    result = build_graph().run(Input(content="The sky is blue."), state=PipelineState(), deps=_stub_components())
+
+    assert result.revision is None
+
+
+def test_build_graph_revise_sets_revision() -> None:
+    components = Components(
+        claim_processor=_process,
+        query_generator=_generate,
+        retriever=_retrieve,
+        verifier=_verify,
+        aggregator=_aggregate,
+        reviser=_revise,
+    )
+
+    result = build_graph(revise=True).run(Input(content="The sky is green."), state=PipelineState(), deps=components)
+
+    assert [v.claim.text for v in result.verdicts] == ["The sky is green"]
+    assert result.revision == "revised: The sky is green. (1 claims)"
+
+
+def test_build_graph_revise_without_reviser_raises() -> None:
+    with pytest.raises(RuntimeError):
+        build_graph(revise=True).run(Input(content="The sky is blue."), state=PipelineState(), deps=_stub_components())
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.43.27"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +461,72 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -534,6 +613,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/f5/3557bf28e0f1943e4849154c821533706e6dea010f96fb6aa0b6949037d1/filelock-3.29.3.tar.gz", hash = "sha256:7fc1b3f39cf172fd8203812043c57b8a65aef9969f38b6704f628b881f761a84", size = 61956, upload-time = "2026-06-10T17:37:11.832Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/8f/b61d427c4f49a8bdadc93f4e7e74df8a6df6f77ee6e26bf0df53d3925363/filelock-3.29.3-py3-none-any.whl", hash = "sha256:e58333029cc9b925f39aad59b1d8f0a1ad836af4e60d7217f4a4dba87461261d", size = 42324, upload-time = "2026-06-10T17:37:10.37Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
 ]
 
 [[package]]
@@ -634,6 +722,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -695,6 +815,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/b5/ff8516e74b459da3dce9567540c39f2d305ee7a2655109f6802873ff1588/huggingface_hub-1.20.1-py3-none-any.whl", hash = "sha256:274448a45c1ba6f112fe2fb168ead05574c654faa156904157a84085cfae14bd", size = 719837, upload-time = "2026-06-18T22:06:51.486Z" },
 ]
 
 [[package]]
@@ -815,6 +956,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -1075,12 +1225,30 @@ dynamodb = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "mypy-boto3-dynamodb"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/41/2823aad9f3abab6104cd8aaafebabfba19927227fbc277e2289c3b915c1d/mypy_boto3_dynamodb-1.43.0.tar.gz", hash = "sha256:f0cea38e058f1d07361ecb55d8f40665d824b42cf4864724c7fccc8bf3946fcd", size = 48755, upload-time = "2026-04-29T22:59:59.119Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/e2/1f63f04600fc21cb848c10ce16490252e27d812bfd5a716659283049d3a3/mypy_boto3_dynamodb-1.43.0-py3-none-any.whl", hash = "sha256:60b64d15e86d406a980d96f734d8c7fb1704668d0234dc8dabd2532c902a3ba6", size = 58873, upload-time = "2026-04-29T22:59:56.823Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
 ]
 
 [[package]]
@@ -1101,12 +1269,234 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -1152,6 +1542,10 @@ api = [
 cloud = [
     { name = "boto3" },
 ]
+factcheckgpt = [
+    { name = "beautifulsoup4" },
+    { name = "sentence-transformers" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1178,6 +1572,7 @@ docs = [
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'api'", specifier = ">=0.22" },
     { name = "anthropic", specifier = ">=0.109" },
+    { name = "beautifulsoup4", marker = "extra == 'factcheckgpt'", specifier = ">=4.15.0" },
     { name = "boto3", marker = "extra == 'cloud'", specifier = ">=1.43" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.137.1" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1186,11 +1581,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'api'", specifier = ">=2.13" },
+    { name = "sentence-transformers", marker = "extra == 'factcheckgpt'", specifier = ">=5.6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'api'", specifier = ">=2.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.49" },
 ]
-provides-extras = ["api", "cloud"]
+provides-extras = ["api", "cloud", "factcheckgpt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1617,6 +2013,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1696,6 +2180,157 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/d2cb00765a6b15c994a7fccf20f9032f16e8193ca49147cb5155166ad744/sentence_transformers-5.6.0.tar.gz", hash = "sha256:0e7164d051e416c1853ade7c274ff52af3f9da0f4be7f0b83d734c27699e1057", size = 453194, upload-time = "2026-06-16T14:01:56.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c1/dc1582b79e9a2eb0cddf9559cd9bcdff084f541d6fe881fdd9d98630dba7/sentence_transformers-5.6.0-py3-none-any.whl", hash = "sha256:d2075b5e687a1611005e20ab04a6846994d51adfcf39610aed066af3c0c0b81f", size = 596411, upload-time = "2026-06-16T14:01:55.103Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1711,6 +2346,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1773,6 +2417,93 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/54/efb7ebca77970012b0cc21687a55d70eb2ba514b2c2b8e18d9fb1222f3be/torch-2.12.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d2dd0f2c5f7ccbddaf34cade0deaf476808368f902b9cdb7f36a2ab42301bc0e", size = 87991951, upload-time = "2026-06-17T21:07:49.309Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/00/4210d76ca7424981f04033ebe7e48816ab83287a62538747a58825db770c/torch-2.12.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2de4e19b88a481482c6c75291f2d6a52eda3ce51f311b29aa9b68499c830c07c", size = 426382721, upload-time = "2026-06-17T21:06:41.842Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/bc9f5a5aa569307076365f25afcebacb22e9c754b1bcfbaaa146627c7fda/torch-2.12.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:649e4ced014ba646f76f8cb9c9726735a6323eb321b7919f942790a923f90921", size = 532261322, upload-time = "2026-06-17T21:06:06.673Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/49/c549461daa008159d006a76a991fbc2f26fa8bac27a4030c858463dcb20f/torch-2.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:e86550597877fb272ddc52db2f85b82cb601ea7bd932576a0340152cae2200b3", size = 122988095, upload-time = "2026-06-17T21:07:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4a/0300261818e1560d72cc160ac826005507e8b7ca0a35788b591436d05b4a/torch-2.12.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c75e93173c700bccd6bfcc4a9d19ce242ab6dacd1f1781483027a16239b9e650", size = 87992358, upload-time = "2026-06-17T21:07:40.299Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a7/874a5ca05e8f159211dca7921060f7057acc1adb26431e119fd150623efc/torch-2.12.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:fcb61ccd20784b62bdd78ec84238a5cfb383b4994902e03bac95505ab360884c", size = 426386134, upload-time = "2026-06-17T21:07:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/75/20bb8fe9c1ad6538cce8cd0391b51927ae5af0b17ed1eab44b8824465dc1/torch-2.12.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f4afc8083dff08719edbea346644476e3cec0cf40ebe256be0ee5d5b7c7e8c0d", size = 532268019, upload-time = "2026-06-17T21:05:37.925Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/fa/824ddb662af55b2eabc0dbb7b57c7c0b1bcd93693754a2b8509ec4d16490/torch-2.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:f92609e3b3ce72f25e2eb780d043ced2480c1a86c47c852604fc7a9108648386", size = 122987777, upload-time = "2026-06-17T21:07:09.49Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b7/1b49fe7086ea36839cc80abc43174c43d0ab6f676c0891c871c162f44fe3/torch-2.12.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e9b6f7d2dd66ea87a3ae620069d31335d594c06effb1a383bdd21cfe61e44ece", size = 88010025, upload-time = "2026-06-17T21:07:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/06/5b44063a6545036dcc680d2d303b137d9176cfb2cc1e1863e3ef94abeb52/torch-2.12.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7973ccd3d2cd35c74449213f7bded199bec6c6247e705cbeda7407af79703d91", size = 426392891, upload-time = "2026-06-17T21:05:52.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/dd/c9ce9a4b0eb3c5bb92d9ea56766e2c22559f0b45171149188494edcce80f/torch-2.12.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c64ac4aac16be5e296dcd912305605804b203333c690bf98c55bc09494ee92ad", size = 532272494, upload-time = "2026-06-17T21:06:22.72Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/f3a601fc1b1f663ff269bfe553654e638651939aa6563e8daa7167c33098/torch-2.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:f6dc4caf7eb4adb38a2d9f536b51db56310fdd1254e69a2d96767e1367c892b3", size = 122987254, upload-time = "2026-06-17T21:06:33.199Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/b8087556cf81ddd808dbeb34afb8396d7ae7a1694ab489f08b1a0004e7d0/torch-2.12.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2afbb2bdaa8a95040e733f05492ddf133c3967c9b7ce0abd218d704b6cab437d", size = 88303173, upload-time = "2026-06-17T21:05:06.603Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/07/fe09d1699fbed2afa10ebc692ff2b99d113f2605b6748cea633989e2789a/torch-2.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:97eba061fcb042fed191400b15568990073d67eaacaa6ee9b7ca01dd8b790fe9", size = 426404009, upload-time = "2026-06-17T21:04:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f7/0ce4f6c1962c60ded7270e0a9eb560fb615c92b89d332cf9e3dff36d5ecc/torch-2.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3867b861391701012adb2df93360efb88494dca245a185e3bb7624495cfe3f33", size = 532184292, upload-time = "2026-06-17T21:05:17.526Z" },
+    { url = "https://files.pythonhosted.org/packages/70/db/e384c12aba30320ca92aaaf557456cbcb26f04b4df307728bb8f019f5000/torch-2.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:dd15595f8fc764cffde8c6361a3beb6ef69a028c851b1b3e70e077f615980d4e", size = 123231142, upload-time = "2026-06-17T21:05:27.061Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.68.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1782,6 +2513,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Ports the FactcheckGPT method (Wang et al., *Factcheck-Bench*, Findings of EMNLP 2024) as a component family on the OpenFactCheck spine, read against the authors' repo at `a9e6a04` (Apache-2.0).

- **`components/factcheckgpt/`** — claim processor (decompose into atomic *checkworthy* claims in one call), query generator, retriever, verifier (maps onto `Verdict`'s existing `error`/`correction` — no type changes), aggregator, and a reviser. Prompts transcribed verbatim minus the output scaffolding; provenance recorded.
- **`pipeline/factcheckgpt.py`** — `factcheckgpt(chat, scraper)` factory, graph built with revision.
- **`integrations/google_scraper/`** — `GoogleScraperClient`: Google search scrape → page scrape → sliding-window chunk → cross-encoder rerank. Faithful to the paper, with the repo's regex parsing, sync I/O, and GPU-only assumptions fixed. No search API. Behind the optional `[factcheckgpt]` extra (`beautifulsoup4`, `sentence-transformers`), lazily imported.
- **`Reviser` capability** — new optional protocol + `Report.revision` field; `build_graph(revise=True)` appends a revision step. The default spine stays revision-free, so Factool/dummy are untouched.

## Verification

- `task dev:lint` (format + ruff + pyright): clean, 0 errors
- Test suite: **669 passed, 3 skipped** (40 new tests; the 3 skips are the bs4-backed parse tests, verified passing with `uv run --with beautifulsoup4`)
- `mkdocs build --strict`: builds

Fidelity is behavioral (faithful prompt/stage transcription, unit-verified); a live end-to-end reproduction lives in `sandbox/22-factcheckgpt.py` (needs the extra + an API key + live scraping).