### PR TITLE
fix: lazy-load facade exports at the package root

### DIFF
--- a/src/openfactcheck/__init__.py
+++ b/src/openfactcheck/__init__.py
@@ -1,13 +1,30 @@
 """OpenFactCheck: an open-source framework for fact-checking and factuality evaluation of LLMs."""
 
-import importlib.metadata
+import importlib
+from importlib.metadata import version
+from typing import TYPE_CHECKING
 
-from openfactcheck._core import OpenFactCheck
-from openfactcheck.config import OpenFactCheckConfig
+if TYPE_CHECKING:
+    from openfactcheck._core import OpenFactCheck
+    from openfactcheck.config import OpenFactCheckConfig
 
 __all__ = [
     "OpenFactCheck",
     "OpenFactCheckConfig",
 ]
 
-__version__ = importlib.metadata.version("openfactcheck")
+__version__ = version("openfactcheck")
+
+# Re-export the facade lazily: importing the package, or any submodule such as the
+# slim API, must not force-load the full library behind OpenFactCheck.
+_EXPORTS = {
+    "OpenFactCheck": "openfactcheck._core",
+    "OpenFactCheckConfig": "openfactcheck.config",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Import a facade export on first access."""
+    if (module := _EXPORTS.get(name)) is not None:
+        return getattr(importlib.import_module(module), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
The package root eagerly imported the facade:

```python
from openfactcheck._core import OpenFactCheck
from openfactcheck.config import OpenFactCheckConfig
```

So importing **any** `openfactcheck` submodule ran `__init__` and force-loaded the whole library behind the facade. The API ships only the `api` package in its slim Lambda container, so the function failed at import:

```
Runtime.ImportModuleError: Unable to import module ... No module named "openfactcheck._core"
```

Expose the facade names through a module `__getattr__` so the blessed `from openfactcheck import OpenFactCheck` still works, but importing a submodule (e.g. `openfactcheck.api`) no longer pulls in `_core`/`config`.

Surfaced by the first API image rebuild since the facade landed (#87) — the previously deployed image predated the eager imports. Verified: importing the API loads no `_core`, the facade import path still resolves, lint + 739 tests green.