### PR TITLE
feat: resolve secrets in the cloud engine, run pipelines in-process

### DIFF
--- a/deployments/base/aws_iam_lambda.tf
+++ b/deployments/base/aws_iam_lambda.tf
@@ -155,3 +155,37 @@ resource "aws_iam_role_policy" "lambda_engine_logs" {
     ]
   })
 }
+
+# Read-only access to the user's encrypted secrets so a run can reach the
+# configured LLM and search providers. Scoped to a query of the users table.
+resource "aws_iam_role_policy" "lambda_engine_dynamodb" {
+  name = "users-secrets-read"
+  role = aws_iam_role.lambda_engine.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "dynamodb:Query"
+        Resource = aws_dynamodb_table.openfactcheck_users.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_engine_kms" {
+  name = "kms-decrypt"
+  role = aws_iam_role.lambda_engine.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "kms:Decrypt"
+        Resource = aws_kms_key.users.arn
+      }
+    ]
+  })
+}

--- a/deployments/base/aws_lambda.tf
+++ b/deployments/base/aws_lambda.tf
@@ -104,8 +104,16 @@ resource "aws_lambda_function" "engine" {
   image_uri        = "${data.aws_ecr_repository.engine.repository_url}:latest"
   source_code_hash = split(":", data.aws_ecr_image.engine.image_digest)[1]
   publish          = true
-  timeout          = 900 # 15 min — max Lambda timeout for long pipelines
-  memory_size      = 512
+  timeout          = 900  # 15 min — max Lambda timeout for long pipelines
+  memory_size      = 2048 # CPU scales with memory; 512 MB starved the per-run SDK import and TLS handshake.
+
+  environment {
+    variables = {
+      OPENFACTCHECK_DYNAMODB_USERS_TABLE_NAME = aws_dynamodb_table.openfactcheck_users.name
+      OPENFACTCHECK_SECRETS_KMS_KEY_ID        = aws_kms_key.users.arn
+      OPENFACTCHECK_DYNAMODB_REGION           = var.aws_region
+    }
+  }
 
   tags = {
     Name = "OpenFactCheck - Lambda Engine - ${terraform.workspace} - ${var.aws_region}"

--- a/deployments/containers/engine/Dockerfile
+++ b/deployments/containers/engine/Dockerfile
@@ -3,6 +3,6 @@ FROM public.ecr.aws/lambda/python:3.12
 COPY pyproject.toml VERSION LICENSE* README* ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir ".[cloud]"
 
 CMD ["openfactcheck.engine.lambda_handler.handler"]

--- a/deployments/containers/engine/manifest.sh
+++ b/deployments/containers/engine/manifest.sh
@@ -2,26 +2,37 @@
 
 # ============================================================================
 # Engine container manifest — defines what to assemble for the Lambda Engine build
-# Engine is pure — no API or database dependencies
+# Ships the engine plus the library layers its block handlers call (chat,
+# prompts, messages). Reads the user's encrypted secrets at run time (cloud
+# extra), but never imports the api/ package.
 # ============================================================================
+
+# Subpackages the engine imports at run time (engine/__init__ registers the
+# handlers, which pull chat, prompts, and messages). Kept in sync with the
+# rsync list in assemble_target below.
+ENGINE_PACKAGES=(engine chat prompts messages)
 
 # Source paths used for hash computation (change detection)
 SOURCE_PATHS=(
     "${PROJECT_ROOT}/src/openfactcheck/__init__.py"
-    "${PROJECT_ROOT}/src/openfactcheck/engine"
     "${PROJECT_ROOT}/pyproject.toml"
     "${PROJECT_ROOT}/VERSION"
     "${CONTAINER_DIR}/Dockerfile"
     "${CONTAINER_DIR}/manifest.sh"
 )
+for pkg in "${ENGINE_PACKAGES[@]}"; do
+    SOURCE_PATHS+=("${PROJECT_ROOT}/src/openfactcheck/${pkg}")
+done
 
 # Assemble the build directory with only what this container needs
 assemble_target() {
     mkdir -p "$BUILD_DIR/src/openfactcheck"
 
-    # Package source — __init__.py (for __version__) and engine/ only
+    # Package source — __init__.py (for __version__) and the engine's runtime layers.
     cp "${PROJECT_ROOT}/src/openfactcheck/__init__.py" "$BUILD_DIR/src/openfactcheck/"
-    rsync -a --exclude='__pycache__' "${PROJECT_ROOT}/src/openfactcheck/engine" "$BUILD_DIR/src/openfactcheck/"
+    for pkg in "${ENGINE_PACKAGES[@]}"; do
+        rsync -a --exclude='__pycache__' "${PROJECT_ROOT}/src/openfactcheck/${pkg}" "$BUILD_DIR/src/openfactcheck/"
+    done
 
     # Build metadata referenced by pyproject.toml
     cp "${PROJECT_ROOT}/pyproject.toml" "$BUILD_DIR/"

--- a/src/openfactcheck/engine/lambda_handler.py
+++ b/src/openfactcheck/engine/lambda_handler.py
@@ -1,19 +1,59 @@
-"""Lambda handler — executes a pipeline and returns the result.
+"""Lambda handler — resolve the user's secrets and execute a pipeline in-process.
 
-Invoked by Step Functions. Receives pipeline JSON, returns execution output.
-The engine is pure — no database access, no messaging, just compute.
+Invoked by Step Functions with the user id and the Blockly pipeline. The user's
+API keys are decrypted from the secret store and placed in the environment only
+for the duration of the run, then removed.
+
+Isolation model: a Lambda execution environment handles one invocation at a
+time (concurrency comes from more environments, never parallel invocations in
+one process), so there is no race on the process environment. Each invocation
+hard-resets the environment to the cold-start baseline plus that user's secrets
+before running and restores the entry environment afterwards, so one run's keys
+are never visible to another. User secrets may only add new variables; they
+never override a baseline variable, so the function's own AWS and infrastructure
+configuration cannot be shadowed by a user-named secret. Running in-process (vs.
+a subprocess per run) lets a warm environment reuse the already-imported
+provider SDKs, which is the bulk of the per-run cost.
 """
 
 import asyncio
+import os
 from typing import Any
 
 from openfactcheck.engine.executor import execute_pipeline
+from openfactcheck.engine.secrets import resolve_user_secrets
+
+# Environment captured at cold start, before any secret is ever injected. Every
+# invocation runs against this baseline, so no secret can leak across runs.
+_BASE_ENV = dict(os.environ)
+
+# Wall-clock limit, kept under the Lambda timeout so a slow run returns a clean
+# result instead of being killed mid-execution.
+_RUN_TIMEOUT_SECONDS = 870
 
 
 def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:  # noqa: ANN401 - AWS Lambda context type requires a heavy dependency.
-    """AWS Lambda entry point — execute pipeline and return result."""
+    """AWS Lambda entry point — execute the pipeline with the user's secrets."""
+    user_id: str = event["user_id"]
     pipeline: dict[str, Any] = event["pipeline"]
-    result = asyncio.run(execute_pipeline(pipeline))
+
+    # Resolve secrets first, while the function's own AWS credentials are intact.
+    secrets = resolve_user_secrets(user_id)
+    # Only add new variables; a user secret never shadows a baseline variable.
+    injectable = {name: value for name, value in secrets.items() if name not in _BASE_ENV}
+
+    saved = dict(os.environ)
+    os.environ.clear()
+    os.environ.update(_BASE_ENV)
+    os.environ.update(injectable)
+    try:
+        result = asyncio.run(asyncio.wait_for(execute_pipeline(pipeline), _RUN_TIMEOUT_SECONDS))
+    except TimeoutError:
+        return {"success": False, "output": "", "error": "Pipeline run timed out"}
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
     return {
         "success": result.success,
         "output": result.output or "",

--- a/src/openfactcheck/engine/secrets.py
+++ b/src/openfactcheck/engine/secrets.py
@@ -1,0 +1,49 @@
+"""Resolve a user's stored secrets for a cloud pipeline run.
+
+The engine runs on behalf of one user. To reach the LLM and search providers,
+it needs that user's API keys, which the API stores encrypted in the users
+table. This reads the user's encrypted secrets and KMS-decrypts them into an
+environment-variable map, the shape the chat layer reads its keys from.
+
+The DynamoDB key layout (``USER#<id>`` / ``SECRET#<name>``) and the
+base64-KMS-ciphertext format mirror how the API writes secrets. The engine
+reimplements only the read-and-decrypt half so it stays free of any ``api``
+import, consistent with shipping as its own container.
+"""
+
+import base64
+import os
+
+# Sort-key prefix marking a user's secret items; mirrors the API storage layout.
+_SECRET_PREFIX = "SECRET#"  # noqa: S105 - sort-key prefix, not a credential.
+
+
+def resolve_user_secrets(user_id: str) -> dict[str, str]:
+    """Return the user's secrets as ``{env_var_name: value}``, decrypting via KMS.
+
+    Reads the table name, region, and KMS key id from the environment. Returns
+    an empty map when the user has stored no secrets.
+    """
+    import boto3  # noqa: PLC0415 - lazy import for the optional cloud dependency.
+
+    table_name = os.environ["OPENFACTCHECK_DYNAMODB_USERS_TABLE_NAME"]
+    region = os.environ.get("OPENFACTCHECK_DYNAMODB_REGION", "us-east-1")
+    key_id = os.environ["OPENFACTCHECK_SECRETS_KMS_KEY_ID"]
+
+    table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+    kms = boto3.client("kms", region_name=region)
+
+    response = table.query(
+        KeyConditionExpression="PK = :pk AND begins_with(SK, :prefix)",
+        ExpressionAttributeValues={":pk": f"USER#{user_id}", ":prefix": _SECRET_PREFIX},
+    )
+
+    secrets: dict[str, str] = {}
+    for item in response.get("Items", []):
+        name = item.get("name")
+        ciphertext = item.get("ciphertext")
+        if not isinstance(name, str) or not isinstance(ciphertext, str):
+            continue
+        decrypted = kms.decrypt(CiphertextBlob=base64.b64decode(ciphertext), KeyId=key_id)
+        secrets[name] = decrypted["Plaintext"].decode()
+    return secrets

--- a/tests/engine/test_lambda_handler.py
+++ b/tests/engine/test_lambda_handler.py
@@ -1,0 +1,106 @@
+"""Tests for the engine Lambda handler (in-process execution + env isolation)."""
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+
+from pytest import MonkeyPatch
+from pytest_mock import MockerFixture
+
+from openfactcheck.engine import lambda_handler
+from openfactcheck.engine.executor import ExecutionResult
+
+EVENT = {"user_id": "u1", "pipeline": {"blocks": {"blocks": []}}}
+
+PipelineRunner = Callable[[dict[str, object]], Awaitable[ExecutionResult]]
+
+
+def _fake_run(captured: dict[str, str], result: ExecutionResult) -> PipelineRunner:
+    """Build a fake execute_pipeline that snapshots os.environ at run time."""
+
+    async def run(_pipeline: dict[str, object]) -> ExecutionResult:
+        captured.clear()
+        captured.update(os.environ)
+        return result
+
+    return run
+
+
+def test_handler_success(mocker: MockerFixture) -> None:
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={})
+    mocker.patch.object(lambda_handler, "execute_pipeline", _fake_run({}, ExecutionResult(success=True, output="Paris")))
+
+    result = lambda_handler.handler(EVENT, None)
+
+    assert result == {"success": True, "output": "Paris", "error": ""}
+
+
+def test_handler_failure(mocker: MockerFixture) -> None:
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={})
+    mocker.patch.object(
+        lambda_handler,
+        "execute_pipeline",
+        _fake_run({}, ExecutionResult(success=False, output="", error="boom")),
+    )
+
+    result = lambda_handler.handler(EVENT, None)
+
+    assert result["success"] is False
+    assert result["error"] == "boom"
+
+
+def test_handler_injects_secrets_during_run_and_restores_after(mocker: MockerFixture) -> None:
+    captured: dict[str, str] = {}
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={"OPENAI_API_KEY": "sk-1"})
+    mocker.patch.object(lambda_handler, "execute_pipeline", _fake_run(captured, ExecutionResult(success=True, output="")))
+
+    lambda_handler.handler(EVENT, None)
+
+    assert captured["OPENAI_API_KEY"] == "sk-1"  # present during the run
+    assert "OPENAI_API_KEY" not in os.environ  # removed after the run
+
+
+def test_handler_does_not_override_baseline_env(mocker: MockerFixture) -> None:
+    captured: dict[str, str] = {}
+    original_path = os.environ["PATH"]
+    mocker.patch.object(
+        lambda_handler,
+        "resolve_user_secrets",
+        return_value={"PATH": "evil", "OPENAI_API_KEY": "sk-1"},
+    )
+    mocker.patch.object(lambda_handler, "execute_pipeline", _fake_run(captured, ExecutionResult(success=True, output="")))
+
+    lambda_handler.handler(EVENT, None)
+
+    assert captured["PATH"] == original_path  # baseline var not shadowed by a user secret
+    assert captured["OPENAI_API_KEY"] == "sk-1"
+
+
+def test_handler_isolates_secrets_across_invocations(mocker: MockerFixture) -> None:
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={"OPENAI_API_KEY": "user-a-key"})
+    mocker.patch.object(lambda_handler, "execute_pipeline", _fake_run({}, ExecutionResult(success=True, output="")))
+    lambda_handler.handler(EVENT, None)  # user A runs with a key
+
+    captured_b: dict[str, str] = {}
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={})  # user B has no secrets
+    mocker.patch.object(lambda_handler, "execute_pipeline", _fake_run(captured_b, ExecutionResult(success=True, output="")))
+    lambda_handler.handler(EVENT, None)  # user B runs next
+
+    assert "OPENAI_API_KEY" not in captured_b  # user A's key is not visible to user B
+
+
+def test_handler_timeout_returns_clean_error_and_restores_env(mocker: MockerFixture, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(lambda_handler, "_RUN_TIMEOUT_SECONDS", 0.01)
+    mocker.patch.object(lambda_handler, "resolve_user_secrets", return_value={"OPENAI_API_KEY": "sk-1"})
+
+    async def slow(_pipeline: dict[str, object]) -> ExecutionResult:
+        await asyncio.sleep(1)
+        return ExecutionResult(success=True, output="")
+
+    mocker.patch.object(lambda_handler, "execute_pipeline", slow)
+
+    result = lambda_handler.handler(EVENT, None)
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()
+    assert "OPENAI_API_KEY" not in os.environ  # env restored even on timeout

--- a/tests/engine/test_secrets.py
+++ b/tests/engine/test_secrets.py
@@ -1,0 +1,86 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+"""Tests for engine secret resolution (moto-mocked DynamoDB + KMS)."""
+
+import base64
+from collections.abc import Callable, Iterator
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from openfactcheck.engine.secrets import resolve_user_secrets
+
+REGION = "us-east-1"
+TABLE = "openfactcheck-users-test"
+
+SecretWriter = Callable[[str, str, str], None]
+
+
+@pytest.fixture
+def put_secret(monkeypatch: pytest.MonkeyPatch) -> Iterator[SecretWriter]:
+    """Yield a helper that stores a KMS-encrypted secret in a moto users table."""
+    with mock_aws():
+        monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+        monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+
+        kms = boto3.client("kms", region_name=REGION)
+        key_id = kms.create_key()["KeyMetadata"]["KeyId"]
+
+        ddb = boto3.client("dynamodb", region_name=REGION)
+        ddb.create_table(
+            TableName=TABLE,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        monkeypatch.setenv("OPENFACTCHECK_DYNAMODB_USERS_TABLE_NAME", TABLE)
+        monkeypatch.setenv("OPENFACTCHECK_SECRETS_KMS_KEY_ID", key_id)
+        monkeypatch.setenv("OPENFACTCHECK_DYNAMODB_REGION", REGION)
+
+        table = boto3.resource("dynamodb", region_name=REGION).Table(TABLE)
+
+        def _put(user_id: str, name: str, value: str) -> None:
+            blob = kms.encrypt(KeyId=key_id, Plaintext=value.encode())["CiphertextBlob"]
+            table.put_item(
+                Item={
+                    "PK": f"USER#{user_id}",
+                    "SK": f"SECRET#{name}",
+                    "name": name,
+                    "ciphertext": base64.b64encode(blob).decode(),
+                },
+            )
+
+        yield _put
+
+
+def test_resolve_user_secrets_round_trip(put_secret: SecretWriter) -> None:
+    put_secret("u1", "OPENAI_API_KEY", "sk-test-value")
+
+    assert resolve_user_secrets("u1") == {"OPENAI_API_KEY": "sk-test-value"}
+
+
+def test_resolve_user_secrets_multiple(put_secret: SecretWriter) -> None:
+    put_secret("u1", "OPENAI_API_KEY", "sk-1")
+    put_secret("u1", "SERPER_API_KEY", "serper-2")
+
+    assert resolve_user_secrets("u1") == {"OPENAI_API_KEY": "sk-1", "SERPER_API_KEY": "serper-2"}
+
+
+def test_resolve_user_secrets_empty(put_secret: SecretWriter) -> None:
+    assert resolve_user_secrets("nobody") == {}
+
+
+def test_resolve_user_secrets_scoped_to_user(put_secret: SecretWriter) -> None:
+    put_secret("u1", "OPENAI_API_KEY", "sk-1")
+
+    assert resolve_user_secrets("u2") == {}


### PR DESCRIPTION
The cloud engine could not fact-check: it never fetched the user's secrets, and its image shipped only `engine/` (not the library code its handlers call). This wires both, in-process for warm-path speed.

- `engine/secrets.py`: the engine fetches and KMS-decrypts the user's stored secrets (`dynamodb:Query` + `kms:Decrypt`), with no `api/` import.
- The handler runs the pipeline **in-process** and injects secrets into the environment only for the run, hard-resetting to a cold-start baseline per invocation and restoring after. Keys never leak across runs, and a user secret cannot shadow a baseline (AWS/infra) variable. Safe because a Lambda environment serves one invocation at a time; the local multi-request API server keeps its subprocess.
- The engine image now ships `chat`/`prompts`/`messages` and installs the `cloud` extra (boto3).
- Engine Lambda IAM (`dynamodb:Query` on the users table, `kms:Decrypt` on the users CMK) and env vars.
- Engine memory 512 to 2048 MB; Lambda CPU scales with memory.

Warm gpt-4o run, end to end: ~7.6s to ~1.3s (memory bump ~2.8x, in-process another ~1.4x). 805 tests pass; ruff, pyright, and tofu fmt clean.