### PR TITLE
feat: execute pipeline blocks through the library

### DIFF
--- a/src/openfactcheck/api/routers/workspaces.py
+++ b/src/openfactcheck/api/routers/workspaces.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import os
+import sys
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -9,9 +11,12 @@ from fastapi import APIRouter, Depends, Path, status
 from pydantic import BaseModel
 
 from openfactcheck.api.config import APIConfig
+from openfactcheck.api.crypto.protocols import SecretCipher
 from openfactcheck.api.dependencies import (
+    get_cipher,
     get_config,
     get_current_user,
+    get_secret_repo,
     get_workspace_repo,
 )
 from openfactcheck.api.errors import (
@@ -31,7 +36,7 @@ from openfactcheck.api.repositories.constants import (
     MAX_CONTENT_BYTES,
     MAX_PIPELINE_BYTES,
 )
-from openfactcheck.api.repositories.protocols import WorkspaceRepository
+from openfactcheck.api.repositories.protocols import SecretRepository, WorkspaceRepository
 from openfactcheck.api.schemas.workspaces import (
     CreateWorkspaceRequest,
     ReorderWorkspacesRequest,
@@ -223,28 +228,75 @@ async def _start_sfn(
     await asyncio.to_thread(_start)
 
 
-async def _run_local(
+_RUN_TIMEOUT_SECONDS = 300
+
+
+async def _decrypt_secrets(secret_repo: SecretRepository, cipher: SecretCipher, user_id: str) -> dict[str, str]:
+    """Decrypt the user's stored secrets into an environment-variable map."""
+    secrets: dict[str, str] = {}
+    for secret in await secret_repo.list(user_id):
+        ciphertext = await secret_repo.get_ciphertext(user_id, secret.name)
+        if ciphertext is not None:
+            secrets[secret.name] = await cipher.decrypt(ciphertext)
+    return secrets
+
+
+def _result_to_run(stdout: bytes, stderr: bytes) -> WorkspaceRun:
+    """Build a run record from the engine subprocess output."""
+    completed = datetime.now(UTC)
+    try:
+        data = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        message = stderr.decode(errors="replace").strip() or "Pipeline execution failed"
+        return WorkspaceRun(status=WorkspaceRunStatus.FAILED, error=message, completed_at=completed)
+    output = str(data.get("output", ""))
+    if data.get("success"):
+        return WorkspaceRun(status=WorkspaceRunStatus.COMPLETED, output=output, completed_at=completed)
+    return WorkspaceRun(
+        status=WorkspaceRunStatus.FAILED,
+        output=output,
+        error=str(data.get("error") or "Pipeline execution failed"),
+        completed_at=completed,
+    )
+
+
+async def _run_local(  # noqa: PLR0913 - distinct collaborators, each needed for the isolated run.
     repo: WorkspaceRepository,
+    secret_repo: SecretRepository,
+    cipher: SecretCipher,
     user_id: str,
     project_id: str,
     workspace_id: str,
     pipeline: dict[str, object],
 ) -> None:
-    """Local mode: run pipeline in-process and update workspace run state."""
-    from openfactcheck.engine import (  # noqa: PLC0415 - lazy import to avoid engine dependency at module level.
-        execute_pipeline,
-    )
+    """Local mode: run the pipeline in an isolated subprocess and store the result.
 
-    result = await execute_pipeline(pipeline)
-    now = datetime.now(UTC)
-    if result.success:
-        run = WorkspaceRun(status=WorkspaceRunStatus.COMPLETED, output=result.output or "", completed_at=now)
-    else:
+    The subprocess environment is the base environment plus this user's
+    decrypted secrets, so one run's API keys never leak into another's.
+    """
+    secrets = await _decrypt_secrets(secret_repo, cipher, user_id)
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "openfactcheck.engine",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, **secrets},
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(json.dumps(pipeline).encode()),
+            timeout=_RUN_TIMEOUT_SECONDS,
+        )
+        run = _result_to_run(stdout, stderr)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
         run = WorkspaceRun(
             status=WorkspaceRunStatus.FAILED,
-            output=result.output or "",
-            error=result.error or "",
-            completed_at=now,
+            error="Pipeline run timed out",
+            completed_at=datetime.now(UTC),
         )
     await repo.set_run(user_id, project_id, workspace_id, run)
 
@@ -256,6 +308,8 @@ async def run_pipeline(  # noqa: PLR0913 - FastAPI DI requires all params as fun
     body: RunRequest,
     user: Annotated[AuthUser, Depends(get_current_user)],
     repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    secret_repo: Annotated[SecretRepository, Depends(get_secret_repo)],
+    cipher: Annotated[SecretCipher, Depends(get_cipher)],
     config: Annotated[APIConfig, Depends(get_config)],
 ) -> RunResponse:
     """Run a pipeline. Sets workspace run to running and starts execution."""
@@ -281,9 +335,11 @@ async def run_pipeline(  # noqa: PLR0913 - FastAPI DI requires all params as fun
             await repo.set_run(user.sub, project_id, workspace_id, run)
             raise
     else:
-        run = WorkspaceRun(status=WorkspaceRunStatus.RUNNING)
+        run = WorkspaceRun(status=WorkspaceRunStatus.RUNNING, started_at=datetime.now(UTC))
         await repo.set_run(user.sub, project_id, workspace_id, run)
-        task = asyncio.create_task(_run_local(repo, user.sub, project_id, workspace_id, body.pipeline))
+        task = asyncio.create_task(
+            _run_local(repo, secret_repo, cipher, user.sub, project_id, workspace_id, body.pipeline),
+        )
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
 

--- a/src/openfactcheck/chat/backends/openai/params.py
+++ b/src/openfactcheck/chat/backends/openai/params.py
@@ -47,7 +47,7 @@ def config_to_kwargs(config: ModelConfig) -> Kwargs:
 
     params: Kwargs = {"model": config.model}
     _set_optional(params, "temperature", config.temperature)
-    _set_optional(params, "max_tokens", config.max_output_tokens)
+    _set_optional(params, "max_completion_tokens", config.max_output_tokens)
     _set_optional(params, "top_p", config.top_p)
     _set_optional(params, "seed", config.seed)
     _set_optional(params, "frequency_penalty", config.frequency_penalty)

--- a/src/openfactcheck/engine/__main__.py
+++ b/src/openfactcheck/engine/__main__.py
@@ -1,0 +1,28 @@
+"""Run a pipeline as an isolated subprocess.
+
+Reads a Blockly workspace JSON on stdin and writes the execution result as
+JSON on stdout. The process environment carries one user's secrets (set by the
+caller), so each run is isolated from every other run in its own process.
+
+    python -m openfactcheck.engine < pipeline.json
+"""
+
+import asyncio
+import json
+import sys
+
+from openfactcheck.engine.executor import execute_pipeline
+
+
+def main() -> None:
+    """Execute the pipeline read from stdin and write the result to stdout."""
+    pipeline = json.load(sys.stdin)
+    result = asyncio.run(execute_pipeline(pipeline))
+    json.dump(
+        {"success": result.success, "output": result.output, "error": result.error or ""},
+        sys.stdout,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openfactcheck/engine/block.py
+++ b/src/openfactcheck/engine/block.py
@@ -36,7 +36,7 @@ class Block:
 
     """
 
-    __slots__ = ("_fields", "_inputs", "_next_data", "id", "type")
+    __slots__ = ("_extra", "_fields", "_inputs", "_next_data", "id", "type")
 
     def __init__(self, data: dict[str, Any]) -> None:
         self.type: str = str(data.get("type", ""))
@@ -44,6 +44,7 @@ class Block:
         self._fields: dict[str, str] = _parse_fields(data)
         self._inputs: dict[str, dict[str, Any]] = _parse_inputs(data)
         self._next_data: dict[str, Any] | None = _parse_next(data)
+        self._extra: dict[str, Any] = _parse_extra(data)
 
     def get_field(self, name: str, default: str = "") -> str:
         """Read a static field value from the block.
@@ -52,6 +53,15 @@ class Block:
         (e.g. the text content in a ``text`` block).
         """
         return self._fields.get(name, default)
+
+    def get_extra(self, name: str, default: object = None) -> object:
+        """Read a value from the block's ``extraState``.
+
+        Some fields serialize their value into ``extraState`` rather than
+        ``fields`` (for example a dropdown whose options load asynchronously),
+        so a block's full configuration can span both.
+        """
+        return self._extra.get(name, default)
 
     def get_input_block(self, name: str) -> Block | None:
         """Get the block connected to a named value input.
@@ -109,3 +119,9 @@ def _parse_next(data: dict[str, Any]) -> dict[str, Any] | None:
     if isinstance(raw, dict):
         return raw
     return None
+
+
+def _parse_extra(data: dict[str, Any]) -> dict[str, Any]:
+    """Extract ``extraState`` as a dict, or empty if absent."""
+    raw = data.get("extraState")
+    return raw if isinstance(raw, dict) else {}

--- a/src/openfactcheck/engine/executor.py
+++ b/src/openfactcheck/engine/executor.py
@@ -16,7 +16,6 @@ from typing import Any
 
 from openfactcheck.engine.block import Block
 from openfactcheck.engine.context import ExecutionContext
-from openfactcheck.engine.errors import EngineError
 from openfactcheck.engine.parser import parse_pipeline
 
 
@@ -55,8 +54,9 @@ async def execute_pipeline(pipeline: dict[str, Any]) -> ExecutionResult:
     2. Walks each block chain, executing handlers via the :class:`ExecutionContext`.
     3. Returns an :class:`ExecutionResult` with captured output or error.
 
-    Any :class:`EngineError` raised during execution is caught and returned
-    as a failed result. Other exceptions propagate to the caller.
+    Any failure during execution (an :class:`EngineError`, a model/library
+    error, or an unexpected exception) is caught and returned as a failed
+    result, so a bad graph never crashes the runner.
     """
     ctx = ExecutionContext()
     try:
@@ -71,7 +71,7 @@ async def execute_pipeline(pipeline: dict[str, Any]) -> ExecutionResult:
             success=True,
             output="\n".join(ctx.output_lines),
         )
-    except EngineError as e:
+    except Exception as e:  # noqa: BLE001 - any block or library failure becomes a failed run, not a crash.
         return ExecutionResult(
             success=False,
             output="\n".join(ctx.output_lines),

--- a/src/openfactcheck/engine/handlers/__init__.py
+++ b/src/openfactcheck/engine/handlers/__init__.py
@@ -1,12 +1,15 @@
 """Block handlers — import all handler modules to auto-register them."""
 
 from openfactcheck.engine.handlers import (
+    io,
     lists,
     logic,
     loops,
     math,
+    models,
+    prompts,
     text,
     variables,
 )
 
-__all__ = ["lists", "logic", "loops", "math", "text", "variables"]
+__all__ = ["io", "lists", "logic", "loops", "math", "models", "prompts", "text", "variables"]

--- a/src/openfactcheck/engine/handlers/io.py
+++ b/src/openfactcheck/engine/handlers/io.py
@@ -1,0 +1,65 @@
+"""Handlers for the Input & Output blocks: text input and structured output."""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, Field, create_model
+
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+
+# Schema field type to Python type; ``dict`` becomes a nested model when it has children.
+_PY_TYPE: dict[str, type] = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "list": list,
+    "dict": dict,
+}
+
+
+@handler("text_input")
+def text_input(block: Block, ctx: ExecutionContext) -> None:
+    """Store the block's text as the ``input_text`` variable."""
+    ctx.variables["input_text"] = block.get_field("INPUT_TEXT")
+
+
+@handler("text_input_value")
+def text_input_value(block: Block, _ctx: ExecutionContext) -> str:
+    """Return the block's text as a value for a slot."""
+    return block.get_field("INPUT_TEXT")
+
+
+@handler("structured_output")
+def structured_output(block: Block, _ctx: ExecutionContext) -> type[BaseModel]:
+    """Build a Pydantic model from the block's schema."""
+    try:
+        fields = json.loads(block.get_field("SCHEMA_DATA", default="[]"))
+    except json.JSONDecodeError:
+        fields = []
+    return _build_model("Output", fields if isinstance(fields, list) else [])
+
+
+def _pascal(name: str) -> str:
+    """Convert a field name to a PascalCase class name."""
+    return "".join(part.capitalize() for part in name.split("_") if part) or "Field"
+
+
+def _build_model(name: str, fields: list[Any]) -> type[BaseModel]:
+    """Build a Pydantic model from a schema field list, recursing into ``dict`` fields."""
+    definitions: dict[str, Any] = {}
+    for field in fields:
+        if not isinstance(field, dict):
+            continue
+        field_name = str(field.get("name") or "field")
+        field_type = str(field.get("type", "str"))
+        if field_type == "dict" and isinstance(field.get("children"), list):
+            base: Any = _build_model(f"{name}{_pascal(field_name)}", field["children"])
+        else:
+            base = _PY_TYPE.get(field_type, str)
+        annotation: Any = list[base] if field.get("asList") else base
+        description = str(field.get("description") or "")
+        definitions[field_name] = (annotation, Field(description=description) if description.strip() else ...)
+    return create_model(name, **definitions)

--- a/src/openfactcheck/engine/handlers/models.py
+++ b/src/openfactcheck/engine/handlers/models.py
@@ -1,0 +1,110 @@
+"""Handlers for the Models & Agents blocks: language model and agent.
+
+The language-model block builds a [`ChatClient`][openfactcheck.chat.ChatClient];
+the agent fills the connected prompt template and runs it through the model.
+Provider API keys are read from the environment, which the runner populates from
+the user's stored secrets.
+"""
+
+from typing import TYPE_CHECKING, cast
+
+from pydantic import BaseModel
+
+from openfactcheck.chat import AnthropicConfig, ChatClient, OpenAIConfig, OpenRouterConfig
+from openfactcheck.chat.errors import ChatModelError
+from openfactcheck.engine import resolve
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.errors import EngineError
+from openfactcheck.engine.handler import handler
+
+if TYPE_CHECKING:
+    from openfactcheck.chat.config import ModelConfig
+    from openfactcheck.prompts import PromptTemplate
+
+# Provider id to its chat-layer config class.
+_CONFIG_CLASS: dict[str, type[BaseModel]] = {
+    "openai": OpenAIConfig,
+    "anthropic": AnthropicConfig,
+    "openrouter": OpenRouterConfig,
+}
+
+
+@handler("language_model")
+def language_model(block: Block, _ctx: ExecutionContext) -> ChatClient:
+    """Build a chat client from the block's provider, model, and parameters.
+
+    The model name and sampling parameters live in the block's ``extraState``.
+    The provider's API key is read from the environment when the client runs.
+    """
+    provider = block.get_field("PROVIDER", default="openai")
+    kwargs: dict[str, object] = {"model": _opt_str(block, "model") or ""}
+    _set(kwargs, "temperature", _opt_float(block, "temperature"))
+    _set(kwargs, "top_p", _opt_float(block, "topP"))
+    _set(kwargs, "max_output_tokens", _opt_int(block, "maxTokens"))
+    if provider in {"openai", "openrouter"}:
+        _set(kwargs, "frequency_penalty", _opt_float(block, "freqPenalty"))
+        _set(kwargs, "presence_penalty", _opt_float(block, "presPenalty"))
+        _set(kwargs, "reasoning_effort", _opt_str(block, "reasoningEffort"))
+
+    config_class = _CONFIG_CLASS.get(provider, OpenAIConfig)
+    return ChatClient(config=cast("ModelConfig", config_class(**kwargs)))
+
+
+@handler("agent")
+def agent(block: Block, ctx: ExecutionContext) -> object:
+    """Fill the connected template and run it through the connected model.
+
+    With a structured-output block attached, the reply is constrained to that
+    model and printed as JSON; otherwise the model's free text is printed.
+    """
+    prompt_block = block.get_input_block("PROMPT")
+    model_block = block.get_input_block("MODEL")
+    if prompt_block is None or model_block is None:
+        raise EngineError("Agent needs both a prompt and a model.")
+
+    template = cast("PromptTemplate", ctx.execute_block(prompt_block))
+    values = {name: resolve.string(block, ctx, f"VAR_{name.upper()}") for name in template.variables}
+    messages = template.to_messages(**values)
+    output_block = block.get_input_block("STRUCTURED_OUTPUT")
+
+    try:
+        client = cast("ChatClient", ctx.execute_block(model_block))
+        if output_block is not None:
+            schema = cast("type[BaseModel]", ctx.execute_block(output_block))
+            structured = client.completion_as(messages, schema)
+            result, rendered = structured, structured.model_dump_json(indent=2)
+        else:
+            response = client.completion(messages)
+            result, rendered = response, response.message.content
+    except ChatModelError as e:
+        raise EngineError(f"Model call failed: {e}") from e
+
+    ctx.print(rendered)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set(kwargs: dict[str, object], key: str, value: object) -> None:
+    """Add ``key`` to ``kwargs`` only when ``value`` is present."""
+    if value is not None:
+        kwargs[key] = value
+
+
+def _opt_float(block: Block, key: str) -> float | None:
+    value = block.get_extra(key)
+    return float(value) if isinstance(value, (int, float)) else None
+
+
+def _opt_int(block: Block, key: str) -> int | None:
+    value = block.get_extra(key)
+    return int(value) if isinstance(value, (int, float)) else None
+
+
+def _opt_str(block: Block, key: str) -> str | None:
+    value = block.get_extra(key)
+    return value if isinstance(value, str) else None

--- a/src/openfactcheck/engine/handlers/prompts.py
+++ b/src/openfactcheck/engine/handlers/prompts.py
@@ -1,0 +1,23 @@
+"""Handler for the Prompts block: prompt template."""
+
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.engine.handler import handler
+from openfactcheck.prompts import PromptTemplate, Role
+
+
+@handler("prompt_template")
+def prompt_template(block: Block, _ctx: ExecutionContext) -> PromptTemplate:
+    """Build a prompt template from the block's system and user bodies.
+
+    A completion needs a user turn, so a lone body (only one field filled)
+    becomes the user message; a system message is added only when it accompanies
+    a user prompt.
+    """
+    system = block.get_field("SYSTEM_TEXT")
+    user = block.get_field("USER_TEXT")
+    messages: list[tuple[Role, str]] = []
+    if system.strip() and user.strip():
+        messages.append(("system", system))
+    messages.append(("user", user if user.strip() else system))
+    return PromptTemplate.from_messages(messages, name="prompt_template")

--- a/tests/api/test_run.py
+++ b/tests/api/test_run.py
@@ -1,0 +1,44 @@
+"""Tests for the pipeline run endpoint (local isolated-subprocess execution)."""
+
+import asyncio
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+PROJECTS_BASE = "/api/v1/projects"
+
+
+async def _make_workspace(client: AsyncClient) -> tuple[str, str]:
+    project_id = (await client.post(f"{PROJECTS_BASE}/", json={"name": "P"})).json()["id"]
+    workspace_id = (await client.post(f"{PROJECTS_BASE}/{project_id}/workspaces/", json={"name": "W"})).json()["id"]
+    return project_id, workspace_id
+
+
+async def _poll_run(client: AsyncClient, project_id: str, workspace_id: str) -> dict[str, Any]:
+    url = f"{PROJECTS_BASE}/{project_id}/workspaces/{workspace_id}/run"
+    for _ in range(200):
+        run = (await client.get(url)).json()
+        if run and run["status"] in {"completed", "failed"}:
+            return run
+        await asyncio.sleep(0.05)
+    raise AssertionError("run did not finish in time")
+
+
+async def test_run_executes_pipeline_in_isolated_subprocess(client: AsyncClient) -> None:
+    project_id, workspace_id = await _make_workspace(client)
+    pipeline = {
+        "blocks": {"blocks": [{"type": "text_print", "inputs": {"TEXT": {"block": {"type": "text", "fields": {"TEXT": "hi"}}}}}]},
+    }
+
+    response = await client.post(
+        f"{PROJECTS_BASE}/{project_id}/workspaces/{workspace_id}/run",
+        json={"pipeline": pipeline},
+    )
+
+    assert response.status_code == 202
+    run = await _poll_run(client, project_id, workspace_id)
+    assert run["status"] == "completed"
+    assert run["output"] == "hi"

--- a/tests/chat/backends/openai/test_params.py
+++ b/tests/chat/backends/openai/test_params.py
@@ -3,7 +3,7 @@
 import pytest
 
 from openfactcheck.chat.backends.openai.params import config_to_kwargs, response_format_kwargs, to_strict_schema
-from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig
+from openfactcheck.chat.config import AnthropicConfig, OpenAIConfig, OpenRouterConfig
 from openfactcheck.chat.errors import UnsupportedFeatureError
 from openfactcheck.chat.requests import ResponseFormat
 
@@ -34,12 +34,23 @@ def test_config_to_kwargs_all_fields() -> None:
 
     assert kwargs["model"] == "gpt-4o"
     assert kwargs["temperature"] == 0.3
-    assert kwargs["max_tokens"] == 100
+    assert kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in kwargs
     assert kwargs["top_p"] == 0.9
     assert kwargs["seed"] == 42
     assert kwargs["frequency_penalty"] == 0.5
     assert kwargs["presence_penalty"] == 0.2
     assert kwargs["reasoning_effort"] == "medium"
+
+
+def test_config_to_kwargs_openrouter_uses_max_completion_tokens() -> None:
+    """OpenRouter also uses ``max_completion_tokens`` (the legacy name is deprecated)."""
+    config = OpenRouterConfig(model="openai/gpt-4o", max_output_tokens=100)
+
+    kwargs = config_to_kwargs(config)
+
+    assert kwargs["max_completion_tokens"] == 100
+    assert "max_tokens" not in kwargs
 
 
 def test_config_to_kwargs_rejects_anthropic() -> None:

--- a/tests/engine/test_io.py
+++ b/tests/engine/test_io.py
@@ -1,0 +1,64 @@
+"""Tests for the Input & Output block handlers."""
+
+import json
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_text_input_value_returns_text() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "text_input_value", "fields": {"INPUT_TEXT": "a claim"}})
+
+    assert ctx.execute_block(block) == "a claim"
+
+
+async def test_text_input_stores_variable() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "text_input", "fields": {"INPUT_TEXT": "a claim"}})
+
+    ctx.execute_block(block)
+
+    assert ctx.variables["input_text"] == "a claim"
+
+
+async def test_structured_output_builds_model() -> None:
+    ctx = ExecutionContext()
+    schema = [
+        {"name": "verdict", "type": "bool", "asList": False, "description": "Whether it is true"},
+        {"name": "scores", "type": "int", "asList": True},
+    ]
+    block = Block({"type": "structured_output", "fields": {"SCHEMA_DATA": json.dumps(schema)}})
+
+    model = cast("type[BaseModel]", ctx.execute_block(block))
+
+    assert issubclass(model, BaseModel)
+    instance = model(verdict=True, scores=[1, 2, 3])
+    assert instance.verdict is True
+    assert instance.scores == [1, 2, 3]
+
+
+async def test_structured_output_nested_dict() -> None:
+    ctx = ExecutionContext()
+    schema = [{"name": "meta", "type": "dict", "asList": False, "children": [{"name": "id", "type": "str", "asList": False}]}]
+    block = Block({"type": "structured_output", "fields": {"SCHEMA_DATA": json.dumps(schema)}})
+
+    model = cast("type[BaseModel]", ctx.execute_block(block))
+    instance = model(meta={"id": "abc"})
+
+    assert instance.meta.id == "abc"
+
+
+async def test_structured_output_empty_schema() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "structured_output", "fields": {"SCHEMA_DATA": "[]"}})
+
+    model = cast("type[BaseModel]", ctx.execute_block(block))
+
+    assert issubclass(model, BaseModel)

--- a/tests/engine/test_models.py
+++ b/tests/engine/test_models.py
@@ -1,0 +1,130 @@
+"""Tests for the Models & Agents block handlers."""
+
+import json
+from typing import Any, cast
+
+import pytest
+from pytest_mock import MockerFixture
+
+from openfactcheck.chat import ChatClient
+from openfactcheck.engine import execute_pipeline
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _pipeline(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": {"blocks": list(blocks)}}
+
+
+def _agent_pipeline(*, structured: bool = False) -> dict[str, Any]:
+    inputs: dict[str, Any] = {
+        "PROMPT": {"block": {"type": "prompt_template", "fields": {"SYSTEM_TEXT": "Check.", "USER_TEXT": "Claim: {{claim}}"}}},
+        "MODEL": {"block": {"type": "language_model", "fields": {"PROVIDER": "openai"}, "extraState": {"model": "gpt-4o-mini"}}},
+        "VAR_CLAIM": {"block": {"type": "text_input_value", "fields": {"INPUT_TEXT": "The sky is green."}}},
+    }
+    if structured:
+        inputs["STRUCTURED_OUTPUT"] = {
+            "block": {"type": "structured_output", "fields": {"SCHEMA_DATA": json.dumps([{"name": "verdict", "type": "bool", "asList": False}])}},
+        }
+    return _pipeline({"type": "agent", "inputs": inputs})
+
+
+# ---------------------------------------------------------------------------
+# Block.get_extra (language_model stores model + params there)
+# ---------------------------------------------------------------------------
+
+
+async def test_Block_get_extra() -> None:
+    block = Block({"type": "language_model", "extraState": {"model": "gpt-4o-mini", "temperature": 0.5}})
+
+    assert block.get_extra("model") == "gpt-4o-mini"
+    assert block.get_extra("temperature") == 0.5
+    assert block.get_extra("missing", "fallback") == "fallback"
+
+
+async def test_Block_get_extra_absent() -> None:
+    block = Block({"type": "text"})
+
+    assert block.get_extra("model") is None
+
+
+# ---------------------------------------------------------------------------
+# language_model
+# ---------------------------------------------------------------------------
+
+
+async def test_language_model_reads_extra_state() -> None:
+    ctx = ExecutionContext()
+    block = Block(
+        {
+            "type": "language_model",
+            "fields": {"PROVIDER": "openai"},
+            "extraState": {"model": "gpt-4o-mini", "temperature": 0.5, "maxTokens": 1000},
+        },
+    )
+
+    client = cast("ChatClient", ctx.execute_block(block))
+
+    assert isinstance(client, ChatClient)
+    assert client._config.model == "gpt-4o-mini"  # noqa: SLF001 - asserting the parsed config in a test.
+    assert client._config.provider == "openai"  # noqa: SLF001 - asserting the parsed config in a test.
+
+
+async def test_language_model_anthropic_skips_openai_only_params() -> None:
+    ctx = ExecutionContext()
+    block = Block(
+        {
+            "type": "language_model",
+            "fields": {"PROVIDER": "anthropic"},
+            "extraState": {"model": "claude-3-5-sonnet", "temperature": 0.4, "maxTokens": 2000, "freqPenalty": 0.5},
+        },
+    )
+
+    client = cast("ChatClient", ctx.execute_block(block))
+
+    assert client._config.provider == "anthropic"  # noqa: SLF001 - asserting the parsed config in a test.
+
+
+# ---------------------------------------------------------------------------
+# agent (mocked model)
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_runs_model_and_prints_response(mocker: MockerFixture) -> None:
+    mocker.patch.object(ChatClient, "completion", return_value=mocker.Mock(message=mocker.Mock(content="False.")))
+
+    result = await execute_pipeline(_agent_pipeline())
+
+    assert result.success
+    assert result.output == "False."
+
+
+async def test_agent_fills_template_variable(mocker: MockerFixture) -> None:
+    completion = mocker.patch.object(ChatClient, "completion", return_value=mocker.Mock(message=mocker.Mock(content="ok")))
+
+    await execute_pipeline(_agent_pipeline())
+
+    messages = completion.call_args.args[0]
+    assert messages[-1].content == "Claim: The sky is green."
+
+
+async def test_agent_structured_output_uses_completion_as(mocker: MockerFixture) -> None:
+    structured = mocker.Mock()
+    structured.model_dump_json.return_value = '{"verdict": false}'
+    mocker.patch.object(ChatClient, "completion_as", return_value=structured)
+
+    result = await execute_pipeline(_agent_pipeline(structured=True))
+
+    assert result.success
+    assert result.output == '{"verdict": false}'
+
+
+async def test_agent_without_model_fails() -> None:
+    pipeline = _pipeline({"type": "agent", "inputs": {"PROMPT": {"block": {"type": "prompt_template", "fields": {"USER_TEXT": "Hi"}}}}})
+
+    result = await execute_pipeline(pipeline)
+
+    assert not result.success
+    assert "model" in (result.error or "").lower()

--- a/tests/engine/test_prompts.py
+++ b/tests/engine/test_prompts.py
@@ -1,0 +1,45 @@
+"""Tests for the Prompts block handler."""
+
+from typing import cast
+
+import pytest
+
+from openfactcheck.engine.block import Block
+from openfactcheck.engine.context import ExecutionContext
+from openfactcheck.prompts import PromptTemplate
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_prompt_template_builds_system_and_user() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "prompt_template", "fields": {"SYSTEM_TEXT": "You are a checker.", "USER_TEXT": "Claim: {{claim}}"}})
+
+    template = cast("PromptTemplate", ctx.execute_block(block))
+
+    assert isinstance(template, PromptTemplate)
+    assert "claim" in template.variables
+    messages = template.to_messages(claim="The sky is green.")
+    assert [m.role for m in messages] == ["system", "user"]
+    assert messages[1].content == "Claim: The sky is green."
+
+
+async def test_prompt_template_user_only() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "prompt_template", "fields": {"SYSTEM_TEXT": "", "USER_TEXT": "Just user."}})
+
+    template = cast("PromptTemplate", ctx.execute_block(block))
+
+    assert [m.role for m in template.to_messages()] == ["user"]
+
+
+async def test_prompt_template_system_only_becomes_user() -> None:
+    ctx = ExecutionContext()
+    block = Block({"type": "prompt_template", "fields": {"SYSTEM_TEXT": "Check {{claim}}", "USER_TEXT": ""}})
+
+    template = cast("PromptTemplate", ctx.execute_block(block))
+
+    messages = template.to_messages(claim="X")
+    assert [m.role for m in messages] == ["user"]
+    assert messages[0].content == "Check X"
+    assert "claim" in template.variables


### PR DESCRIPTION
Makes the engine actually run a fact-check graph end to end (local mode), instead of interpreting a toy text/math program.

## Engine
- Handlers for the OpenFactCheck blocks, **split by toolbox category**: `engine/handlers/io.py` (Input & Output), `models.py` (Models & Agents), `prompts.py` (Prompts). They build a real `PromptTemplate`, a `ChatClient`, and a Pydantic model from the structured-output schema; the agent fills the template's variables and calls `completion` / `completion_as`.
- `Block` now reads `extraState` (the language-model block stores its model + sampling params there, not in `fields`).
- The executor turns any block/library failure into a failed result (no hung runs).

## Isolation
- Each run executes in **its own subprocess** (`engine/__main__.py`) whose environment is that user's decrypted secrets. The API process never mutates its own env, so one run's keys never leak into another. (The cloud engine Lambda fetching/decrypting secrets is a separate follow-up.)

## Also
- A **lone prompt body** (only system or only user filled) becomes the user message, so a system-only prompt still runs (Anthropic rejects an empty messages list).
- **chat:** OpenAI and OpenRouter send `max_completion_tokens`; `max_tokens` is deprecated and rejected by newer models.
- **Fix:** a `RUNNING` workspace run now sets `started_at` (it would 400 before; surfaced by the new `/run` test).

795 tests pass (17 new), lint + pyright clean.