### PR TITLE
feat(api): user secrets and preferences store with KMS encryption

### DIFF
--- a/deployments/base/aws_dynamodb.tf
+++ b/deployments/base/aws_dynamodb.tf
@@ -24,3 +24,35 @@ resource "aws_dynamodb_table" "openfactcheck" {
     Name = "OpenFactCheck - DynamoDB - ${terraform.workspace} - ${var.aws_region}"
   }
 }
+
+# ##############################################################################
+# DynamoDB Table — User settings and secrets (dedicated, KMS-encrypted)
+# ##############################################################################
+
+resource "aws_dynamodb_table" "openfactcheck_users" {
+  name         = "openfactcheck-users-db-${terraform.workspace}-${var.aws_region}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "PK"
+  range_key    = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.users.arn
+  }
+
+  deletion_protection_enabled = terraform.workspace == "production" ? true : false
+
+  tags = {
+    Name = "OpenFactCheck - Users DynamoDB - ${terraform.workspace} - ${var.aws_region}"
+  }
+}

--- a/deployments/base/aws_iam_lambda.tf
+++ b/deployments/base/aws_iam_lambda.tf
@@ -61,8 +61,29 @@ resource "aws_iam_role_policy" "lambda_api_dynamodb" {
         ]
         Resource = [
           aws_dynamodb_table.openfactcheck.arn,
-          "${aws_dynamodb_table.openfactcheck.arn}/index/*"
+          "${aws_dynamodb_table.openfactcheck.arn}/index/*",
+          aws_dynamodb_table.openfactcheck_users.arn,
+          "${aws_dynamodb_table.openfactcheck_users.arn}/index/*"
         ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_api_kms" {
+  name = "kms-secrets"
+  role = aws_iam_role.lambda_api.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt"
+        ]
+        Resource = aws_kms_key.users.arn
       }
     ]
   })

--- a/deployments/base/aws_kms.tf
+++ b/deployments/base/aws_kms.tf
@@ -1,0 +1,18 @@
+# ##############################################################################
+# KMS Key — encrypts user secrets stored in the users table
+# ##############################################################################
+
+resource "aws_kms_key" "users" {
+  description             = "OpenFactCheck user secrets encryption (${terraform.workspace})"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  tags = {
+    Name = "OpenFactCheck - Users KMS Key - ${terraform.workspace} - ${var.aws_region}"
+  }
+}
+
+resource "aws_kms_alias" "users" {
+  name          = "alias/openfactcheck-users-${terraform.workspace}-${var.aws_region}"
+  target_key_id = aws_kms_key.users.key_id
+}

--- a/deployments/base/aws_lambda.tf
+++ b/deployments/base/aws_lambda.tf
@@ -28,16 +28,18 @@ resource "aws_lambda_function" "api" {
 
   environment {
     variables = {
-      OPENFACTCHECK_MODE                 = "cloud"
-      OPENFACTCHECK_DYNAMODB_TABLE_NAME  = aws_dynamodb_table.openfactcheck.name
-      OPENFACTCHECK_DYNAMODB_REGION      = var.aws_region
-      OPENFACTCHECK_COGNITO_REGION       = var.aws_region
-      OPENFACTCHECK_COGNITO_USER_POOL_ID = aws_cognito_user_pool.openfactcheck.id
-      OPENFACTCHECK_COGNITO_CLIENT_ID    = aws_cognito_user_pool_client.openfactcheck_client.id
-      OPENFACTCHECK_CORS_ORIGINS         = jsonencode(local.cors_origins)
-      OPENFACTCHECK_STATE_MACHINE_ARN     = aws_sfn_state_machine.pipeline.arn
-      OPENFACTCHECK_DEBUG                = "false"
-      OPENFACTCHECK_AUTH_BYPASS          = "false"
+      OPENFACTCHECK_MODE                      = "cloud"
+      OPENFACTCHECK_DYNAMODB_TABLE_NAME       = aws_dynamodb_table.openfactcheck.name
+      OPENFACTCHECK_DYNAMODB_USERS_TABLE_NAME = aws_dynamodb_table.openfactcheck_users.name
+      OPENFACTCHECK_SECRETS_KMS_KEY_ID        = aws_kms_key.users.arn
+      OPENFACTCHECK_DYNAMODB_REGION           = var.aws_region
+      OPENFACTCHECK_COGNITO_REGION            = var.aws_region
+      OPENFACTCHECK_COGNITO_USER_POOL_ID      = aws_cognito_user_pool.openfactcheck.id
+      OPENFACTCHECK_COGNITO_CLIENT_ID         = aws_cognito_user_pool_client.openfactcheck_client.id
+      OPENFACTCHECK_CORS_ORIGINS              = jsonencode(local.cors_origins)
+      OPENFACTCHECK_STATE_MACHINE_ARN         = aws_sfn_state_machine.pipeline.arn
+      OPENFACTCHECK_DEBUG                     = "false"
+      OPENFACTCHECK_AUTH_BYPASS               = "false"
     }
   }
 

--- a/deployments/base/outputs.tf
+++ b/deployments/base/outputs.tf
@@ -22,6 +22,16 @@ output "dynamodb_table_name" {
   value       = aws_dynamodb_table.openfactcheck.name
 }
 
+output "dynamodb_users_table_name" {
+  description = "DynamoDB users table name (settings and secrets)"
+  value       = aws_dynamodb_table.openfactcheck_users.name
+}
+
+output "users_kms_key_arn" {
+  description = "KMS key ARN for user secrets encryption"
+  value       = aws_kms_key.users.arn
+}
+
 output "ecr_repository_url" {
   description = "ECR repository URL for the API container image"
   value       = data.aws_ecr_repository.api.repository_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ api = [
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.22",
     "mangum>=0.21",
+    "cryptography>=48.0.1",
 ]
 cloud = [
     "boto3>=1.43",
@@ -88,6 +89,11 @@ venv = ".venv"
 
 [[tool.pyright.executionEnvironments]]
 root = "src/openfactcheck/api/repositories/dynamodb"
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+
+[[tool.pyright.executionEnvironments]]
+root = "src/openfactcheck/api/crypto"
 reportUnknownMemberType = false
 reportUnknownVariableType = false
 
@@ -289,7 +295,7 @@ dev = [
     "pytest-asyncio>=1.4",
     "pytest-mock>=3.15",
     "httpx>=0.28",
-    "boto3-stubs[dynamodb]>=1.43",
+    "boto3-stubs[dynamodb,kms]>=1.43",
     "moto[dynamodb]>=5.2",
     "ruff>=0.15",
 ]

--- a/src/openfactcheck/api/app.py
+++ b/src/openfactcheck/api/app.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, FastAPI
 from openfactcheck.api.config import APIConfig
 from openfactcheck.api.dependencies import get_config
 from openfactcheck.api.middleware import register_middleware
-from openfactcheck.api.routers import health, projects, workspaces
+from openfactcheck.api.routers import health, preferences, projects, secrets, workspaces
 
 
 def create_app(config: APIConfig | None = None) -> FastAPI:
@@ -43,6 +43,8 @@ def create_app(config: APIConfig | None = None) -> FastAPI:
     v1 = APIRouter(prefix="/api/v1")
     v1.include_router(projects.router)
     v1.include_router(workspaces.router)
+    v1.include_router(secrets.router)
+    v1.include_router(preferences.router)
     app.include_router(v1)
 
     return app

--- a/src/openfactcheck/api/config.py
+++ b/src/openfactcheck/api/config.py
@@ -28,7 +28,12 @@ class APIConfig(BaseSettings):
     mode: Literal["local", "cloud"] = "local"
     sqlite_path: str = "~/.openfactcheck/data.db"
     dynamodb_table_name: str = "openfactcheck"
+    dynamodb_users_table_name: str = "openfactcheck-users"  # Dedicated table for user settings and secrets.
     dynamodb_region: str = "us-east-1"
 
     # Run
     state_machine_arn: str = ""
+
+    # Secrets encryption
+    secrets_kms_key_id: str = ""  # KMS key id or ARN, used in "cloud" mode.
+    secrets_key_path: str = "~/.openfactcheck/secrets.key"  # Local key file, used in "local" mode.

--- a/src/openfactcheck/api/crypto/__init__.py
+++ b/src/openfactcheck/api/crypto/__init__.py
@@ -1,0 +1,5 @@
+"""Encryption for user secret values, with cloud (KMS) and local backends."""
+
+from openfactcheck.api.crypto.protocols import SecretCipher
+
+__all__ = ["SecretCipher"]

--- a/src/openfactcheck/api/crypto/kms.py
+++ b/src/openfactcheck/api/crypto/kms.py
@@ -1,0 +1,49 @@
+"""AWS KMS-backed secret cipher for cloud deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import TYPE_CHECKING
+
+import boto3
+
+if TYPE_CHECKING:
+    from mypy_boto3_kms.client import KMSClient
+
+
+class KmsCipher:
+    """Encrypts secret values with a KMS customer-managed key.
+
+    Each value is encrypted directly with the key. KMS accepts plaintext up to
+    4 KB, well beyond any API key, so no envelope key management is needed. The
+    ciphertext is base64-encoded for storage as a plain string.
+    """
+
+    def __init__(self, key_id: str, region_name: str = "us-east-1") -> None:
+        """Build a cipher bound to a KMS key.
+
+        Args:
+            key_id: Identifier or ARN of the KMS customer-managed key.
+            region_name: AWS region the key lives in.
+        """
+        self._key_id = key_id
+        self._client: KMSClient = boto3.client("kms", region_name=region_name)
+
+    async def encrypt(self, plaintext: str) -> str:
+        """Encrypt a secret value into a base64-encoded ciphertext."""
+
+        def _do() -> str:
+            response = self._client.encrypt(KeyId=self._key_id, Plaintext=plaintext.encode())
+            return base64.b64encode(response["CiphertextBlob"]).decode()
+
+        return await asyncio.to_thread(_do)
+
+    async def decrypt(self, ciphertext: str) -> str:
+        """Decrypt a base64-encoded ciphertext back to its secret value."""
+
+        def _do() -> str:
+            response = self._client.decrypt(KeyId=self._key_id, CiphertextBlob=base64.b64decode(ciphertext))
+            return response["Plaintext"].decode()
+
+        return await asyncio.to_thread(_do)

--- a/src/openfactcheck/api/crypto/local.py
+++ b/src/openfactcheck/api/crypto/local.py
@@ -1,0 +1,43 @@
+"""Fernet-backed secret cipher for local development."""
+
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+
+class LocalCipher:
+    """Encrypts secret values with a locally stored symmetric key.
+
+    The key is generated on first use and persisted to a key file with
+    owner-only permissions, so secrets encrypted in local mode survive across
+    restarts. It exists because local mode has no KMS to call.
+    """
+
+    def __init__(self, key_path: str) -> None:
+        """Build a cipher backed by a key file, creating the key if absent.
+
+        Args:
+            key_path: Path to the key file. A new key is written with mode
+                ``0600`` when the file does not yet exist.
+        """
+        self._fernet = Fernet(self._load_or_create_key(key_path))
+
+    @staticmethod
+    def _load_or_create_key(key_path: str) -> bytes:
+        """Read the key file, generating and persisting a new key when it is missing."""
+        path = Path(key_path).expanduser()
+        if path.exists():
+            return path.read_bytes()
+        key = Fernet.generate_key()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(key)
+        path.chmod(0o600)
+        return key
+
+    async def encrypt(self, plaintext: str) -> str:
+        """Encrypt a secret value into a token string."""
+        return self._fernet.encrypt(plaintext.encode()).decode()
+
+    async def decrypt(self, ciphertext: str) -> str:
+        """Decrypt a token string back to its secret value."""
+        return self._fernet.decrypt(ciphertext.encode()).decode()

--- a/src/openfactcheck/api/crypto/protocols.py
+++ b/src/openfactcheck/api/crypto/protocols.py
@@ -1,0 +1,35 @@
+"""Protocol for encrypting secret values at the storage boundary."""
+
+from typing import Protocol
+
+
+class SecretCipher(Protocol):
+    """Encrypts and decrypts user secret values.
+
+    An implementation sits between the secret repository and the stored
+    ciphertext: a value is encrypted before it is written and decrypted only
+    when a run needs it. The backing key material never leaves the
+    implementation, so callers handle plaintext and opaque ciphertext only.
+    """
+
+    async def encrypt(self, plaintext: str) -> str:
+        """Encrypt a secret value.
+
+        Args:
+            plaintext: The raw secret value.
+
+        Returns:
+            Opaque ciphertext, safe to persist in the database.
+        """
+        ...
+
+    async def decrypt(self, ciphertext: str) -> str:
+        """Decrypt a stored ciphertext back to its secret value.
+
+        Args:
+            ciphertext: Ciphertext produced when the value was encrypted.
+
+        Returns:
+            The original plaintext value.
+        """
+        ...

--- a/src/openfactcheck/api/dependencies.py
+++ b/src/openfactcheck/api/dependencies.py
@@ -9,10 +9,13 @@ from openfactcheck.api.auth.cognito import CognitoVerifier
 from openfactcheck.api.auth.dev import DevVerifier
 from openfactcheck.api.auth.protocols import TokenVerifier
 from openfactcheck.api.config import APIConfig
+from openfactcheck.api.crypto.protocols import SecretCipher
 from openfactcheck.api.errors import AuthError
 from openfactcheck.api.models import AuthUser
 from openfactcheck.api.repositories.protocols import (
+    PreferencesRepository,
     ProjectRepository,
+    SecretRepository,
     WorkspaceRepository,
 )
 
@@ -33,6 +36,9 @@ class _State:
     verifier: TokenVerifier | None = None
     project_repo: ProjectRepository | None = None
     workspace_repo: WorkspaceRepository | None = None
+    secret_repo: SecretRepository | None = None
+    preferences_repo: PreferencesRepository | None = None
+    cipher: SecretCipher | None = None
 
 
 _state = _State()
@@ -89,8 +95,14 @@ async def get_current_user(
 async def _init_repos(config: APIConfig) -> None:
     """Wire up all repository singletons based on config mode."""
     if config.mode == "cloud":
+        from openfactcheck.api.repositories.dynamodb.preferences import (  # noqa: PLC0415 - lazy import for optional backend.
+            DynamoPreferencesRepository,
+        )
         from openfactcheck.api.repositories.dynamodb.projects import (  # noqa: PLC0415 - lazy import for optional backend.
             DynamoProjectRepository,
+        )
+        from openfactcheck.api.repositories.dynamodb.secrets import (  # noqa: PLC0415 - lazy import for optional backend.
+            DynamoSecretRepository,
         )
         from openfactcheck.api.repositories.dynamodb.workspaces import (  # noqa: PLC0415 - lazy import for optional backend.
             DynamoWorkspaceRepository,
@@ -98,14 +110,22 @@ async def _init_repos(config: APIConfig) -> None:
 
         _state.project_repo = DynamoProjectRepository(config.dynamodb_table_name, config.dynamodb_region)
         _state.workspace_repo = DynamoWorkspaceRepository(config.dynamodb_table_name, config.dynamodb_region)
+        _state.secret_repo = DynamoSecretRepository(config.dynamodb_users_table_name, config.dynamodb_region)
+        _state.preferences_repo = DynamoPreferencesRepository(config.dynamodb_users_table_name, config.dynamodb_region)
     else:
         from openfactcheck.api.repositories.sqlite.engine import (  # noqa: PLC0415 - lazy import for optional backend.
             create_engine,
             create_session_factory,
             create_tables,
         )
+        from openfactcheck.api.repositories.sqlite.preferences import (  # noqa: PLC0415 - lazy import for optional backend.
+            SqlitePreferencesRepository,
+        )
         from openfactcheck.api.repositories.sqlite.projects import (  # noqa: PLC0415 - lazy import for optional backend.
             SqliteProjectRepository,
+        )
+        from openfactcheck.api.repositories.sqlite.secrets import (  # noqa: PLC0415 - lazy import for optional backend.
+            SqliteSecretRepository,
         )
         from openfactcheck.api.repositories.sqlite.workspaces import (  # noqa: PLC0415 - lazy import for optional backend.
             SqliteWorkspaceRepository,
@@ -116,6 +136,8 @@ async def _init_repos(config: APIConfig) -> None:
         sf = create_session_factory(engine)
         _state.project_repo = SqliteProjectRepository(sf)
         _state.workspace_repo = SqliteWorkspaceRepository(sf)
+        _state.secret_repo = SqliteSecretRepository(sf)
+        _state.preferences_repo = SqlitePreferencesRepository(sf)
 
 
 async def get_project_repo(
@@ -138,3 +160,50 @@ async def get_workspace_repo(
     if _state.workspace_repo is None:
         raise RuntimeError("Failed to initialize workspace repository")
     return _state.workspace_repo
+
+
+async def get_secret_repo(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> SecretRepository:
+    """Return the secret repository."""
+    if _state.secret_repo is None:
+        await _init_repos(config)
+    if _state.secret_repo is None:
+        raise RuntimeError("Failed to initialize secret repository")
+    return _state.secret_repo
+
+
+async def get_preferences_repo(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> PreferencesRepository:
+    """Return the preferences repository."""
+    if _state.preferences_repo is None:
+        await _init_repos(config)
+    if _state.preferences_repo is None:
+        raise RuntimeError("Failed to initialize preferences repository")
+    return _state.preferences_repo
+
+
+# ---------------------------------------------------------------------------
+# Cipher
+# ---------------------------------------------------------------------------
+
+
+async def get_cipher(
+    config: Annotated[APIConfig, Depends(get_config)],
+) -> SecretCipher:
+    """Return the secret cipher for the configured mode, creating it on first call."""
+    if _state.cipher is None:
+        if config.mode == "cloud":
+            from openfactcheck.api.crypto.kms import (  # noqa: PLC0415 - lazy import for optional cloud backend.
+                KmsCipher,
+            )
+
+            _state.cipher = KmsCipher(config.secrets_kms_key_id, config.dynamodb_region)
+        else:
+            from openfactcheck.api.crypto.local import (  # noqa: PLC0415 - lazy import for optional backend.
+                LocalCipher,
+            )
+
+            _state.cipher = LocalCipher(config.secrets_key_path)
+    return _state.cipher

--- a/src/openfactcheck/api/errors.py
+++ b/src/openfactcheck/api/errors.py
@@ -11,6 +11,7 @@ class ErrorCode(StrEnum):
     VALIDATION_ERROR = "VALIDATION_ERROR"
     PROJECT_LIMIT_REACHED = "PROJECT_LIMIT_REACHED"
     WORKSPACE_LIMIT_REACHED = "WORKSPACE_LIMIT_REACHED"
+    SECRET_LIMIT_REACHED = "SECRET_LIMIT_REACHED"  # noqa: S105 - error code, not a credential.
     UNAUTHORIZED = "UNAUTHORIZED"
     FORBIDDEN = "FORBIDDEN"
     EXECUTION_TIMEOUT = "EXECUTION_TIMEOUT"
@@ -76,6 +77,14 @@ class WorkspaceLimitError(AppError):
     def __init__(self, detail: str = "Workspace limit reached") -> None:
         """Create the error, optionally with a custom detail message."""
         super().__init__(detail, ErrorCode.WORKSPACE_LIMIT_REACHED, status=422)
+
+
+class SecretLimitError(AppError):
+    """Raised when a user has reached their maximum secret count (HTTP 422)."""
+
+    def __init__(self, detail: str = "Secret limit reached") -> None:
+        """Create the error, optionally with a custom detail message."""
+        super().__init__(detail, ErrorCode.SECRET_LIMIT_REACHED, status=422)
 
 
 class AuthError(AppError):

--- a/src/openfactcheck/api/models/__init__.py
+++ b/src/openfactcheck/api/models/__init__.py
@@ -1,6 +1,8 @@
 """Domain models for the API layer."""
 
+from openfactcheck.api.models.preferences import Preferences
 from openfactcheck.api.models.project import Project, ProjectCreate, ProjectUpdate
+from openfactcheck.api.models.secret import Secret
 from openfactcheck.api.models.user import AuthUser
 from openfactcheck.api.models.workspace import (
     Workspace,
@@ -13,9 +15,11 @@ from openfactcheck.api.models.workspace import (
 
 __all__ = [
     "AuthUser",
+    "Preferences",
     "Project",
     "ProjectCreate",
     "ProjectUpdate",
+    "Secret",
     "Workspace",
     "WorkspaceCreate",
     "WorkspaceRun",

--- a/src/openfactcheck/api/models/preferences.py
+++ b/src/openfactcheck/api/models/preferences.py
@@ -1,0 +1,25 @@
+"""User preferences domain model."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from openfactcheck.api.models.validators import to_camel
+
+
+class Preferences(BaseModel):
+    """Account-level user preferences.
+
+    A single record per user. Unset fields take their defaults, so a user with
+    no stored preferences reads as an all-default record.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="ignore",
+        use_attribute_docstrings=True,
+    )
+
+    tour_completed: bool = False
+    """Whether the user has finished the welcome tour."""

--- a/src/openfactcheck/api/models/secret.py
+++ b/src/openfactcheck/api/models/secret.py
@@ -1,0 +1,41 @@
+"""User secret domain model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from openfactcheck.api.models.validators import normalize_datetime, to_camel
+
+SECRET_NAME_PATTERN = r"^[a-z][a-z0-9_]{0,63}$"  # noqa: S105 - regex for secret names, not a credential.
+"""Allowed secret names: a leading lowercase letter, then lowercase letters, digits, or underscores, up to 64 chars."""
+
+
+class Secret(BaseModel):
+    """A stored user secret, returned without its value.
+
+    The raw value is never exposed once set; only a short hint of its trailing
+    characters comes back, enough to recognize which key is stored.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        extra="ignore",
+        use_attribute_docstrings=True,
+    )
+
+    name: str
+    """Identifier for the secret, for example ``"openai"``."""
+
+    hint: str = ""
+    """Trailing characters of the value, shown so the user can recognize the stored key."""
+
+    created_at: datetime
+    """Timestamp the secret was first set."""
+
+    updated_at: datetime
+    """Timestamp of the most recent change."""
+
+    _normalize_datetime = field_validator("created_at", "updated_at", mode="before")(normalize_datetime)

--- a/src/openfactcheck/api/models/secret.py
+++ b/src/openfactcheck/api/models/secret.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from openfactcheck.api.models.validators import normalize_datetime, to_camel
 
-SECRET_NAME_PATTERN = r"^[a-z][a-z0-9_]{0,63}$"  # noqa: S105 - regex for secret names, not a credential.
-"""Allowed secret names: a leading lowercase letter, then lowercase letters, digits, or underscores, up to 64 chars."""
+SECRET_NAME_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]{0,63}$"  # noqa: S105 - regex for secret names, not a credential.
+"""Allowed secret names: env-var style, leading letter or underscore then letters/digits/underscores, max 64."""
 
 
 class Secret(BaseModel):

--- a/src/openfactcheck/api/repositories/constants.py
+++ b/src/openfactcheck/api/repositories/constants.py
@@ -8,6 +8,9 @@ MAX_PROJECTS_PER_USER = 50
 MAX_WORKSPACES_PER_PROJECT = 5
 """Upper limit on the number of workspaces a single project may contain."""
 
+MAX_SECRETS_PER_USER = 20
+"""Upper limit on the number of secrets a single user may store."""
+
 MAX_CONTENT_BYTES = 350_000
 """Upper limit on the serialized size of a workspace's content blob."""
 

--- a/src/openfactcheck/api/repositories/dynamodb/keys.py
+++ b/src/openfactcheck/api/repositories/dynamodb/keys.py
@@ -15,6 +15,14 @@ Workspace keys:
 Run keys:
     PK: USER#<userId>#PROJECT#<projectId>
     SK: WORKSPACE#<workspaceId>
+
+Secret keys:
+    PK: USER#<userId>
+    SK: SECRET#<name>
+
+Preferences keys:
+    PK: USER#<userId>
+    SK: PREFERENCES
 """
 
 # ---------------------------------------------------------------------------
@@ -45,3 +53,33 @@ def workspace_pk(user_id: str, project_id: str) -> str:
 def workspace_sk(workspace_id: str) -> str:
     """Sort key for a specific workspace."""
     return f"WORKSPACE#{workspace_id}"
+
+
+# ---------------------------------------------------------------------------
+# Secret keys
+# ---------------------------------------------------------------------------
+
+
+def secret_pk(user_id: str) -> str:
+    """Partition key grouping all secrets for a user."""
+    return f"USER#{user_id}"
+
+
+def secret_sk(name: str) -> str:
+    """Sort key for a specific secret."""
+    return f"SECRET#{name}"
+
+
+# ---------------------------------------------------------------------------
+# Preferences keys
+# ---------------------------------------------------------------------------
+
+
+def preferences_pk(user_id: str) -> str:
+    """Partition key for a user's preferences."""
+    return f"USER#{user_id}"
+
+
+def preferences_sk() -> str:
+    """Sort key for the user's single preferences record."""
+    return "PREFERENCES"

--- a/src/openfactcheck/api/repositories/dynamodb/preferences.py
+++ b/src/openfactcheck/api/repositories/dynamodb/preferences.py
@@ -1,0 +1,25 @@
+"""DynamoDB-backed user preferences repository."""
+
+from openfactcheck.api.models import Preferences
+from openfactcheck.api.repositories.dynamodb.base import BaseDynamoRepository
+from openfactcheck.api.repositories.dynamodb.keys import preferences_pk, preferences_sk
+from openfactcheck.api.repositories.dynamodb.types import DynamoItem
+
+
+class DynamoPreferencesRepository(BaseDynamoRepository):
+    """DynamoDB-backed repository for a user's preferences."""
+
+    async def get(self, user_id: str) -> Preferences:
+        """Return the user's preferences, or an all-default record if none are stored."""
+        item = await self._get(preferences_pk(user_id), preferences_sk())
+        return Preferences.model_validate(item) if item else Preferences()
+
+    async def set(self, user_id: str, preferences: Preferences) -> Preferences:
+        """Replace the user's preferences with the given record."""
+        item: DynamoItem = {
+            "PK": preferences_pk(user_id),
+            "SK": preferences_sk(),
+            **preferences.model_dump(by_alias=True),
+        }
+        await self._put(item)
+        return preferences

--- a/src/openfactcheck/api/repositories/dynamodb/secrets.py
+++ b/src/openfactcheck/api/repositories/dynamodb/secrets.py
@@ -1,0 +1,67 @@
+"""DynamoDB-backed user secret repository."""
+
+import asyncio
+from datetime import UTC, datetime
+
+from openfactcheck.api.models import Secret
+from openfactcheck.api.repositories.constants import MAX_SECRETS_PER_USER
+from openfactcheck.api.repositories.dynamodb.base import BaseDynamoRepository
+from openfactcheck.api.repositories.dynamodb.keys import secret_pk, secret_sk
+from openfactcheck.api.repositories.dynamodb.types import DynamoItem
+
+
+class DynamoSecretRepository(BaseDynamoRepository):
+    """DynamoDB-backed repository for a user's encrypted secrets."""
+
+    async def list(self, user_id: str) -> list[Secret]:
+        """List the user's secrets (masked), ordered by name."""
+        items = await self._query_by_pk(secret_pk(user_id), sk_prefix="SECRET#")
+        secrets = [Secret.model_validate(item) for item in items]
+        return sorted(secrets, key=lambda s: s.name)
+
+    async def set(self, user_id: str, name: str, ciphertext: str, hint: str) -> Secret | None:
+        """Create or replace a secret's encrypted value.
+
+        Returns ``None`` if storing a new secret would exceed
+        [`MAX_SECRETS_PER_USER`][openfactcheck.api.repositories.constants.MAX_SECRETS_PER_USER].
+        Replacing an existing secret is always allowed.
+        """
+        existing = await self._query_by_pk(secret_pk(user_id), sk_prefix="SECRET#")
+        names = {item.get("name") for item in existing}
+        if name not in names and len(existing) >= MAX_SECRETS_PER_USER:
+            return None
+
+        now = datetime.now(UTC).isoformat()
+
+        def _do() -> DynamoItem:
+            response = self._table.update_item(
+                Key={"PK": secret_pk(user_id), "SK": secret_sk(name)},
+                UpdateExpression=(
+                    "SET #name = :name, hint = :hint, ciphertext = :ciphertext, "
+                    "updatedAt = :now, createdAt = if_not_exists(createdAt, :now)"
+                ),
+                ExpressionAttributeNames={"#name": "name"},
+                ExpressionAttributeValues={
+                    ":name": name,
+                    ":hint": hint,
+                    ":ciphertext": ciphertext,
+                    ":now": now,
+                },
+                ReturnValues="ALL_NEW",
+            )
+            return response["Attributes"]
+
+        attrs = await asyncio.to_thread(_do)
+        return Secret.model_validate(attrs)
+
+    async def get_ciphertext(self, user_id: str, name: str) -> str | None:
+        """Return the stored ciphertext for a secret, or ``None`` if it is not set."""
+        item = await self._get(secret_pk(user_id), secret_sk(name))
+        if item is None:
+            return None
+        ciphertext = item.get("ciphertext")
+        return ciphertext if isinstance(ciphertext, str) else None
+
+    async def delete(self, user_id: str, name: str) -> bool:
+        """Delete a secret. Returns ``False`` if it does not exist."""
+        return await self._delete(secret_pk(user_id), secret_sk(name))

--- a/src/openfactcheck/api/repositories/protocols.py
+++ b/src/openfactcheck/api/repositories/protocols.py
@@ -3,9 +3,11 @@
 from typing import Protocol
 
 from openfactcheck.api.models import (
+    Preferences,
     Project,
     ProjectCreate,
     ProjectUpdate,
+    Secret,
     Workspace,
     WorkspaceCreate,
     WorkspaceRun,
@@ -101,4 +103,41 @@ class WorkspaceRepository(Protocol):
 
     async def set_run(self, user_id: str, project_id: str, workspace_id: str, run: WorkspaceRun) -> None:
         """Replace the workspace's latest run state with the given run."""
+        ...
+
+
+class SecretRepository(Protocol):
+    """Data access interface for a user's encrypted secrets."""
+
+    async def list(self, user_id: str) -> list[Secret]:
+        """List the user's secrets (masked, no values), ordered by name."""
+        ...
+
+    async def set(self, user_id: str, name: str, ciphertext: str, hint: str) -> Secret | None:
+        """Create or replace a secret's encrypted value.
+
+        Returns ``None`` if storing a new secret would exceed
+        [`MAX_SECRETS_PER_USER`][openfactcheck.api.repositories.constants.MAX_SECRETS_PER_USER];
+        replacing an existing secret is always allowed.
+        """
+        ...
+
+    async def get_ciphertext(self, user_id: str, name: str) -> str | None:
+        """Return the stored ciphertext for a secret, or ``None`` if it is not set."""
+        ...
+
+    async def delete(self, user_id: str, name: str) -> bool:
+        """Delete a secret. Returns ``False`` if it does not exist."""
+        ...
+
+
+class PreferencesRepository(Protocol):
+    """Data access interface for a user's preferences."""
+
+    async def get(self, user_id: str) -> Preferences:
+        """Return the user's preferences, or an all-default record if none are stored."""
+        ...
+
+    async def set(self, user_id: str, preferences: Preferences) -> Preferences:
+        """Replace the user's preferences with the given record."""
         ...

--- a/src/openfactcheck/api/repositories/sqlite/preferences.py
+++ b/src/openfactcheck/api/repositories/sqlite/preferences.py
@@ -1,0 +1,36 @@
+"""SQLite-backed user preferences repository."""
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import Preferences
+from openfactcheck.api.repositories.sqlite.tables import PreferencesRow
+
+
+class SqlitePreferencesRepository:
+    """SQLite-backed repository for a user's preferences."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        """Build a repository that opens sessions from the given factory.
+
+        Args:
+            session_factory: Async session factory bound to a SQLite engine.
+        """
+        self._session_factory = session_factory
+
+    async def get(self, user_id: str) -> Preferences:
+        """Return the user's preferences, or an all-default record if none are stored."""
+        async with self._session_factory() as session:
+            row = await session.get(PreferencesRow, user_id)
+            return Preferences.model_validate_json(row.data_json) if row else Preferences()
+
+    async def set(self, user_id: str, preferences: Preferences) -> Preferences:
+        """Replace the user's preferences with the given record."""
+        data = preferences.model_dump_json()
+        async with self._session_factory() as session:
+            row = await session.get(PreferencesRow, user_id)
+            if row is None:
+                session.add(PreferencesRow(user_id=user_id, data_json=data))
+            else:
+                row.data_json = data
+            await session.commit()
+        return preferences

--- a/src/openfactcheck/api/repositories/sqlite/preferences.py
+++ b/src/openfactcheck/api/repositories/sqlite/preferences.py
@@ -3,6 +3,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from openfactcheck.api.models import Preferences
+from openfactcheck.api.repositories.sqlite.helpers import row_to_dict
 from openfactcheck.api.repositories.sqlite.tables import PreferencesRow
 
 
@@ -21,16 +22,17 @@ class SqlitePreferencesRepository:
         """Return the user's preferences, or an all-default record if none are stored."""
         async with self._session_factory() as session:
             row = await session.get(PreferencesRow, user_id)
-            return Preferences.model_validate_json(row.data_json) if row else Preferences()
+            return Preferences.model_validate(row_to_dict(row)) if row else Preferences()
 
     async def set(self, user_id: str, preferences: Preferences) -> Preferences:
         """Replace the user's preferences with the given record."""
-        data = preferences.model_dump_json()
+        fields = preferences.model_dump()
         async with self._session_factory() as session:
             row = await session.get(PreferencesRow, user_id)
             if row is None:
-                session.add(PreferencesRow(user_id=user_id, data_json=data))
+                session.add(PreferencesRow(user_id=user_id, **fields))
             else:
-                row.data_json = data
+                for field, value in fields.items():
+                    setattr(row, field, value)
             await session.commit()
         return preferences

--- a/src/openfactcheck/api/repositories/sqlite/secrets.py
+++ b/src/openfactcheck/api/repositories/sqlite/secrets.py
@@ -1,0 +1,78 @@
+"""SQLite-backed user secret repository."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import Secret
+from openfactcheck.api.repositories.constants import MAX_SECRETS_PER_USER
+from openfactcheck.api.repositories.sqlite.helpers import row_to_dict
+from openfactcheck.api.repositories.sqlite.tables import SecretRow
+
+
+class SqliteSecretRepository:
+    """SQLite-backed repository for a user's encrypted secrets."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        """Build a repository that opens sessions from the given factory.
+
+        Args:
+            session_factory: Async session factory bound to a SQLite engine.
+        """
+        self._session_factory = session_factory
+
+    async def list(self, user_id: str) -> list[Secret]:
+        """List the user's secrets (masked), ordered by name."""
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(SecretRow).where(SecretRow.user_id == user_id).order_by(SecretRow.name),
+            )
+            return [Secret.model_validate(row_to_dict(row)) for row in result.scalars()]
+
+    async def set(self, user_id: str, name: str, ciphertext: str, hint: str) -> Secret | None:
+        """Create or replace a secret's encrypted value.
+
+        Returns ``None`` if storing a new secret would exceed
+        [`MAX_SECRETS_PER_USER`][openfactcheck.api.repositories.constants.MAX_SECRETS_PER_USER].
+        Replacing an existing secret is always allowed.
+        """
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            row = await session.get(SecretRow, (user_id, name))
+            if row is None:
+                count = await session.execute(
+                    select(func.count()).select_from(SecretRow).where(SecretRow.user_id == user_id),
+                )
+                if count.scalar_one() >= MAX_SECRETS_PER_USER:
+                    return None
+                row = SecretRow(
+                    user_id=user_id,
+                    name=name,
+                    ciphertext=ciphertext,
+                    hint=hint,
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(row)
+            else:
+                row.ciphertext = ciphertext
+                row.hint = hint
+                row.updated_at = now
+            await session.commit()
+            return Secret.model_validate(row_to_dict(row))
+
+    async def get_ciphertext(self, user_id: str, name: str) -> str | None:
+        """Return the stored ciphertext for a secret, or ``None`` if it is not set."""
+        async with self._session_factory() as session:
+            row = await session.get(SecretRow, (user_id, name))
+            return row.ciphertext if row else None
+
+    async def delete(self, user_id: str, name: str) -> bool:
+        """Delete a secret. Returns ``False`` if it does not exist."""
+        async with self._session_factory() as session:
+            cursor = await session.execute(
+                delete(SecretRow).where(SecretRow.user_id == user_id, SecretRow.name == name),
+            )
+            await session.commit()
+            return bool(cursor.rowcount)

--- a/src/openfactcheck/api/repositories/sqlite/tables.py
+++ b/src/openfactcheck/api/repositories/sqlite/tables.py
@@ -66,4 +66,4 @@ class PreferencesRow(Base):
     __tablename__ = "preferences"
 
     user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
-    data_json: Mapped[str] = mapped_column(Text, default="{}")
+    tour_completed: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/src/openfactcheck/api/repositories/sqlite/tables.py
+++ b/src/openfactcheck/api/repositories/sqlite/tables.py
@@ -45,3 +45,25 @@ class WorkspaceRow(Base):
     run_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class SecretRow(Base):
+    """ORM model for the ``secrets`` table."""
+
+    __tablename__ = "secrets"
+
+    user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    name: Mapped[str] = mapped_column(String(64), primary_key=True)
+    ciphertext: Mapped[str] = mapped_column(Text)
+    hint: Mapped[str] = mapped_column(String(8), default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class PreferencesRow(Base):
+    """ORM model for the ``preferences`` table."""
+
+    __tablename__ = "preferences"
+
+    user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    data_json: Mapped[str] = mapped_column(Text, default="{}")

--- a/src/openfactcheck/api/routers/preferences.py
+++ b/src/openfactcheck/api/routers/preferences.py
@@ -1,0 +1,33 @@
+"""User preferences endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from openfactcheck.api.dependencies import get_current_user, get_preferences_repo
+from openfactcheck.api.models import AuthUser, Preferences
+from openfactcheck.api.repositories.protocols import PreferencesRepository
+from openfactcheck.api.schemas.preferences import PreferencesResponse, UpdatePreferencesRequest
+
+router = APIRouter(prefix="/preferences", tags=["preferences"])
+
+
+@router.get("/")
+async def get_preferences(
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[PreferencesRepository, Depends(get_preferences_repo)],
+) -> PreferencesResponse:
+    """Return the current user's preferences."""
+    preferences = await repo.get(user.sub)
+    return PreferencesResponse.from_model(preferences)
+
+
+@router.put("/")
+async def update_preferences(
+    body: UpdatePreferencesRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[PreferencesRepository, Depends(get_preferences_repo)],
+) -> PreferencesResponse:
+    """Replace the current user's preferences."""
+    preferences = await repo.set(user.sub, Preferences(tour_completed=body.tour_completed))
+    return PreferencesResponse.from_model(preferences)

--- a/src/openfactcheck/api/routers/secrets.py
+++ b/src/openfactcheck/api/routers/secrets.py
@@ -1,0 +1,60 @@
+"""User secret management endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, status
+
+from openfactcheck.api.crypto.protocols import SecretCipher
+from openfactcheck.api.dependencies import get_cipher, get_current_user, get_secret_repo
+from openfactcheck.api.errors import NotFoundError, SecretLimitError
+from openfactcheck.api.models import AuthUser
+from openfactcheck.api.models.secret import SECRET_NAME_PATTERN
+from openfactcheck.api.repositories.protocols import SecretRepository
+from openfactcheck.api.schemas.secrets import SecretResponse, SetSecretRequest
+
+router = APIRouter(prefix="/secrets", tags=["secrets"])
+
+SecretName = Annotated[str, Path(pattern=SECRET_NAME_PATTERN, max_length=64)]
+
+_MIN_HINT_LENGTH = 8
+"""Shortest value length for which a trailing hint is revealed."""
+
+
+@router.get("/")
+async def list_secrets(
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[SecretRepository, Depends(get_secret_repo)],
+) -> list[SecretResponse]:
+    """List the user's stored secrets, without their values."""
+    secrets = await repo.list(user.sub)
+    return [SecretResponse.from_model(s) for s in secrets]
+
+
+@router.put("/{name}")
+async def set_secret(
+    name: SecretName,
+    body: SetSecretRequest,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[SecretRepository, Depends(get_secret_repo)],
+    cipher: Annotated[SecretCipher, Depends(get_cipher)],
+) -> SecretResponse:
+    """Set or replace a secret's value. The value is encrypted and never returned."""
+    ciphertext = await cipher.encrypt(body.value)
+    # Reveal the last four characters as a hint, only when the value is long enough not to over-reveal it.
+    hint = body.value[-4:] if len(body.value) >= _MIN_HINT_LENGTH else ""
+    secret = await repo.set(user.sub, name, ciphertext, hint)
+    if secret is None:
+        raise SecretLimitError
+    return SecretResponse.from_model(secret)
+
+
+@router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_secret(
+    name: SecretName,
+    user: Annotated[AuthUser, Depends(get_current_user)],
+    repo: Annotated[SecretRepository, Depends(get_secret_repo)],
+) -> None:
+    """Delete a secret."""
+    deleted = await repo.delete(user.sub, name)
+    if not deleted:
+        raise NotFoundError(f"Secret '{name}' not found")

--- a/src/openfactcheck/api/schemas/preferences.py
+++ b/src/openfactcheck/api/schemas/preferences.py
@@ -1,0 +1,39 @@
+"""Preferences request/response schemas."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from openfactcheck.api.models import Preferences
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class UpdatePreferencesRequest(BaseModel):
+    """Input payload for replacing a user's preferences."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    tour_completed: bool = False
+    """Whether the user has finished the welcome tour."""
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class PreferencesResponse(BaseModel):
+    """A user's preferences returned in API responses."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    tour_completed: bool
+    """Whether the user has finished the welcome tour."""
+
+    @staticmethod
+    def from_model(preferences: Preferences) -> PreferencesResponse:
+        """Convert a domain ``Preferences`` to a response schema."""
+        return PreferencesResponse(tour_completed=preferences.tour_completed)

--- a/src/openfactcheck/api/schemas/secrets.py
+++ b/src/openfactcheck/api/schemas/secrets.py
@@ -1,0 +1,58 @@
+"""Secret request/response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from openfactcheck.api.models import Secret
+
+# ---------------------------------------------------------------------------
+# Requests
+# ---------------------------------------------------------------------------
+
+
+class SetSecretRequest(BaseModel):
+    """Input payload for setting or replacing a secret's value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    value: str = Field(min_length=1, max_length=4096)
+    """The raw secret value. Stored encrypted and never returned.
+
+    1 to 4096 characters.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class SecretResponse(BaseModel):
+    """A stored secret returned in API responses, without its value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    name: str
+    """Identifier for the secret, for example ``"openai"``."""
+
+    hint: str
+    """Trailing characters of the value, shown so the user can recognize the stored key."""
+
+    created_at: datetime
+    """Timestamp the secret was first set."""
+
+    updated_at: datetime
+    """Timestamp of the most recent change."""
+
+    @staticmethod
+    def from_model(secret: Secret) -> SecretResponse:
+        """Convert a domain ``Secret`` to a response schema."""
+        return SecretResponse(
+            name=secret.name,
+            hint=secret.hint,
+            created_at=secret.created_at,
+            updated_at=secret.updated_at,
+        )

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,6 +1,9 @@
 """API integration test fixtures — test client, mock auth, in-memory SQLite."""
 
+import shutil
+import tempfile
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -8,10 +11,20 @@ from httpx import ASGITransport, AsyncClient
 from openfactcheck.api.app import create_app
 from openfactcheck.api.auth.dev import DEV_USER
 from openfactcheck.api.config import APIConfig
-from openfactcheck.api.dependencies import get_current_user, get_project_repo, get_workspace_repo
+from openfactcheck.api.crypto.local import LocalCipher
+from openfactcheck.api.dependencies import (
+    get_cipher,
+    get_current_user,
+    get_preferences_repo,
+    get_project_repo,
+    get_secret_repo,
+    get_workspace_repo,
+)
 from openfactcheck.api.models import AuthUser
 from openfactcheck.api.repositories.sqlite.engine import create_engine, create_session_factory, create_tables
+from openfactcheck.api.repositories.sqlite.preferences import SqlitePreferencesRepository
 from openfactcheck.api.repositories.sqlite.projects import SqliteProjectRepository
+from openfactcheck.api.repositories.sqlite.secrets import SqliteSecretRepository
 from openfactcheck.api.repositories.sqlite.workspaces import SqliteWorkspaceRepository
 
 TEST_USER = DEV_USER
@@ -25,6 +38,11 @@ async def client() -> AsyncIterator[AsyncClient]:
     sf = create_session_factory(engine)
     project_repo = SqliteProjectRepository(sf)
     workspace_repo = SqliteWorkspaceRepository(sf)
+    secret_repo = SqliteSecretRepository(sf)
+    preferences_repo = SqlitePreferencesRepository(sf)
+
+    key_dir = tempfile.mkdtemp()
+    cipher = LocalCipher(str(Path(key_dir) / "secrets.key"))
 
     config = APIConfig(auth_bypass=True)
     app = create_app(config)
@@ -38,11 +56,24 @@ async def client() -> AsyncIterator[AsyncClient]:
     async def override_workspace_repo() -> SqliteWorkspaceRepository:
         return workspace_repo
 
+    async def override_secret_repo() -> SqliteSecretRepository:
+        return secret_repo
+
+    async def override_preferences_repo() -> SqlitePreferencesRepository:
+        return preferences_repo
+
+    async def override_cipher() -> LocalCipher:
+        return cipher
+
     app.dependency_overrides[get_current_user] = override_current_user
     app.dependency_overrides[get_project_repo] = override_project_repo
     app.dependency_overrides[get_workspace_repo] = override_workspace_repo
+    app.dependency_overrides[get_secret_repo] = override_secret_repo
+    app.dependency_overrides[get_preferences_repo] = override_preferences_repo
+    app.dependency_overrides[get_cipher] = override_cipher
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
 
     await engine.dispose()
+    shutil.rmtree(key_dir, ignore_errors=True)

--- a/tests/api/crypto/conftest.py
+++ b/tests/api/crypto/conftest.py
@@ -1,0 +1,28 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+"""Shared fixtures for cipher tests — moto-mocked KMS key."""
+
+import os
+from collections.abc import AsyncIterator
+
+import boto3
+import pytest_asyncio
+from moto import mock_aws
+
+from openfactcheck.api.crypto.kms import KmsCipher
+
+REGION = "us-east-1"
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def kms_cipher() -> AsyncIterator[KmsCipher]:
+    """Yield a KmsCipher bound to a fresh moto-mocked KMS key."""
+    with mock_aws():
+        os.environ["AWS_DEFAULT_REGION"] = REGION
+        os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+        os.environ["AWS_SECURITY_TOKEN"] = "testing"
+        os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+        client = boto3.client("kms", region_name=REGION)
+        key = client.create_key()
+        yield KmsCipher(key["KeyMetadata"]["KeyId"], REGION)

--- a/tests/api/crypto/test_kms.py
+++ b/tests/api/crypto/test_kms.py
@@ -1,0 +1,16 @@
+"""Tests for KmsCipher (moto-mocked KMS)."""
+
+import pytest
+
+from openfactcheck.api.crypto.kms import KmsCipher
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_KmsCipher_encrypt_decrypt_round_trip(kms_cipher: KmsCipher) -> None:
+    """Decrypting a KMS-encrypted value returns the original, and the ciphertext differs from it."""
+    ciphertext = await kms_cipher.encrypt("sk-secret-value")
+    plaintext = await kms_cipher.decrypt(ciphertext)
+
+    assert ciphertext != "sk-secret-value"
+    assert plaintext == "sk-secret-value"

--- a/tests/api/crypto/test_local.py
+++ b/tests/api/crypto/test_local.py
@@ -1,0 +1,30 @@
+"""Tests for LocalCipher."""
+
+import stat
+from pathlib import Path
+
+import pytest
+
+from openfactcheck.api.crypto.local import LocalCipher
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_LocalCipher_encrypt_decrypt_round_trip(tmp_path: Path) -> None:
+    """Decrypting an encrypted value returns the original, and the ciphertext differs from it."""
+    cipher = LocalCipher(str(tmp_path / "secrets.key"))
+
+    ciphertext = await cipher.encrypt("sk-secret-value")
+    plaintext = await cipher.decrypt(ciphertext)
+
+    assert ciphertext != "sk-secret-value"
+    assert plaintext == "sk-secret-value"
+
+
+async def test_LocalCipher_persists_key_with_owner_only_permissions(tmp_path: Path) -> None:
+    """The key file is written with 0600 permissions and reused by a fresh instance."""
+    key_path = tmp_path / "secrets.key"
+    ciphertext = await LocalCipher(str(key_path)).encrypt("value")
+
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert await LocalCipher(str(key_path)).decrypt(ciphertext) == "value"

--- a/tests/api/repositories/dynamodb/test_preferences.py
+++ b/tests/api/repositories/dynamodb/test_preferences.py
@@ -1,0 +1,44 @@
+"""Tests for DynamoPreferencesRepository."""
+
+import pytest
+
+from openfactcheck.api.models import Preferences
+from openfactcheck.api.repositories.dynamodb.preferences import DynamoPreferencesRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+REGION = "us-east-1"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(dynamo_table: str) -> DynamoPreferencesRepository:
+    return DynamoPreferencesRepository(dynamo_table, region_name=REGION)
+
+
+async def test_DynamoPreferencesRepository_get_returns_defaults_when_unset(repo: DynamoPreferencesRepository) -> None:
+    """An unset user reads as an all-default preferences record."""
+    assert await repo.get(USER_ID) == Preferences(tour_completed=False)
+
+
+async def test_DynamoPreferencesRepository_set_persists(repo: DynamoPreferencesRepository) -> None:
+    """Set stores preferences that a later get returns."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+
+    assert (await repo.get(USER_ID)).tour_completed is True
+
+
+async def test_DynamoPreferencesRepository_set_replaces(repo: DynamoPreferencesRepository) -> None:
+    """A second set replaces the stored preferences."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+    await repo.set(USER_ID, Preferences(tour_completed=False))
+
+    assert (await repo.get(USER_ID)).tour_completed is False
+
+
+async def test_DynamoPreferencesRepository_scopes_to_user(repo: DynamoPreferencesRepository) -> None:
+    """Preferences are isolated per user."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+
+    assert (await repo.get(OTHER_USER)).tour_completed is False

--- a/tests/api/repositories/dynamodb/test_secrets.py
+++ b/tests/api/repositories/dynamodb/test_secrets.py
@@ -1,0 +1,83 @@
+"""Tests for DynamoSecretRepository."""
+
+import pytest
+
+from openfactcheck.api.repositories.dynamodb.secrets import MAX_SECRETS_PER_USER, DynamoSecretRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+REGION = "us-east-1"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(dynamo_table: str) -> DynamoSecretRepository:
+    return DynamoSecretRepository(dynamo_table, region_name=REGION)
+
+
+async def test_DynamoSecretRepository_set_returns_masked_secret(repo: DynamoSecretRepository) -> None:
+    """Set returns the secret's name and hint, never its value."""
+    secret = await repo.set(USER_ID, "openai", "ciphertext-abc", "wxyz")
+
+    assert secret is not None
+    assert secret.name == "openai"
+    assert secret.hint == "wxyz"
+    assert "ciphertext" not in secret.model_dump()
+
+
+async def test_DynamoSecretRepository_list_is_sorted_and_masked(repo: DynamoSecretRepository) -> None:
+    """List returns the user's secrets ordered by name, without ciphertext."""
+    await repo.set(USER_ID, "openrouter", "ct-2", "2222")
+    await repo.set(USER_ID, "anthropic", "ct-1", "1111")
+
+    secrets = await repo.list(USER_ID)
+
+    assert [s.name for s in secrets] == ["anthropic", "openrouter"]
+    assert set(secrets[0].model_dump()) == {"name", "hint", "created_at", "updated_at"}
+
+
+async def test_DynamoSecretRepository_get_ciphertext(repo: DynamoSecretRepository) -> None:
+    """Get-ciphertext returns the stored ciphertext, or None when unset."""
+    await repo.set(USER_ID, "openai", "ciphertext-abc", "wxyz")
+
+    assert await repo.get_ciphertext(USER_ID, "openai") == "ciphertext-abc"
+    assert await repo.get_ciphertext(USER_ID, "missing") is None
+
+
+async def test_DynamoSecretRepository_set_replaces_and_keeps_created_at(repo: DynamoSecretRepository) -> None:
+    """Replacing a secret keeps created_at and does not move updated_at backwards."""
+    first = await repo.set(USER_ID, "openai", "ct-1", "1111")
+    second = await repo.set(USER_ID, "openai", "ct-2", "2222")
+
+    assert first is not None
+    assert second is not None
+    assert second.created_at == first.created_at
+    assert second.updated_at >= first.updated_at
+    assert await repo.get_ciphertext(USER_ID, "openai") == "ct-2"
+
+
+async def test_DynamoSecretRepository_set_enforces_limit(repo: DynamoSecretRepository) -> None:
+    """Set returns None for a new secret past the limit, but still replaces existing ones."""
+    for i in range(MAX_SECRETS_PER_USER):
+        assert await repo.set(USER_ID, f"key_{i}", "ct", "hint") is not None
+
+    assert await repo.set(USER_ID, "one_too_many", "ct", "hint") is None
+    assert await repo.set(USER_ID, "key_0", "ct-new", "new") is not None
+
+
+async def test_DynamoSecretRepository_delete(repo: DynamoSecretRepository) -> None:
+    """Delete removes a secret and reports whether one was deleted."""
+    await repo.set(USER_ID, "openai", "ct", "hint")
+
+    assert await repo.delete(USER_ID, "openai") is True
+    assert await repo.delete(USER_ID, "openai") is False
+    assert await repo.list(USER_ID) == []
+
+
+async def test_DynamoSecretRepository_scopes_to_user(repo: DynamoSecretRepository) -> None:
+    """Secrets are isolated per user."""
+    await repo.set(USER_ID, "openai", "ct", "hint")
+
+    assert await repo.list(OTHER_USER) == []
+    assert await repo.get_ciphertext(OTHER_USER, "openai") is None

--- a/tests/api/repositories/sqlite/test_preferences.py
+++ b/tests/api/repositories/sqlite/test_preferences.py
@@ -1,0 +1,44 @@
+"""Tests for SqlitePreferencesRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.models import Preferences
+from openfactcheck.api.repositories.sqlite.preferences import SqlitePreferencesRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(db_session_factory: async_sessionmaker[AsyncSession]) -> SqlitePreferencesRepository:
+    return SqlitePreferencesRepository(db_session_factory)
+
+
+async def test_SqlitePreferencesRepository_get_returns_defaults_when_unset(repo: SqlitePreferencesRepository) -> None:
+    """An unset user reads as an all-default preferences record."""
+    assert await repo.get(USER_ID) == Preferences(tour_completed=False)
+
+
+async def test_SqlitePreferencesRepository_set_persists(repo: SqlitePreferencesRepository) -> None:
+    """Set stores preferences that a later get returns."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+
+    assert (await repo.get(USER_ID)).tour_completed is True
+
+
+async def test_SqlitePreferencesRepository_set_replaces(repo: SqlitePreferencesRepository) -> None:
+    """A second set replaces the stored preferences."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+    await repo.set(USER_ID, Preferences(tour_completed=False))
+
+    assert (await repo.get(USER_ID)).tour_completed is False
+
+
+async def test_SqlitePreferencesRepository_scopes_to_user(repo: SqlitePreferencesRepository) -> None:
+    """Preferences are isolated per user."""
+    await repo.set(USER_ID, Preferences(tour_completed=True))
+
+    assert (await repo.get(OTHER_USER)).tour_completed is False

--- a/tests/api/repositories/sqlite/test_secrets.py
+++ b/tests/api/repositories/sqlite/test_secrets.py
@@ -1,0 +1,83 @@
+"""Tests for SqliteSecretRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from openfactcheck.api.repositories.sqlite.secrets import MAX_SECRETS_PER_USER, SqliteSecretRepository
+
+USER_ID = "user-1"
+OTHER_USER = "user-2"
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+@pytest.fixture
+def repo(db_session_factory: async_sessionmaker[AsyncSession]) -> SqliteSecretRepository:
+    return SqliteSecretRepository(db_session_factory)
+
+
+async def test_SqliteSecretRepository_set_returns_masked_secret(repo: SqliteSecretRepository) -> None:
+    """Set returns the secret's name and hint, never its value."""
+    secret = await repo.set(USER_ID, "openai", "ciphertext-abc", "wxyz")
+
+    assert secret is not None
+    assert secret.name == "openai"
+    assert secret.hint == "wxyz"
+    assert "ciphertext" not in secret.model_dump()
+
+
+async def test_SqliteSecretRepository_list_is_sorted_and_masked(repo: SqliteSecretRepository) -> None:
+    """List returns the user's secrets ordered by name, without ciphertext."""
+    await repo.set(USER_ID, "openrouter", "ct-2", "2222")
+    await repo.set(USER_ID, "anthropic", "ct-1", "1111")
+
+    secrets = await repo.list(USER_ID)
+
+    assert [s.name for s in secrets] == ["anthropic", "openrouter"]
+    assert set(secrets[0].model_dump()) == {"name", "hint", "created_at", "updated_at"}
+
+
+async def test_SqliteSecretRepository_get_ciphertext(repo: SqliteSecretRepository) -> None:
+    """Get-ciphertext returns the stored ciphertext, or None when unset."""
+    await repo.set(USER_ID, "openai", "ciphertext-abc", "wxyz")
+
+    assert await repo.get_ciphertext(USER_ID, "openai") == "ciphertext-abc"
+    assert await repo.get_ciphertext(USER_ID, "missing") is None
+
+
+async def test_SqliteSecretRepository_set_replaces_and_keeps_created_at(repo: SqliteSecretRepository) -> None:
+    """Replacing a secret keeps created_at and does not move updated_at backwards."""
+    first = await repo.set(USER_ID, "openai", "ct-1", "1111")
+    second = await repo.set(USER_ID, "openai", "ct-2", "2222")
+
+    assert first is not None
+    assert second is not None
+    assert second.created_at == first.created_at
+    assert second.updated_at >= first.updated_at
+    assert await repo.get_ciphertext(USER_ID, "openai") == "ct-2"
+
+
+async def test_SqliteSecretRepository_set_enforces_limit(repo: SqliteSecretRepository) -> None:
+    """Set returns None for a new secret past the limit, but still replaces existing ones."""
+    for i in range(MAX_SECRETS_PER_USER):
+        assert await repo.set(USER_ID, f"key_{i}", "ct", "hint") is not None
+
+    assert await repo.set(USER_ID, "one_too_many", "ct", "hint") is None
+    assert await repo.set(USER_ID, "key_0", "ct-new", "new") is not None
+
+
+async def test_SqliteSecretRepository_delete(repo: SqliteSecretRepository) -> None:
+    """Delete removes a secret and reports whether one was deleted."""
+    await repo.set(USER_ID, "openai", "ct", "hint")
+
+    assert await repo.delete(USER_ID, "openai") is True
+    assert await repo.delete(USER_ID, "openai") is False
+    assert await repo.list(USER_ID) == []
+
+
+async def test_SqliteSecretRepository_scopes_to_user(repo: SqliteSecretRepository) -> None:
+    """Secrets are isolated per user."""
+    await repo.set(USER_ID, "openai", "ct", "hint")
+
+    assert await repo.list(OTHER_USER) == []
+    assert await repo.get_ciphertext(OTHER_USER, "openai") is None

--- a/tests/api/test_preferences.py
+++ b/tests/api/test_preferences.py
@@ -1,0 +1,33 @@
+"""Tests for user preferences endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+PREFERENCES_BASE = "/api/v1/preferences"
+
+
+async def test_get_preferences_defaults(client: AsyncClient) -> None:
+    """GET returns all-default preferences for a user who has set none."""
+    response = await client.get(f"{PREFERENCES_BASE}/")
+
+    assert response.status_code == 200
+    assert response.json() == {"tour_completed": False}
+
+
+async def test_update_preferences(client: AsyncClient) -> None:
+    """PUT replaces and returns the user's preferences."""
+    response = await client.put(f"{PREFERENCES_BASE}/", json={"tour_completed": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"tour_completed": True}
+
+
+async def test_update_preferences_persists(client: AsyncClient) -> None:
+    """A later GET returns the preferences set by a prior PUT."""
+    await client.put(f"{PREFERENCES_BASE}/", json={"tour_completed": True})
+
+    response = await client.get(f"{PREFERENCES_BASE}/")
+
+    assert response.json() == {"tour_completed": True}

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -60,7 +60,7 @@ async def test_set_secret_replaces(client: AsyncClient) -> None:
 
 async def test_set_secret_rejects_invalid_name(client: AsyncClient) -> None:
     """A name that breaks the pattern is rejected."""
-    response = await client.put(f"{SECRETS_BASE}/BadName", json={"value": "value-1234"})
+    response = await client.put(f"{SECRETS_BASE}/bad-name", json={"value": "value-1234"})
 
     assert response.status_code == 422
 

--- a/tests/api/test_secrets.py
+++ b/tests/api/test_secrets.py
@@ -1,0 +1,99 @@
+"""Tests for secret management endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+from openfactcheck.api.repositories.constants import MAX_SECRETS_PER_USER
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+SECRETS_BASE = "/api/v1/secrets"
+
+
+async def test_set_secret(client: AsyncClient) -> None:
+    """PUT stores a secret and returns its masked record."""
+    response = await client.put(f"{SECRETS_BASE}/openai", json={"value": "sk-proj-ABCDEFGHwxyz"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "openai"
+    assert body["hint"] == "wxyz"
+
+
+async def test_set_secret_never_returns_value(client: AsyncClient) -> None:
+    """The raw value never appears in the set or list responses."""
+    value = "sk-proj-ABCDEFGHwxyz"
+    set_response = await client.put(f"{SECRETS_BASE}/openai", json={"value": value})
+    list_response = await client.get(f"{SECRETS_BASE}/")
+
+    assert value not in set_response.text
+    assert value not in list_response.text
+    assert "value" not in set_response.json()
+
+
+async def test_list_secrets(client: AsyncClient) -> None:
+    """GET returns the user's secrets ordered by name."""
+    await client.put(f"{SECRETS_BASE}/openrouter", json={"value": "value-two-2222"})
+    await client.put(f"{SECRETS_BASE}/anthropic", json={"value": "value-one-1111"})
+
+    response = await client.get(f"{SECRETS_BASE}/")
+
+    assert response.status_code == 200
+    assert [s["name"] for s in response.json()] == ["anthropic", "openrouter"]
+
+
+async def test_list_secrets_empty(client: AsyncClient) -> None:
+    """GET returns an empty list when no secrets are stored."""
+    response = await client.get(f"{SECRETS_BASE}/")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_set_secret_replaces(client: AsyncClient) -> None:
+    """A second PUT replaces the value and updates the hint."""
+    await client.put(f"{SECRETS_BASE}/openai", json={"value": "old-value-0000"})
+    response = await client.put(f"{SECRETS_BASE}/openai", json={"value": "new-value-9999"})
+
+    assert response.json()["hint"] == "9999"
+
+
+async def test_set_secret_rejects_invalid_name(client: AsyncClient) -> None:
+    """A name that breaks the pattern is rejected."""
+    response = await client.put(f"{SECRETS_BASE}/BadName", json={"value": "value-1234"})
+
+    assert response.status_code == 422
+
+
+async def test_set_secret_rejects_empty_value(client: AsyncClient) -> None:
+    """An empty value is rejected."""
+    response = await client.put(f"{SECRETS_BASE}/openai", json={"value": ""})
+
+    assert response.status_code == 422
+
+
+async def test_set_secret_enforces_limit(client: AsyncClient) -> None:
+    """Storing a new secret past the limit returns 422."""
+    for i in range(MAX_SECRETS_PER_USER):
+        assert (await client.put(f"{SECRETS_BASE}/key_{i}", json={"value": "value-1234"})).status_code == 200
+
+    response = await client.put(f"{SECRETS_BASE}/one_too_many", json={"value": "value-1234"})
+
+    assert response.status_code == 422
+
+
+async def test_delete_secret(client: AsyncClient) -> None:
+    """DELETE removes a secret."""
+    await client.put(f"{SECRETS_BASE}/openai", json={"value": "value-1234"})
+
+    response = await client.delete(f"{SECRETS_BASE}/openai")
+
+    assert response.status_code == 204
+    assert (await client.get(f"{SECRETS_BASE}/")).json() == []
+
+
+async def test_delete_secret_missing(client: AsyncClient) -> None:
+    """Deleting a secret that does not exist returns 404."""
+    response = await client.delete(f"{SECRETS_BASE}/openai")
+
+    assert response.status_code == 404

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,9 @@ wheels = [
 dynamodb = [
     { name = "mypy-boto3-dynamodb" },
 ]
+kms = [
+    { name = "mypy-boto3-kms" },
+]
 
 [[package]]
 name = "botocore"
@@ -1230,6 +1233,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-boto3-kms"
+version = "1.43.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/a5/a63234e7787019443c52f720afea57cf1a1d22a6e8e077b3c6a3916fdd98/mypy_boto3_kms-1.43.12.tar.gz", hash = "sha256:a4d23f018422a79bc4a886676f63eba548a98b06f5dcd0395e424d7c472eb340", size = 30688, upload-time = "2026-05-20T20:01:23.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/17/9d36757acee0987ef78220d1868f1ceb0cf458928444f5a81e98a4de3b44/mypy_boto3_kms-1.43.12-py3-none-any.whl", hash = "sha256:4a74f7b4aa9fcce9a1021ad2586059f2374a4b89baa251e57e6acc16282fd782", size = 39009, upload-time = "2026-05-20T20:01:20.104Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1520,6 +1532,7 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "aiosqlite" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "mangum" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -1535,7 +1548,7 @@ rarr = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "boto3-stubs", extra = ["dynamodb"] },
+    { name = "boto3-stubs", extra = ["dynamodb", "kms"] },
     { name = "httpx" },
     { name = "moto", extra = ["dynamodb"] },
     { name = "openfactcheck", extra = ["api", "cloud"] },
@@ -1559,6 +1572,7 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'api'", specifier = ">=0.22" },
     { name = "anthropic", specifier = ">=0.109" },
     { name = "boto3", marker = "extra == 'cloud'", specifier = ">=1.43" },
+    { name = "cryptography", marker = "extra == 'api'", specifier = ">=48.0.1" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.137.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mangum", marker = "extra == 'api'", specifier = ">=0.21" },
@@ -1575,7 +1589,7 @@ provides-extras = ["api", "cloud", "rarr"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3-stubs", extras = ["dynamodb"], specifier = ">=1.43" },
+    { name = "boto3-stubs", extras = ["dynamodb", "kms"], specifier = ">=1.43" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "moto", extras = ["dynamodb"], specifier = ">=5.2" },
     { name = "openfactcheck", extras = ["api", "cloud"] },


### PR DESCRIPTION
Adds a user-settings subsystem to the API: per-user **secrets** (encrypted) and **preferences**, in a dedicated `openfactcheck-users` DynamoDB table separate from the app-data table so it carries its own KMS key and tight IAM.

## Crypto
- `SecretCipher` protocol with two backends, dispatched by `config.mode`: `KmsCipher` (cloud, direct KMS encrypt/decrypt) and `LocalCipher` (offline Fernet, auto-generated `0600` key file).

## Secrets
- Masked `Secret` model (name + last-4 hint + timestamps; the value is never returned), repository on DynamoDB + SQLite, `GET/PUT/DELETE /api/v1/secrets`. Name-validated, per-user limit enforced. Encryption happens at the endpoint; the repository only ever stores ciphertext.

## Preferences
- `Preferences` model + repository, `GET/PUT /api/v1/preferences` — moves account settings (such as tour-completed) off Cognito.

## Infra (Terraform, base/)
- KMS CMK + alias, the `openfactcheck-users-db` table with SSE-KMS, and the API Lambda IAM (`kms:Encrypt`/`Decrypt` + table access) plus env wiring. `tofu validate` clean.

## Tests
777 pass (38 new): cipher round-trips (incl. moto-mocked KMS), both repositories on moto-DynamoDB and SQLite, and the endpoints via `AsyncClient` — including that the raw value never leaves the server.

Backend half of the secrets feature; the playground settings UI and per-block-key removal follow in a separate PR. The engine run-time key resolution (read + decrypt at execution) is a later step, so the engine Lambda intentionally has no secret access yet.